### PR TITLE
ui(workstream): move the strip below the composer

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -257,9 +257,9 @@ export function ChatView(): JSX.Element {
 
       <ServicesPanel />
 
-      <WorkstreamStrip />
-
       <Composer onSend={submit} sending={sending} onStop={stop} />
+
+      <WorkstreamStrip />
 
       {loopPaneOpen && activeLoop && (
         <LoopDetailsPane

--- a/src/renderer/src/components/Composer.tsx
+++ b/src/renderer/src/components/Composer.tsx
@@ -72,7 +72,7 @@ export function Composer({
   const canSend = !!value.trim() || images.length > 0
 
   return (
-    <div className="bg-bg px-4 py-3">
+    <div className="bg-bg px-4 pb-1.5 pt-3">
       <div
         onDragOver={(e) => {
           if (e.dataTransfer.types.includes('Files')) {

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -6,13 +6,15 @@ import { workstreamStripView, statusKeyForSession } from '@shared/workstream'
 import { cn } from '../lib/cn'
 
 /**
- * The workstream strip — one quiet row above the composer answering "where does
+ * The workstream strip — one quiet row under the composer answering "where does
  * this session's work land?".
  *
  *   ⌥ auth work  │  ⎇ roxy/auth  │  ○ local
  *
  * Deliberately a separate row from the composer's footer: that row is about HOW
  * the model runs (agent, model, context), this one is about WHERE the work goes.
+ * It sits BELOW the composer because it's provenance, not input — the composer
+ * stays the last thing between the caret and the send button.
  *
  * It renders NOTHING outside a git repo. Most folders aren't repos, and a
  * permanently greyed-out row would just be a nag.
@@ -66,42 +68,46 @@ export function WorkstreamStrip(): JSX.Element | null {
   const changed = (statusKey ? gitStatus[statusKey]?.changed : 0) ?? 0
 
   return (
-    <div className="flex shrink-0 items-center gap-1 px-4 pb-1.5 text-xs">
-      <WorkstreamSegment chat={owner} readOnly={readOnly} label={view.label} />
+    // Same px-4 gutter + centered max-w-3xl column as the composer, so the strip
+    // reads as the composer's footer rather than a stray row pinned to the left.
+    <div className="shrink-0 px-4 pb-2.5 text-xs">
+      <div className="mx-auto flex max-w-3xl items-center gap-1 px-1">
+        <WorkstreamSegment chat={owner} readOnly={readOnly} label={view.label} />
 
-      <Divider />
+        <Divider />
 
-      {/* Segment 2 — output, not a control. Switching a branch in place is a
-          different (and riskier) action than opening a workstream; the
-          workstream menu above is the branch picker. */}
-      <span
-        className="flex min-w-0 items-center gap-1.5 px-1.5 py-1 text-text-muted"
-        title={branch ? `On branch ${branch}` : undefined}
-      >
-        <GitBranch className="h-3.5 w-3.5 shrink-0 opacity-70" />
-        <span className="truncate">{branch ?? 'detached'}</span>
-        {dirty && (
-          <span
-            className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning"
-            title={`${changed} uncommitted change${changed === 1 ? '' : 's'}`}
-          />
-        )}
-      </span>
+        {/* Segment 2 — output, not a control. Switching a branch in place is a
+            different (and riskier) action than opening a workstream; the
+            workstream menu above is the branch picker. */}
+        <span
+          className="flex min-w-0 items-center gap-1.5 px-1.5 py-1 text-text-muted"
+          title={branch ? `On branch ${branch}` : undefined}
+        >
+          <GitBranch className="h-3.5 w-3.5 shrink-0 opacity-70" />
+          <span className="truncate">{branch ?? 'detached'}</span>
+          {dirty && (
+            <span
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning"
+              title={`${changed} uncommitted change${changed === 1 ? '' : 's'}`}
+            />
+          )}
+        </span>
 
-      <Divider />
+        <Divider />
 
-      {/* Segment 3 — TODO: this becomes the branch lifecycle, and each state is
-          reachable with plain git except the last two:
-            ○ local  →  ↑N to push  →  pushed  →  PR #N  →  merged
-          Clicking it should open a panel with the remote, ahead/behind, and
-          commit/push actions. Left static here so the layout is final. */}
-      <span
-        className="flex items-center gap-1.5 px-1.5 py-1 text-text-subtle"
-        title="Not pushed yet"
-      >
-        <span className="h-1.5 w-1.5 rounded-full border border-text-subtle/70" />
-        local
-      </span>
+        {/* Segment 3 — TODO: this becomes the branch lifecycle, and each state is
+            reachable with plain git except the last two:
+              ○ local  →  ↑N to push  →  pushed  →  PR #N  →  merged
+            Clicking it should open a panel with the remote, ahead/behind, and
+            commit/push actions. Left static here so the layout is final. */}
+        <span
+          className="flex items-center gap-1.5 px-1.5 py-1 text-text-subtle"
+          title="Not pushed yet"
+        >
+          <span className="h-1.5 w-1.5 rounded-full border border-text-subtle/70" />
+          local
+        </span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
The workstream strip sat **above** the composer, which put the least urgent thing on screen in the most prominent spot. Reading down the chat column you hit the conversation, then a metadata row about branches and push state, and only then the box you actually came to type in.

It's provenance, not input: "where does this work land" is context you glance at, not something you act on mid-sentence. Below the composer it still answers the question without interrupting the path from the last message to the caret, and the composer becomes the last thing before the send button.

### Alignment

This mattered once the two were adjacent. The strip was flush-left at `px-4` while the composer is a centered `max-w-3xl` column, so they were never on the same left edge. Above the composer, with a gap between them, nobody noticed. Directly underneath it read as broken -- a stray row pinned to the window edge rather than a footer. It now uses the same centered column, so the workstream label lines up with the composer's left edge.

Spacing is split rather than duplicated: the composer drops `py-3` to `pb-1.5 pt-3` and the strip carries the bottom gap, so the pair sits on the window edge the way the composer alone used to.

### Files

- `ChatView.tsx` -- render `<WorkstreamStrip />` after `<Composer />`
- `WorkstreamStrip.tsx` -- centered `max-w-3xl` column, `pb-2.5`
- `Composer.tsx` -- `py-3` to `pb-1.5 pt-3`

### Verification

- `npm run typecheck` clean
- `npm run smoke:shared` -- 422 checks passed
- `npx electron-vite build` succeeds
- `prettier --check` clean on all three files

Rebased onto `dff5518`. Worth noting this branch was where the two papercuts fixed in 383da44 turned up -- the missing `node_modules` and the 65-file prettier CRLF noise. Both confirmed fixed: install now happens automatically and `prettier --check` is honest.