### PR TITLE
feat(subagents): stream a delegate's work live into its task card

### DIFF
--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -11,7 +11,8 @@
  * Wires without tool support yet (azure/bedrock) fall back to a plain answer.
  */
 import type { ChatMessage, LlmEvent } from '../../shared/api'
-import type { MessagePart, ReasoningEffort, TokenUsage } from '../../shared/types'
+import type { ReasoningEffort, TokenUsage } from '../../shared/types'
+import { PartsFold, partsToContent } from '../../shared/parts'
 import {
   getAgent,
   isReadOnlyAgent,
@@ -1411,49 +1412,39 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
     runSignal: AbortSignal,
     forwardToParent: boolean
   ): Promise<{ report: string; state: 'completed' | 'error' }> => {
-    const parts: MessagePart[] = []
-    const toolAt = new Map<string, number>()
-    const addText = (delta: string): void => {
-      const last = parts[parts.length - 1]
-      if (last && last.type === 'text') last.text += delta
-      else parts.push({ type: 'text', text: delta })
-    }
+    // One fold builds the subagent's transcript; the same events are forwarded to
+    // the parent, so what persists on the sub session and what you watch live in
+    // the `task` card are the same thing by construction.
+    const fold = new PartsFold()
     const persistSub = (): void => {
       if (!subChatId) return
       try {
-        const prose: string[] = []
-        for (const p of parts) if (p.type === 'text' || p.type === 'reasoning') prose.push(p.text)
         repo.addMessage({
           chatId: subChatId,
           role: 'assistant',
-          content: prose.join('\n').trim(),
-          parts
+          content: partsToContent(fold.parts),
+          parts: fold.parts
         })
       } catch {
         // best-effort — never break the parent turn over sub-session persistence
       }
     }
-    // The subagent's own tool calls surface as nested cards (prefixed call ids) in
-    // the parent AND are recorded into its own session's parts.
+    /**
+     * Every step the subagent takes — its prose, its thinking, and its tool calls
+     * — folded into its own transcript AND forwarded to the parent turn wrapped as
+     * a `tool-child` addressed to this `task` card, so the launching session shows
+     * the delegate working live instead of a spinner and a wall of text at the end.
+     *
+     * A background run skips forwarding: its launching turn is typically over, and
+     * it reports through its own session plus the completion card instead.
+     */
     const emitNested = (event: LlmEvent): void => {
-      if (event.type === 'tool-start') {
-        toolAt.set(event.callId, parts.length)
-        parts.push({ type: 'tool', tool: event.tool, state: 'running', title: event.title })
-        if (forwardToParent) emit({ ...event, callId: `${callId}.${event.callId}` })
-      } else if (event.type === 'tool-delta') {
-        const p = parts[toolAt.get(event.callId) ?? -1]
-        if (p?.type === 'tool') p.output = (p.output ?? '') + event.chunk
-        if (forwardToParent) emit({ ...event, callId: `${callId}.${event.callId}` })
-      } else if (event.type === 'tool-end') {
-        const p = parts[toolAt.get(event.callId) ?? -1]
-        if (p?.type === 'tool') {
-          p.state = event.ok ? 'done' : 'error'
-          p.output = event.output
-          p.image = event.image
-          p.diff = event.diff
-        }
-        if (forwardToParent) emit({ ...event, callId: `${callId}.${event.callId}` })
-      }
+      // Depth is capped at 1, so a subagent never emits `tool-child` itself; the
+      // guard is here so a future depth bump degrades to flattening rather than
+      // silently mis-addressing a grandchild's events to the wrong card.
+      if (event.type === 'tool-child') return
+      fold.apply(event)
+      if (forwardToParent) emit({ type: 'tool-child', callId, event })
     }
 
     try {
@@ -1473,8 +1464,8 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
         browserKey,
         signal: runSignal,
         emitTool: emitNested,
-        onText: addText,
-        onReasoning: () => {},
+        onText: (delta) => emitNested({ type: 'text', delta }),
+        onReasoning: (delta) => emitNested({ type: 'reasoning', delta }),
         tools: [
           ...schemasFor(agent.tools, false),
           ...(isReadOnlyAgent(agent) ? [] : (mcpTools ?? [])),

--- a/src/main/services/remote.ts
+++ b/src/main/services/remote.ts
@@ -28,8 +28,9 @@ import type {
   RemoteState,
   RemoteStartInput
 } from '../../shared/api'
-import type { MessagePart, Message } from '../../shared/types'
+import type { Message } from '../../shared/types'
 import { reconstructTurn } from '../../shared/tool-history'
+import { PartsFold, partsToContent } from '../../shared/parts'
 import { pruneToolMessages, KEEP_RECENT_TOKENS } from '../../shared/context'
 import { DEFAULT_AGENT_ID } from '../../shared/agents'
 import * as repo from '../db/repo'
@@ -37,7 +38,12 @@ import { listModels } from './models'
 import { pickDefaultModel } from '../../shared/models'
 import { runSessionTurn } from './session-turn'
 import { sessionCwd } from './workspace'
-import { MAX_FRAME_BYTES, parseFrame, type HostFrame, type RemoteSessionInfo } from './remote-protocol'
+import {
+  MAX_FRAME_BYTES,
+  parseFrame,
+  type HostFrame,
+  type RemoteSessionInfo
+} from './remote-protocol'
 /**
  * Relay base. Prod dials roxy.gg; a dev build defaults to the local roxy.gg
  * (localhost:3000). Override with `ROXY_REMOTE_BASE` (e.g. a staging URL).
@@ -86,7 +92,7 @@ interface Share {
   localTurns: Set<string>
   /** Live parts accumulators for in-flight turns, so a guest that joins/switches
    *  mid-turn can be seeded with the reply-so-far (keyed by sessionId). */
-  liveTurns: Map<string, PartsAccumulator>
+  liveTurns: Map<string, PartsFold>
   reconnectAttempts: number
   reconnectTimer: ReturnType<typeof setTimeout> | null
   /** True once we intentionally tear down, so `close` doesn't try to reconnect. */
@@ -355,64 +361,6 @@ function buildRemoteMessages(
   return flat
 }
 
-/**
- * Fold a turn's streamed events into ordered message parts — the main-process
- * twin of the renderer's live parts builder — so the assistant reply can be
- * persisted (and thus show on the desktop + survive into the next turn).
- */
-class PartsAccumulator {
-  readonly parts: MessagePart[] = []
-  private readonly callIndex = new Map<string, number>()
-
-  apply(event: LlmEvent): void {
-    if (event.type === 'text') {
-      const last = this.parts[this.parts.length - 1]
-      if (last && last.type === 'text') last.text += event.delta
-      else this.parts.push({ type: 'text', text: event.delta })
-    } else if (event.type === 'reasoning') {
-      const last = this.parts[this.parts.length - 1]
-      if (last && last.type === 'reasoning') last.text += event.delta
-      else this.parts.push({ type: 'reasoning', text: event.delta })
-    } else if (event.type === 'tool-start') {
-      this.callIndex.set(event.callId, this.parts.length)
-      this.parts.push({
-        type: 'tool',
-        tool: event.tool,
-        state: 'running',
-        title: event.title,
-        callId: event.callId,
-        input: event.input
-      })
-    } else if (event.type === 'tool-delta') {
-      const idx = this.callIndex.get(event.callId)
-      const part = idx !== undefined ? this.parts[idx] : undefined
-      if (part?.type === 'tool') part.output = (part.output ?? '') + event.chunk
-    } else if (event.type === 'tool-end') {
-      const idx = this.callIndex.get(event.callId)
-      const part = idx !== undefined ? this.parts[idx] : undefined
-      if (part?.type === 'tool') {
-        part.state = event.ok ? 'done' : 'error'
-        part.output = event.output
-        part.image = event.image
-        part.diff = event.diff
-      }
-    }
-  }
-}
-
-/** Collapse parts into a plain-text preview for the message `content` column. */
-function partsToContent(parts: MessagePart[]): string {
-  let text = ''
-  let reasoning = ''
-  let toolOutput = ''
-  for (const part of parts) {
-    if (part.type === 'text') text += part.text
-    else if (part.type === 'reasoning') reasoning += part.text
-    else if (part.type === 'tool' && part.output) toolOutput = part.output
-  }
-  return (text.trim() || reasoning.trim() || toolOutput).trim()
-}
-
 // --- The crux: run a guest's prompt exactly like a local one ---------------
 
 /**
@@ -464,7 +412,12 @@ async function handlePrompt(sessionId: string, text: string): Promise<void> {
  * for the phone to show its bubble. A direct phone send echoes locally, so it's
  * false there to avoid a double bubble.
  */
-async function runTurn(active: Share, sessionId: string, text: string, announce: boolean): Promise<void> {
+async function runTurn(
+  active: Share,
+  sessionId: string,
+  text: string,
+  announce: boolean
+): Promise<void> {
   // Serialize turns *per session*: claim the slot synchronously so two quick
   // prompts can't start concurrent turns on the same session (mirrors the
   // renderer's guard). Different sessions can still run independently. Also
@@ -480,7 +433,7 @@ async function runTurn(active: Share, sessionId: string, text: string, announce:
   active.turns.set(sessionId, controller)
   // Register the live accumulator up-front so a guest that joins/switches during
   // this turn (even mid provider-resolution) is seeded with the reply-so-far.
-  const acc = new PartsAccumulator()
+  const acc = new PartsFold()
   active.liveTurns.set(sessionId, acc)
 
   try {
@@ -490,7 +443,12 @@ async function runTurn(active: Share, sessionId: string, text: string, announce:
     // Announce the prompt text for a drained queue item so the phone shows its
     // bubble (a direct send already echoed it locally). `sendQueue` above already
     // removed it from the pending list, so it moves cleanly from queue → turn.
-    sendFrameFor(active, { t: 'turn', sessionId, state: 'running', userText: announce ? text : undefined })
+    sendFrameFor(active, {
+      t: 'turn',
+      sessionId,
+      state: 'running',
+      userText: announce ? text : undefined
+    })
     // Mirror the turn start to the desktop so it opens a live bubble now (the
     // user message was just persisted + bumped above; the reply streams next).
     broadcastDeltaFor(active, { sessionId, kind: 'turn', state: 'running' })
@@ -555,7 +513,12 @@ async function runTurn(active: Share, sessionId: string, text: string, announce:
       parts.push({ type: 'text', text: `_\u26a0 ${result.error ?? 'Model request failed.'}_` })
     }
     if (parts.length) {
-      repo.addMessage({ chatId: sessionId, role: 'assistant', content: partsToContent(parts), parts })
+      repo.addMessage({
+        chatId: sessionId,
+        role: 'assistant',
+        content: partsToContent(parts),
+        parts
+      })
     }
     bumpFor(active)
   } finally {
@@ -609,7 +572,7 @@ export function notifyQueueChanged(): void {
 export interface LocalTurnRelay {
   active: Share
   sessionId: string
-  acc: PartsAccumulator
+  acc: PartsFold
 }
 
 /**
@@ -630,7 +593,7 @@ export function relayLocalTurnStart(sessionId: string, userText?: string): Local
   // Mark the session busy so a phone prompt queues behind this desktop turn
   // instead of starting a second concurrent one (the shared busy gate).
   active.localTurns.add(sessionId)
-  const acc = new PartsAccumulator()
+  const acc = new PartsFold()
   active.liveTurns.set(sessionId, acc)
   // `userText` mirrors the drained-queue announce path: the phone never echoed a
   // desktop-typed prompt, so it shows the bubble now and opens the streaming spinner.
@@ -674,7 +637,9 @@ export function relayLocalTurnEnd(relay: LocalTurnRelay): void {
 function connect(): void {
   const active = share
   if (!active) return
-  const socket = new WebSocket(`${WS_BASE}/api/remote/ws?token=${encodeURIComponent(active.hostToken)}`)
+  const socket = new WebSocket(
+    `${WS_BASE}/api/remote/ws?token=${encodeURIComponent(active.hostToken)}`
+  )
   active.socket = socket
 
   socket.on('open', () => {
@@ -871,7 +836,11 @@ async function startInternal(input: RemoteStartInput): Promise<RemoteState> {
   if (!sessionId || !repo.getChat(sessionId)) {
     const fallback = repo.listChats().find((c) => c.kind === 'main')
     if (!fallback) {
-      return { ...IDLE_STATE, phase: 'error', error: 'Open a session first, then share your workspace.' }
+      return {
+        ...IDLE_STATE,
+        phase: 'error',
+        error: 'Open a session first, then share your workspace.'
+      }
     }
     sessionId = fallback.id
   }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -70,6 +70,24 @@
   animation: var(--animate-fade-in);
 }
 
+/* A live status line advancing to its next value — the new label rises into
+   place as the old one is replaced. Small travel (3px) on purpose: this fires
+   once per agent step, so anything larger reads as thrashing rather than
+   progress. Keyed remounts drive it (see ActivityLine in ToolCall). */
+@keyframes ticker-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.animate-ticker-in {
+  animation: ticker-in 180ms var(--ease-out-quart) both;
+}
+
 /* Modal entrances. Unlike popovers, modals aren't anchored to a trigger, so they
    scale from center. The scrim fades; the panel scales+fades in together. */
 @keyframes modal-scrim-in {
@@ -125,6 +143,9 @@
   }
   .press-scale:active:not(:disabled) {
     transform: none;
+  }
+  .animate-ticker-in {
+    animation: fade-in 120ms ease both;
   }
 }
 

--- a/src/renderer/src/components/MessageParts.tsx
+++ b/src/renderer/src/components/MessageParts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Streamdown } from 'streamdown'
 import { Brain, ChevronRight } from 'lucide-react'
 import type { MessagePart } from '@shared/types'
+import { streamSignature } from '@shared/parts'
 import { ToolCall } from './ToolCall'
 import { ThinkingIndicator } from './ThinkingIndicator'
 import { cn } from '../lib/cn'
@@ -15,22 +16,6 @@ const STREAM_ANIMATION = {
   easing: 'ease',
   stagger: 0
 } as const
-
-/**
- * A signature that changes on every streamed delta: total streamed characters +
- * part count + the last tool's state. When it stops changing, the turn has gone
- * "quiet" even though it's still live (the model is building a tool call whose
- * args stream in the main process, emitting nothing here).
- */
-function streamSignature(parts: MessagePart[]): string {
-  let chars = 0
-  for (const p of parts) {
-    if (p.type === 'text' || p.type === 'reasoning') chars += p.text.length
-    else if (p.type === 'tool') chars += p.output?.length ?? 0
-  }
-  const last = parts[parts.length - 1]
-  return `${parts.length}:${chars}:${last?.type === 'tool' ? last.state : ''}`
-}
 
 /**
  * True once a streaming turn has emitted nothing for `delayMs`. Resets on every
@@ -95,6 +80,18 @@ export function MessageParts({
               output={part.output}
               image={part.image}
               diff={part.diff}
+              nested={part.children}
+              // A subagent's transcript renders through this same component, so a
+              // nested tool card looks and behaves exactly like a top-level one.
+              // Passed as a callback (not a self-import) to keep the recursion
+              // explicit and one-directional: ToolCall never reaches back up.
+              //
+              // `streaming` is gated on the CARD's state, not the turn's: once a
+              // subagent has reported, its transcript is history and must stop
+              // animating even while the parent turn keeps going.
+              renderNested={(children) => (
+                <MessageParts parts={children} streaming={streaming && part.state === 'running'} />
+              )}
             />
           )
         }

--- a/src/renderer/src/components/ToolCall.tsx
+++ b/src/renderer/src/components/ToolCall.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
 import {
   Camera,
   Check,
@@ -17,9 +18,10 @@ import {
   Wrench
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
-import type { ToolDiff } from '@shared/types'
+import type { MessagePart, ToolDiff } from '@shared/types'
 import { cn } from '../lib/cn'
 import { TerminalOutput } from './TerminalOutput'
+import { BrailleSpinner } from './ThinkingIndicator'
 
 const FileDiffView = lazy(() => import('./FileDiffView'))
 const FileView = lazy(() => import('./FileView'))
@@ -58,8 +60,77 @@ const TOOL_ICON: Record<string, LucideIcon> = {
 }
 
 /**
+ * How many steps a subagent has taken — tool calls only. Its reasoning and prose
+ * are how it narrates the work, not work itself, and counting them would inflate
+ * "12 steps" for a delegate that only thought out loud.
+ */
+const countSteps = (parts: MessagePart[]): number =>
+  parts.reduce((n, p) => (p.type === 'tool' ? n + 1 : n), 0)
+
+/**
+ * What a subagent is doing RIGHT NOW, from the last part of its live transcript.
+ * Shown on the collapsed `task` card so a delegation reads as visible progress
+ * instead of an opaque spinner.
+ *
+ * Returns the label AND the index of the part it came from. The index is the
+ * animation key: it changes once per STEP, whereas the label changes on every
+ * token while the delegate writes prose. Keying on the text would restart the
+ * entrance animation on each token — a flicker, not a transition.
+ */
+function activity(parts: MessagePart[]): { label: string; step: number } {
+  const step = parts.length - 1
+  const last = parts[step]
+  if (!last) return { label: 'starting…', step: -1 }
+  if (last.type === 'tool') {
+    return { label: [last.tool, last.title].filter(Boolean).join(' '), step }
+  }
+  if (last.type === 'reasoning') return { label: 'thinking…', step }
+  if (last.type === 'image') return { label: 'captured an image', step }
+  // Prose: the delegate is writing its report — show its last line so you can
+  // watch the conclusion form rather than a static "writing…".
+  const line = last.text.trim().split('\n').filter(Boolean).pop()
+  return { label: line ? line.slice(0, 120) : 'writing…', step }
+}
+
+/**
+ * The live one-liner under a running `task` header: what the subagent is doing
+ * and how far it has got. Both halves animate on step boundaries only.
+ */
+function ActivityLine({ parts }: { parts: MessagePart[] }): JSX.Element {
+  const { label, step } = activity(parts)
+  const steps = countSteps(parts)
+  return (
+    // pl-8 aligns the spinner with the header's tool icon (px-2.5 + chevron + gap),
+    // so the strip reads as a continuation of the card rather than a new row.
+    <div className="flex items-center gap-2 border-t border-border/60 py-1 pl-8 pr-2.5">
+      <BrailleSpinner className="shrink-0 text-xs text-accent" />
+      {/* Keys are prefixed: they're siblings, and a bare index would collide with
+          the counter's whenever the two numbers happen to match. */}
+      <span
+        key={`at-${step}`}
+        className="animate-ticker-in truncate font-mono text-[11px] text-text-subtle"
+      >
+        {label}
+      </span>
+      {steps > 0 && (
+        <span
+          key={`n-${steps}`}
+          className="animate-ticker-in ml-auto shrink-0 font-mono text-[10px] tabular-nums text-text-subtle"
+        >
+          {steps} {steps === 1 ? 'step' : 'steps'}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
  * Renders a single tool call as an inline, expandable card — the way an agent
  * step shows up between reasoning and prose. Click to reveal the output.
+ *
+ * A `task` card is special: it owns a subagent's whole transcript. Its steps
+ * stream into `children` and render nested inside this card (via `renderNested`,
+ * a callback rather than a direct import so the recursion stays one-directional).
  */
 export function ToolCall({
   tool,
@@ -67,7 +138,9 @@ export function ToolCall({
   title,
   output,
   image,
-  diff
+  diff,
+  nested: nestedParts,
+  renderNested
 }: {
   tool: string
   state: 'running' | 'done' | 'error'
@@ -75,10 +148,19 @@ export function ToolCall({
   output?: string
   image?: string
   diff?: ToolDiff
+  /** A subagent's live transcript, for a `task` card. */
+  nested?: MessagePart[]
+  /** Renders that transcript — supplied by MessageParts so this file needn't import it. */
+  renderNested?: (parts: MessagePart[]) => ReactNode
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const Icon = TOOL_ICON[tool] ?? Wrench
   const body = output?.trimEnd() ?? ''
+  const nested = nestedParts && nestedParts.length > 0 ? nestedParts : undefined
+  const live = state === 'running'
+  // A finished subagent's transcript stays available but collapses to its report;
+  // reopening replays the steps. While running, the activity strip is the summary.
+  const showNested = Boolean(nested && renderNested)
 
   // Auto-open a running bash command so you can watch its logs stream in live,
   // then collapse it again once it finishes -- completed calls shouldn't leave a
@@ -86,6 +168,16 @@ export function ToolCall({
   useEffect(() => {
     if (tool === 'bash') setOpen(state === 'running')
   }, [tool, state])
+
+  // A `task` card deliberately does NOT auto-expand while running: a subagent
+  // emits dozens of steps, and dumping them inline would bury the parent turn.
+  // The collapsed activity strip is the live view; expanding is opt-in.
+  // Once expanded during a run, keep the newest step in sight.
+  const tailRef = useRef<HTMLDivElement>(null)
+  const stepCount = nested ? countSteps(nested) : 0
+  useEffect(() => {
+    if (open && live && showNested) tailRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [open, live, showNested, stepCount])
 
   // Warm the heavy syntax-highlight chunk as soon as a code card appears, so the
   // FIRST expand renders immediately instead of suspending on a lazy import
@@ -109,19 +201,33 @@ export function ToolCall({
             open && 'rotate-90'
           )}
         />
-        <Icon className="h-4 w-4 shrink-0 text-text-muted" />
+        <Icon
+          className={cn(
+            'h-4 w-4 shrink-0 text-text-muted',
+            live && tool === 'task' && 'text-accent'
+          )}
+        />
         <span className="shrink-0 text-xs font-medium text-text">{tool}</span>
         {title && (
           <span className="truncate font-mono text-xs text-text-muted" title={title}>
             {title}
           </span>
         )}
-        <span className="ml-auto shrink-0">
+        <span className="ml-auto flex shrink-0 items-center gap-1.5">
+          {/* Once finished, the card collapses to "how much work did it do" — the
+              same count the live strip was showing, so it doesn't appear to jump. */}
+          {showNested && !live && stepCount > 0 && (
+            <span className="font-mono text-[10px] tabular-nums text-text-subtle">
+              {stepCount} {stepCount === 1 ? 'step' : 'steps'}
+            </span>
+          )}
           {state === 'running' && <Loader2 className="h-3.5 w-3.5 animate-spin text-text-subtle" />}
           {state === 'done' && <Check className="h-3.5 w-3.5 text-success" />}
           {state === 'error' && <TriangleAlert className="h-3.5 w-3.5 text-danger" />}
         </span>
       </button>
+      {/* Collapsed + running: a live one-liner of what the delegate is doing now. */}
+      {showNested && live && !open && <ActivityLine parts={nested!} />}
       {open && diff ? (
         <div className="animate-fade-in max-h-96 overflow-auto border-t border-border bg-surface">
           <Suspense
@@ -142,6 +248,25 @@ export function ToolCall({
         </div>
       ) : open && (tool === 'bash' || tool === 'bash_output') ? (
         <TerminalOutput text={body} state={state} />
+      ) : open && showNested ? (
+        <div className="animate-fade-in border-t border-border bg-surface">
+          {/* The subagent's own transcript, indented under a rail so it reads as a
+              separate agent's work rather than more of the parent's. */}
+          <div className="max-h-[28rem] overflow-auto px-3 py-2">
+            <div className="border-l-2 border-border pl-3">{renderNested!(nested!)}</div>
+            <div ref={tailRef} />
+          </div>
+          {body && !live && (
+            <div className="border-t border-border">
+              <div className="px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wide text-text-subtle">
+                Report
+              </div>
+              <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words px-3 pb-2 font-mono text-xs leading-relaxed text-text-muted">
+                {body}
+              </pre>
+            </div>
+          )}
+        </div>
       ) : open ? (
         <pre className="animate-fade-in max-h-72 overflow-auto border-t border-border bg-surface px-3 py-2 font-mono text-xs leading-relaxed text-text-muted">
           {body || (state === 'running' ? 'Running…' : '(no output)')}

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -23,6 +23,7 @@ import type {
 import { selectPromptName, buildEnvironment, assembleSystemPrompt } from '@shared/prompt'
 import { PROMPT_TEXT, AGENT_PROMPT_TEXT } from '@shared/prompt-text'
 import { reconstructTurn, REPLAY_OUTPUT_CAP } from '@shared/tool-history'
+import { PartsFold, partsToContent } from '@shared/parts'
 import { isOverflow, pruneToolMessages, KEEP_RECENT_TOKENS } from '@shared/context'
 import { pickDefaultModel } from '@shared/models'
 import { uniqueSlug } from '@shared/slugs'
@@ -162,7 +163,7 @@ const remoteMirror = { deferred: false }
  * mirrors a remote reply token-by-token (the twin of a local send's `parts`).
  * A turn:idle frame clears the entry once the persisted reply takes over.
  */
-const remoteTurns = new Map<string, { parts: MessagePart[]; callIndex: Map<string, number> }>()
+const remoteTurns = new Map<string, PartsFold>()
 
 /**
  * Desktop live-mirror: reload the shared chat's transcript from disk after a
@@ -209,7 +210,7 @@ function applyRemoteDelta(payload: RemoteDelta): void {
     if (payload.state === 'running') {
       // Open an empty live bubble (a "thinking" indicator) the moment the turn
       // starts, so the desktop isn't blank while the first token is resolved.
-      remoteTurns.set(sessionId, { parts: [], callIndex: new Map() })
+      remoteTurns.set(sessionId, new PartsFold())
       reflect([])
     } else {
       remoteTurns.delete(sessionId)
@@ -218,68 +219,15 @@ function applyRemoteDelta(payload: RemoteDelta): void {
     return
   }
 
-  // A stream event: fold it into this session's live parts (mirrors the main
-  // process's PartsAccumulator and the local send's delta handler).
-  const turn = remoteTurns.get(sessionId) ?? { parts: [], callIndex: new Map() }
-  remoteTurns.set(sessionId, turn)
-  const { event } = payload
-  let { parts } = turn
-  if (event.type === 'text') {
-    const last = parts[parts.length - 1]
-    if (last && last.type === 'text') {
-      parts = parts.map((p, i) =>
-        i === parts.length - 1 ? { type: 'text', text: last.text + event.delta } : p
-      )
-    } else {
-      parts = [...parts, { type: 'text', text: event.delta }]
-    }
-  } else if (event.type === 'reasoning') {
-    const last = parts[parts.length - 1]
-    if (last && last.type === 'reasoning') {
-      parts = parts.map((p, i) =>
-        i === parts.length - 1 ? { type: 'reasoning', text: last.text + event.delta } : p
-      )
-    } else {
-      parts = [...parts, { type: 'reasoning', text: event.delta }]
-    }
-  } else if (event.type === 'tool-start') {
-    turn.callIndex.set(event.callId, parts.length)
-    parts = [
-      ...parts,
-      {
-        type: 'tool',
-        tool: event.tool,
-        state: 'running',
-        title: event.title,
-        callId: event.callId,
-        input: event.input
-      }
-    ]
-  } else if (event.type === 'tool-delta') {
-    const idx = turn.callIndex.get(event.callId)
-    if (idx !== undefined) {
-      parts = parts.map((p, i) =>
-        i === idx && p.type === 'tool' ? { ...p, output: (p.output ?? '') + event.chunk } : p
-      )
-    }
-  } else if (event.type === 'tool-end') {
-    const idx = turn.callIndex.get(event.callId)
-    if (idx !== undefined) {
-      parts = parts.map((p, i) =>
-        i === idx && p.type === 'tool'
-          ? {
-              ...p,
-              state: event.ok ? 'done' : 'error',
-              output: event.output,
-              image: event.image,
-              diff: event.diff
-            }
-          : p
-      )
-    }
+  // A stream event: fold it into this session's live parts through the SAME pure
+  // fold the local send and the main process use, so remote mirroring can never
+  // drift from — or silently drop an event type handled by — the local path.
+  let turn = remoteTurns.get(sessionId)
+  if (!turn) {
+    turn = new PartsFold()
+    remoteTurns.set(sessionId, turn)
   }
-  turn.parts = parts
-  reflect(parts)
+  reflect(turn.apply(payload.event))
 }
 
 export const useRoxyStore = create<RoxyStore>((set, get) => ({
@@ -904,91 +852,48 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
         model,
         get().activeAgentId
       )
-      // Build parts live from the agent's event stream: text grows the current
-      // text part; each tool call adds a card that flips running→done/error.
-      const callIndex = new Map<string, number>()
+      // Build parts live from the agent's event stream through the shared fold:
+      // text grows the current text part, each tool call adds a card that flips
+      // running→done/error, and a subagent's steps nest inside its `task` card.
+      // Seeded with whatever the turn already rendered (a `!verb` card).
+      const fold = new PartsFold()
+      fold.parts = parts
+      // Side effects that must fire when a specific tool starts/ends live here
+      // rather than inside the fold, which stays pure.
+      const findByCallId = (callId: string): MessagePart | undefined =>
+        fold.parts.find((p) => p.type === 'tool' && p.callId === callId)
       deltaHandlers.set(requestId, (event) => {
         if (!chatExists()) return
-        if (event.type === 'text') {
-          const last = parts[parts.length - 1]
-          if (last && last.type === 'text') {
-            const text = last.text + event.delta
-            parts = parts.map((p, i) => (i === parts.length - 1 ? { type: 'text', text } : p))
-          } else {
-            parts = [...parts, { type: 'text', text: event.delta }]
-          }
-        } else if (event.type === 'reasoning') {
-          // The model's live thinking tokens — grow the current reasoning part so
-          // the "Thinking…" block fills in instead of just spinning.
-          const last = parts[parts.length - 1]
-          if (last && last.type === 'reasoning') {
-            const text = last.text + event.delta
-            parts = parts.map((p, i) => (i === parts.length - 1 ? { type: 'reasoning', text } : p))
-          } else {
-            parts = [...parts, { type: 'reasoning', text: event.delta }]
-          }
-        } else if (event.type === 'tool-start') {
-          callIndex.set(event.callId, parts.length)
-          parts = [
-            ...parts,
-            {
-              type: 'tool',
-              tool: event.tool,
-              state: 'running',
-              title: event.title,
-              callId: event.callId,
-              input: event.input
-            }
-          ]
+        parts = fold.apply(event)
+        if (event.type === 'tool-start') {
           // A `task` just spawned a subagent (its own `sub` session was created
           // in main) — surface it under the parent in the sidebar immediately.
           if (event.tool === 'task') void get().refreshChats()
-        } else if (event.type === 'tool-delta') {
-          const idx = callIndex.get(event.callId)
-          if (idx !== undefined) {
-            parts = parts.map((p, i) =>
-              i === idx && p.type === 'tool' ? { ...p, output: (p.output ?? '') + event.chunk } : p
-            )
-          }
         } else if (event.type === 'tool-end') {
-          const idx = callIndex.get(event.callId)
-          if (idx !== undefined) {
-            const ended = parts[idx]
-            parts = parts.map((p, i) =>
-              i === idx && p.type === 'tool'
-                ? {
-                    ...p,
-                    state: event.ok ? 'done' : 'error',
-                    output: event.output,
-                    image: event.image,
-                    diff: event.diff
-                  }
-                : p
-            )
+          const ended = findByCallId(event.callId)
+          if (event.ok && ended?.type === 'tool' && ended.tool.startsWith('loop_')) {
             // A loop_* tool just created/removed/toggled a loop — reflect it in
             // the sidebar right away instead of waiting for a manual refresh.
-            if (event.ok && ended?.type === 'tool' && ended.tool.startsWith('loop_')) {
-              void get().refreshLoops()
-              void get().refreshChats()
-            } else if (ended?.type === 'tool' && ended.tool === 'task') {
-              // A subagent finished — its `sub` session now has its reply; refresh
-              // the sidebar and reload it if the user is tapped into it.
-              void (async () => {
-                await get().refreshChats()
-                const active = get().activeChatId
-                if (active && get().chats.find((c) => c.id === active)?.kind === 'sub') {
-                  set({ messages: await api.messages.list(active) })
-                }
-              })()
-            } else if (
-              event.ok &&
-              ended?.type === 'tool' &&
-              ended.tool === 'change_session_metadata'
-            ) {
-              // The agent renamed / described / re-tasked its own session —
-              // refresh so the sidebar title + the SessionInfo strip update live.
-              void get().refreshChats()
-            }
+            void get().refreshLoops()
+            void get().refreshChats()
+          } else if (ended?.type === 'tool' && ended.tool === 'task') {
+            // A subagent finished — its `sub` session now has its reply; refresh
+            // the sidebar and reload it if the user is tapped into it.
+            void (async () => {
+              await get().refreshChats()
+              const active = get().activeChatId
+              if (active && get().chats.find((c) => c.id === active)?.kind === 'sub') {
+                set({ messages: await api.messages.list(active) })
+              }
+            })()
+          } else if (
+            event.ok &&
+            ended?.type === 'tool' &&
+            ended.tool === 'change_session_metadata'
+          ) {
+            // The agent renamed / described / re-tasked its own session —
+            // refresh so the sidebar title + the SessionInfo strip update live.
+            void get().refreshChats()
           }
         }
         setStreaming(parts)
@@ -1301,19 +1206,6 @@ function buildReasoning(prompt: string): string {
     `No live model is wired in yet, so I'll stream a placeholder through the parts ` +
     `pipeline — reasoning first, then prose, with tool calls as inline cards.`
   )
-}
-
-/** Collapse a turn's parts into a plain-text preview for the `content` column. */
-function partsToContent(parts: MessagePart[]): string {
-  let text = ''
-  let reasoning = ''
-  let toolOutput = ''
-  for (const part of parts) {
-    if (part.type === 'text') text += part.text
-    else if (part.type === 'reasoning') reasoning += part.text
-    else if (part.type === 'tool' && part.output) toolOutput = part.output
-  }
-  return (text.trim() || reasoning.trim() || toolOutput).trim()
 }
 
 /**

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -241,6 +241,20 @@ export type LlmEvent =
       image?: string
       diff?: ToolDiff
     }
+  /**
+   * One step of a SUBAGENT's turn, addressed to the `task` card that spawned it.
+   * `callId` is the parent `task` call; `event` is the child's own event, folded
+   * into that card's `children` instead of the top-level parts list.
+   *
+   * Wrapping (rather than prefixing child call ids and emitting them flat) keeps
+   * the nesting explicit end-to-end: the fold knows a child event is a child, so
+   * it can never be mistaken for a call the parent model made and replayed as
+   * bogus tool history on the next turn.
+   */
+  | { type: 'tool-child'; callId: string; event: LlmChildEvent }
+
+/** The subset of `LlmEvent` a subagent can emit — everything except further nesting. */
+export type LlmChildEvent = Exclude<LlmEvent, { type: 'tool-child' }>
 
 export interface LlmDelta {
   requestId: string

--- a/src/shared/parts.ts
+++ b/src/shared/parts.ts
@@ -1,0 +1,201 @@
+/**
+ * Streamed-parts folding — pure functions, no Electron/DB/React deps, so they run
+ * in the plain-Node smoke and are shared by every consumer of `LlmEvent`.
+ *
+ * There used to be THREE hand-written copies of this fold (the renderer's local
+ * send handler, the renderer's remote-mirror handler, and the main process's
+ * `PartsAccumulator`), which meant every new event type had to be implemented
+ * three times or one surface would silently drop it. This is the single one.
+ *
+ * The fold is immutable: `apply` returns a NEW parts array and never mutates the
+ * previous one, so React sees a changed reference on every delta (the renderer
+ * was already written this way) and the main process just reassigns.
+ */
+import type { LlmChildEvent, LlmEvent } from './api'
+import type { MessagePart } from './types'
+import { previewText } from './context'
+
+/**
+ * How much of a SUBAGENT tool's output the parent's `task` card keeps.
+ *
+ * A nested transcript is a *summary* view: the subagent's own session persists
+ * the full thing, so mirroring every byte onto the parent turn would double-store
+ * potentially megabytes of tool output in the parent's `parts` JSON column for no
+ * added information. Head/tail preview keeps the card useful (you can see what it
+ * ran and how it ended) at a bounded cost; "open the sub session" is the full view.
+ */
+export const CHILD_OUTPUT_CAP = 2000
+
+/**
+ * Hard ceiling on nested parts per `task` card. A runaway subagent (hundreds of
+ * steps) must not be able to grow one parent message row without bound. Past the
+ * cap we keep folding into EXISTING parts (a running tool still finishes and
+ * flips to done) but stop appending new ones.
+ */
+export const MAX_CHILD_PARTS = 400
+
+const CHILD_MARKER = '…[truncated — open the subagent session for the full output]…'
+
+const capChildOutput = (text: string): string =>
+  previewText(text, {
+    maxChars: CHILD_OUTPUT_CAP,
+    maxLines: CHILD_OUTPUT_CAP,
+    marker: CHILD_MARKER
+  })
+
+/**
+ * Fold one event into a parts list, returning a new list. `index` maps a tool
+ * call id to its slot and is mutated in place (it's bookkeeping, not state React
+ * renders). `cap` bounds appends for nested transcripts; 0 means unbounded.
+ */
+function foldInto(
+  parts: MessagePart[],
+  index: Map<string, number>,
+  event: LlmChildEvent,
+  cap = 0
+): MessagePart[] {
+  const full = cap > 0 && parts.length >= cap
+  if (event.type === 'text' || event.type === 'reasoning') {
+    const last = parts[parts.length - 1]
+    // Grow the trailing text/reasoning part so prose reveals token by token
+    // instead of fragmenting into one part per delta.
+    if (last && last.type === event.type) {
+      const text = last.text + event.delta
+      return parts.map((p, i) => (i === parts.length - 1 ? { type: event.type, text } : p))
+    }
+    if (full) return parts
+    return [...parts, { type: event.type, text: event.delta }]
+  }
+  if (event.type === 'tool-start') {
+    if (full) return parts
+    index.set(event.callId, parts.length)
+    return [
+      ...parts,
+      {
+        type: 'tool',
+        tool: event.tool,
+        state: 'running',
+        title: event.title,
+        callId: event.callId,
+        input: event.input
+      }
+    ]
+  }
+  if (event.type === 'tool-delta') {
+    const idx = index.get(event.callId)
+    if (idx === undefined) return parts
+    return parts.map((p, i) =>
+      i === idx && p.type === 'tool'
+        ? {
+            ...p,
+            output:
+              cap > 0
+                ? capChildOutput((p.output ?? '') + event.chunk)
+                : (p.output ?? '') + event.chunk
+          }
+        : p
+    )
+  }
+  if (event.type === 'tool-end') {
+    const idx = index.get(event.callId)
+    if (idx === undefined) return parts
+    return parts.map((p, i) =>
+      i === idx && p.type === 'tool'
+        ? {
+            ...p,
+            state: event.ok ? 'done' : 'error',
+            output: cap > 0 ? capChildOutput(event.output) : event.output,
+            image: event.image,
+            diff: event.diff
+          }
+        : p
+    )
+  }
+  return parts
+}
+
+/**
+ * Folds a turn's streamed events into ordered message parts. One instance per
+ * live turn; read `parts` after each `apply` (the reference changes on every
+ * event that mutated anything).
+ */
+export class PartsFold {
+  parts: MessagePart[] = []
+  /** callId → slot in `parts`, for the turn's own tool calls. */
+  private readonly index = new Map<string, number>()
+  /** Parent `task` callId → its subagent's own callId → slot in that card's `children`. */
+  private readonly childIndex = new Map<string, Map<string, number>>()
+
+  apply(event: LlmEvent): MessagePart[] {
+    if (event.type !== 'tool-child') {
+      this.parts = foldInto(this.parts, this.index, event)
+      return this.parts
+    }
+    // A subagent step: fold it into its `task` card's nested transcript. Dropping
+    // it when the card is missing is correct — a child event can only arrive
+    // after its parent `tool-start` (the harness emits the card first).
+    const idx = this.index.get(event.callId)
+    if (idx === undefined) return this.parts
+    const parent = this.parts[idx]
+    if (parent?.type !== 'tool') return this.parts
+    let sub = this.childIndex.get(event.callId)
+    if (!sub) {
+      sub = new Map()
+      this.childIndex.set(event.callId, sub)
+    }
+    const children = foldInto(parent.children ?? [], sub, event.event, MAX_CHILD_PARTS)
+    if (children === parent.children) return this.parts
+    this.parts = this.parts.map((p, i) => (i === idx ? { ...parent, children } : p))
+    return this.parts
+  }
+}
+
+/**
+ * Total streamed characters across a parts tree, INCLUDING nested subagent
+ * transcripts. Callers use it as a liveness signal: while this keeps climbing,
+ * the turn is visibly producing something.
+ */
+export function countStreamedChars(parts: MessagePart[]): number {
+  let chars = 0
+  for (const p of parts) {
+    if (p.type === 'text' || p.type === 'reasoning') chars += p.text.length
+    else if (p.type === 'tool') {
+      chars += p.output?.length ?? 0
+      if (p.children) chars += countStreamedChars(p.children)
+    }
+  }
+  return chars
+}
+
+/** Total parts in a tree, counting nested subagent parts — the other half of the liveness signal. */
+export function countParts(parts: MessagePart[]): number {
+  let n = 0
+  for (const p of parts) {
+    n += 1
+    if (p.type === 'tool' && p.children) n += countParts(p.children)
+  }
+  return n
+}
+
+/**
+ * A signature that changes on every streamed delta anywhere in the tree (nested
+ * subagent activity included). When it stops changing, the turn has gone quiet.
+ */
+export function streamSignature(parts: MessagePart[]): string {
+  const last = parts[parts.length - 1]
+  const tail = last?.type === 'tool' ? `${last.state}:${last.children?.length ?? 0}` : ''
+  return `${countParts(parts)}:${countStreamedChars(parts)}:${tail}`
+}
+
+/** Collapse parts into a plain-text preview for a message's `content` column. */
+export function partsToContent(parts: MessagePart[]): string {
+  let text = ''
+  let reasoning = ''
+  let toolOutput = ''
+  for (const part of parts) {
+    if (part.type === 'text') text += part.text
+    else if (part.type === 'reasoning') reasoning += part.text
+    else if (part.type === 'tool' && part.output) toolOutput = part.output
+  }
+  return (text.trim() || reasoning.trim() || toolOutput).trim()
+}

--- a/src/shared/tool-history.ts
+++ b/src/shared/tool-history.ts
@@ -52,6 +52,12 @@ const REPLAY_MARKER = '…[tool output truncated to fit context — full result 
  * matching `role:'tool'` result messages. Text that arrives after a tool call
  * opens a new assistant step (OpenAI multi-step form). Reasoning/image parts are
  * display-only here and skipped.
+ *
+ * A `task` part's `children` (its subagent's transcript) are display-only too and
+ * are deliberately NOT walked: the parent model never made those calls, and
+ * replaying them as its own `tool_calls` would invent history it never saw. All
+ * it ever received was the subagent's final report — which is this part's
+ * `output`, and is replayed normally below.
  */
 export function reconstructAssistant(parts: MessagePart[]): ChatMessage[] {
   const out: ChatMessage[] = []
@@ -60,7 +66,11 @@ export function reconstructAssistant(parts: MessagePart[]): ChatMessage[] {
   let results: ChatMessage[] = []
   const commit = (): void => {
     if (!text.trim() && calls.length === 0 && results.length === 0) return
-    out.push({ role: 'assistant', content: text.trim(), ...(calls.length ? { toolCalls: calls } : {}) })
+    out.push({
+      role: 'assistant',
+      content: text.trim(),
+      ...(calls.length ? { toolCalls: calls } : {})
+    })
     out.push(...results)
     text = ''
     calls = []
@@ -135,7 +145,12 @@ export function flattenToolHistory(messages: ChatMessage[]): ChatMessage[] {
       // Merge consecutive assistant messages (a multi-step tool turn is one bubble).
       const last = out[out.length - 1]
       if (last && last.role === 'assistant') appendToLastAssistant(m.content)
-      else out.push({ role: 'assistant', content: m.content, ...(m.images ? { images: m.images } : {}) })
+      else
+        out.push({
+          role: 'assistant',
+          content: m.content,
+          ...(m.images ? { images: m.images } : {})
+        })
       continue
     }
     out.push({ ...m })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -181,6 +181,19 @@ export type MessagePart =
       image?: string
       /** Before/after file contents for write/edit, shown as a diff on expand. */
       diff?: ToolDiff
+      /**
+       * A `task` card's subagent transcript — the delegate's own reasoning, prose,
+       * and tool calls, streamed live and nested INSIDE this card rather than
+       * leaking out as flat sibling cards in the parent turn.
+       *
+       * Recursive by type but only ever one level deep in practice
+       * (MAX_SUBAGENT_DEPTH = 1 in the harness).
+       *
+       * DISPLAY-ONLY: `reconstructAssistant` deliberately never replays children as
+       * the parent's own `tool_calls` — the parent model never made those calls;
+       * all it ever saw was the subagent's final report.
+       */
+      children?: MessagePart[]
     }
 
 export interface Message {

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -31,6 +31,14 @@ import {
   REPLAY_OUTPUT_CAP
 } from '../src/shared/tool-history'
 import {
+  PartsFold,
+  partsToContent,
+  streamSignature,
+  countStreamedChars,
+  CHILD_OUTPUT_CAP,
+  MAX_CHILD_PARTS
+} from '../src/shared/parts'
+import {
   normalizeFetchUrl,
   acceptHeader,
   mimeFromContentType,
@@ -917,6 +925,237 @@ const started = renderBackgroundStarted('general', 'crunch data')
 check('renderBackgroundStarted names the task', started.includes('crunch data'))
 check('renderBackgroundStarted warns against polling', /DO NOT poll/i.test(started))
 
+// ---- PartsFold: one fold for local / remote / main, incl. nested subagents ----
+{
+  const fold = new PartsFold()
+  fold.apply({ type: 'reasoning', delta: 'hmm' })
+  fold.apply({ type: 'reasoning', delta: '…' })
+  fold.apply({ type: 'text', delta: 'Hello' })
+  fold.apply({ type: 'text', delta: ' world' })
+  check(
+    'fold: consecutive deltas grow one part per kind',
+    fold.parts.length === 2 &&
+      fold.parts[0].type === 'reasoning' &&
+      fold.parts[0].text === 'hmm…' &&
+      fold.parts[1].type === 'text' &&
+      fold.parts[1].text === 'Hello world'
+  )
+
+  const before = fold.parts
+  fold.apply({ type: 'text', delta: '!' })
+  check('fold: returns a NEW array so React re-renders', fold.parts !== before)
+
+  fold.apply({
+    type: 'tool-start',
+    callId: 'c1',
+    tool: 'bash',
+    title: 'ls',
+    input: { command: 'ls' }
+  })
+  fold.apply({ type: 'tool-delta', callId: 'c1', chunk: 'a.txt\n' })
+  fold.apply({ type: 'tool-end', callId: 'c1', output: 'a.txt\nb.txt', ok: true })
+  const tool = fold.parts[2]
+  check(
+    'fold: tool card runs then resolves with its id + input kept',
+    tool.type === 'tool' &&
+      tool.state === 'done' &&
+      tool.callId === 'c1' &&
+      tool.output === 'a.txt\nb.txt' &&
+      (tool.input as { command?: string }).command === 'ls'
+  )
+
+  fold.apply({ type: 'tool-end', callId: 'nope', output: 'x', ok: true })
+  check('fold: an unknown callId is ignored, not appended', fold.parts.length === 3)
+}
+
+{
+  // The point of the feature: a subagent's steps nest INSIDE its task card and
+  // never leak into the parent's top-level parts.
+  const fold = new PartsFold()
+  fold.apply({ type: 'tool-start', callId: 't1', tool: 'task', title: 'Explore: map it' })
+  fold.apply({ type: 'tool-child', callId: 't1', event: { type: 'reasoning', delta: 'plan' } })
+  fold.apply({
+    type: 'tool-child',
+    callId: 't1',
+    event: { type: 'tool-start', callId: 'c1', tool: 'grep', title: 'foo' }
+  })
+  fold.apply({
+    type: 'tool-child',
+    callId: 't1',
+    event: { type: 'tool-end', callId: 'c1', output: 'hit', ok: true }
+  })
+  fold.apply({ type: 'tool-child', callId: 't1', event: { type: 'text', delta: 'Found it.' } })
+
+  check('fold/nested: parent keeps exactly one top-level card', fold.parts.length === 1)
+  const task = fold.parts[0]
+  check(
+    'fold/nested: subagent steps land in children, in order',
+    task.type === 'tool' &&
+      task.children?.length === 3 &&
+      task.children[0].type === 'reasoning' &&
+      task.children[1].type === 'tool' &&
+      task.children[1].tool === 'grep' &&
+      task.children[1].state === 'done' &&
+      task.children[2].type === 'text' &&
+      task.children[2].text === 'Found it.'
+  )
+  check(
+    'fold/nested: the task card itself is still running until its own tool-end',
+    task.type === 'tool' && task.state === 'running'
+  )
+
+  fold.apply({ type: 'tool-end', callId: 't1', output: 'The report.', ok: true })
+  const done = fold.parts[0]
+  check(
+    'fold/nested: the report resolves the card without losing the transcript',
+    done.type === 'tool' &&
+      done.state === 'done' &&
+      done.output === 'The report.' &&
+      done.children?.length === 3
+  )
+
+  // A child event for a task card that was never announced must be dropped, not
+  // mis-attributed to some other card.
+  const stray = fold.parts
+  fold.apply({ type: 'tool-child', callId: 'ghost', event: { type: 'text', delta: 'x' } })
+  check('fold/nested: a child with no parent card is dropped', fold.parts === stray)
+}
+
+{
+  // Two concurrent subagents must not cross transcripts — they share child call
+  // ids (each subagent numbers its own calls), so the fold keys by parent card.
+  const fold = new PartsFold()
+  fold.apply({ type: 'tool-start', callId: 'A', tool: 'task', title: 'one' })
+  fold.apply({ type: 'tool-start', callId: 'B', tool: 'task', title: 'two' })
+  fold.apply({
+    type: 'tool-child',
+    callId: 'A',
+    event: { type: 'tool-start', callId: 'c1', tool: 'read', title: 'a.ts' }
+  })
+  fold.apply({
+    type: 'tool-child',
+    callId: 'B',
+    event: { type: 'tool-start', callId: 'c1', tool: 'read', title: 'b.ts' }
+  })
+  fold.apply({
+    type: 'tool-child',
+    callId: 'B',
+    event: { type: 'tool-end', callId: 'c1', output: 'B!', ok: true }
+  })
+  const [a, b] = fold.parts
+  check(
+    'fold/nested: colliding child ids stay in their own parent',
+    a.type === 'tool' &&
+      b.type === 'tool' &&
+      a.children?.length === 1 &&
+      b.children?.length === 1 &&
+      a.children[0].type === 'tool' &&
+      a.children[0].title === 'a.ts' &&
+      a.children[0].state === 'running' &&
+      b.children[0].type === 'tool' &&
+      b.children[0].output === 'B!' &&
+      b.children[0].state === 'done'
+  )
+}
+
+{
+  // Nested output is a summary view: the sub session holds the full thing, so the
+  // parent row must not balloon with a subagent's megabyte of tool output.
+  const fold = new PartsFold()
+  fold.apply({ type: 'tool-start', callId: 't1', tool: 'task', title: 'big' })
+  fold.apply({
+    type: 'tool-child',
+    callId: 't1',
+    event: { type: 'tool-start', callId: 'c1', tool: 'bash', title: 'noise' }
+  })
+  fold.apply({
+    type: 'tool-child',
+    callId: 't1',
+    event: { type: 'tool-end', callId: 'c1', output: 'x\n'.repeat(50_000), ok: true }
+  })
+  const task = fold.parts[0]
+  const childOut =
+    task.type === 'tool' && task.children?.[0].type === 'tool'
+      ? (task.children[0].output ?? '')
+      : ''
+  check(
+    'fold/nested: a huge child output is capped for the parent row',
+    childOut.length > 0 && childOut.length <= CHILD_OUTPUT_CAP + 200,
+    `len=${childOut.length}`
+  )
+
+  // And a runaway step count can't grow the row without bound either.
+  for (let i = 0; i < MAX_CHILD_PARTS + 50; i++) {
+    fold.apply({
+      type: 'tool-child',
+      callId: 't1',
+      event: { type: 'tool-start', callId: `x${i}`, tool: 'read', title: `f${i}` }
+    })
+  }
+  const capped = fold.parts[0]
+  check(
+    'fold/nested: nested parts stop appending at the cap',
+    capped.type === 'tool' && (capped.children?.length ?? 0) === MAX_CHILD_PARTS
+  )
+}
+
+{
+  // The liveness signal must see nested activity, or the "thinking" indicator
+  // flips on while a subagent is visibly streaming inside its card.
+  const fold = new PartsFold()
+  fold.apply({ type: 'tool-start', callId: 't1', tool: 'task', title: 'x' })
+  const quietSig = streamSignature(fold.parts)
+  fold.apply({ type: 'tool-child', callId: 't1', event: { type: 'text', delta: 'working' } })
+  check(
+    'fold: streamSignature changes on nested activity',
+    streamSignature(fold.parts) !== quietSig
+  )
+  check(
+    'fold: countStreamedChars counts nested text',
+    countStreamedChars(fold.parts) === 'working'.length
+  )
+
+  check(
+    'partsToContent prefers prose over tool output',
+    partsToContent([
+      { type: 'tool', tool: 'bash', state: 'done', output: 'raw' },
+      { type: 'text', text: '  done  ' }
+    ]) === 'done'
+  )
+}
+
+{
+  // A subagent's steps are display-only: replaying them as the parent's own
+  // tool_calls would feed the model calls it never made.
+  const replayed = reconstructAssistant([
+    {
+      type: 'tool',
+      tool: 'task',
+      state: 'done',
+      callId: 't1',
+      input: { description: 'go' },
+      output: 'The report.',
+      children: [
+        { type: 'text', text: 'internal chatter' },
+        { type: 'tool', tool: 'grep', state: 'done', callId: 'c1', output: 'hit' }
+      ]
+    }
+  ])
+  const calls = replayed.flatMap((m) => (m.role === 'assistant' ? (m.toolCalls ?? []) : []))
+  check(
+    'reconstructAssistant replays the task call ONLY, never its children',
+    calls.length === 1 && calls[0].id === 't1' && calls[0].name === 'task'
+  )
+  check(
+    'reconstructAssistant gives the model the report as the task result',
+    replayed.some((m) => m.role === 'tool' && m.toolCallId === 't1' && m.content === 'The report.')
+  )
+  check(
+    'reconstructAssistant never leaks nested output into the transcript',
+    !replayed.some((m) => m.content.includes('internal chatter') || m.content.includes('hit'))
+  )
+}
+
 // ---- LSP: framing + registry + uri + rendering (Phase 12) ----
 
 // JSON-RPC Content-Length framing round-trips through the incremental decoder.
@@ -1778,15 +2017,20 @@ async function main(): Promise<void> {
     check('general IS write-capable', isWriteCapableSubagent('general') === true)
     // Fail closed: the default subagent is `general`, so an unknown name must
     // never be optimistically treated as safe to parallelize.
-    check('an unknown subagent is treated as write-capable', isWriteCapableSubagent('nope') === true)
+    check(
+      'an unknown subagent is treated as write-capable',
+      isWriteCapableSubagent('nope') === true
+    )
     check('an empty subagent name is write-capable', isWriteCapableSubagent('') === true)
 
     const part = partitionTasksByWriteCapability(
       ['explore', 'general', 'explore', 'general'],
       (t) => isWriteCapableSubagent(t)
     )
-    check('partition splits readers from writers',
-      part.readers.length === 2 && part.writers.length === 2)
+    check(
+      'partition splits readers from writers',
+      part.readers.length === 2 && part.writers.length === 2
+    )
 
     /**
      * Run tasks, recording the max number of the SAME KIND in flight at once.
@@ -1815,15 +2059,21 @@ async function main(): Promise<void> {
 
     // Writers must never overlap...
     const w = await trace(['general', 'general', 'general'])
-    check('two write-capable subagents never overlap', (w.peak.get('general') ?? 0) === 1,
-      String(w.peak.get('general')))
+    check(
+      'two write-capable subagents never overlap',
+      (w.peak.get('general') ?? 0) === 1,
+      String(w.peak.get('general'))
+    )
     check('...and all of them still run', w.results.length === 3)
     check('...in their original order', w.order.join(',') === 'general,general,general')
 
     // ...while readers still do.
     const r = await trace(['explore', 'explore', 'explore'])
-    check('read-only subagents DO overlap', (r.peak.get('explore') ?? 0) > 1,
-      String(r.peak.get('explore')))
+    check(
+      'read-only subagents DO overlap',
+      (r.peak.get('explore') ?? 0) > 1,
+      String(r.peak.get('explore'))
+    )
     check('...and all of them run', r.results.length === 3)
 
     // Mixed: readers fan out, the single writer is unaffected.
@@ -1850,8 +2100,10 @@ async function main(): Promise<void> {
       check('mixed turn: a writer runs while readers are still in flight', sawOverlap)
     }
     check('mixed turn: every task returns a result', m.results.length === 4)
-    check('mixed turn: results carry their task back',
-      m.results.every((x) => x.result === `done:${x.task}`))
+    check(
+      'mixed turn: results carry their task back',
+      m.results.every((x) => x.result === `done:${x.task}`)
+    )
 
     // Abort stops LAUNCHING more writers, but keeps what already finished so the
     // caller can still pair every tool_call with a tool result.
@@ -1872,9 +2124,16 @@ async function main(): Promise<void> {
       check('...but keeps the result that already completed', out.length === 1)
     }
 
-    check('no tasks -> no results',
-      (await runTasksByWriteCapability([], { isWriteCapable: () => true, limit: 4, run: async () => 1 }))
-        .length === 0)
+    check(
+      'no tasks -> no results',
+      (
+        await runTasksByWriteCapability([], {
+          isWriteCapable: () => true,
+          limit: 4,
+          run: async () => 1
+        })
+      ).length === 0
+    )
   }
 
   // ---- workstream strip visibility rules ----
@@ -1909,14 +2168,20 @@ async function main(): Promise<void> {
 
     check('strip: hidden with no session', view(null) === null)
     check('strip: hidden when git is unavailable', view(mk(), repoStatus, false) === null)
-    check('strip: hidden when the folder has no workspace', view(mk({ workspacePath: null })) === null)
+    check(
+      'strip: hidden when the folder has no workspace',
+      view(mk({ workspacePath: null })) === null
+    )
     check('strip: hidden before the first status lands', view(mk(), NO_STATUS) === null)
     check(
       'strip: hidden when the folder is not a repo',
       view(mk(), { isRepo: false, branch: null, dirty: false, changed: 0 }) === null
     )
     // Probing (null) must not hide it permanently once status says it's a repo.
-    check('strip: shows while git availability is still unknown', view(mk(), repoStatus, null) !== null)
+    check(
+      'strip: shows while git availability is still unknown',
+      view(mk(), repoStatus, null) !== null
+    )
 
     const plain = view(mk())
     check('strip: default workstream is labelled as such', plain?.label === 'default workstream')
@@ -1957,7 +2222,11 @@ async function main(): Promise<void> {
   // ---- <env> dev port (parallel sessions must not fight over :3000) ----
   {
     const withPort = buildEnvironment({ cwd: '/w', devPort: 3101 })
-    check('buildEnvironment states the dev port', withPort.includes('Dev server port: 3101'), withPort)
+    check(
+      'buildEnvironment states the dev port',
+      withPort.includes('Dev server port: 3101'),
+      withPort
+    )
     check(
       'the port line tells the model other sessions own others',
       /other sessions own other ports/.test(withPort)
@@ -1965,16 +2234,16 @@ async function main(): Promise<void> {
     // PORT alone is not enough (vite.config.ts etc. hardcode a port), but a
     // session WITHOUT one must not get a misleading line.
     check('no port -> no port line', !buildEnvironment({ cwd: '/w' }).includes('Dev server port'))
-    check('port 0 is not emitted', !buildEnvironment({ cwd: '/w', devPort: 0 }).includes('Dev server port'))
+    check(
+      'port 0 is not emitted',
+      !buildEnvironment({ cwd: '/w', devPort: 0 }).includes('Dev server port')
+    )
   }
 
   // ---- resolveWorktreeCwd (worktree path math) ----
   // Exercised against BOTH path flavours: Roxy ships on Windows and posix, and
   // the repo-subfolder case is where a naive join breaks.
-  for (const [label, p] of [
-    ['posix', posixPath] as const,
-    ['win32', win32Path] as const
-  ]) {
+  for (const [label, p] of [['posix', posixPath] as const, ['win32', win32Path] as const]) {
     const sep = label === 'win32' ? '\\' : '/'
     const root = label === 'win32' ? 'C:\\repo' : '/repo'
     const wt = label === 'win32' ? 'C:\\wt\\fix' : '/wt/fix'
@@ -1993,13 +2262,11 @@ async function main(): Promise<void> {
     )
     check(
       `resolveWorktreeCwd (${label}): project is a SUBFOLDER -> same subpath inside`,
-      resolveWorktreeCwd(`${root}${sep}apps${sep}web`, wt, root, p) ===
-        `${wt}${sep}apps${sep}web`
+      resolveWorktreeCwd(`${root}${sep}apps${sep}web`, wt, root, p) === `${wt}${sep}apps${sep}web`
     )
     check(
       `resolveWorktreeCwd (${label}): no repo root -> the project folder`,
-      resolveWorktreeCwd(`${root}${sep}apps${sep}web`, wt, null, p) ===
-        `${root}${sep}apps${sep}web`
+      resolveWorktreeCwd(`${root}${sep}apps${sep}web`, wt, null, p) === `${root}${sep}apps${sep}web`
     )
     check(
       `resolveWorktreeCwd (${label}): workspace outside the repo -> the project folder`,


### PR DESCRIPTION
A `task` call used to be a black box: the parent turn showed a spinner while the subagent's prose and reasoning were swallowed (`onText` wrote to a local array, `onReasoning` was a no-op), and its tool calls leaked out as flat sibling cards with dotted call ids -- indistinguishable from work the parent did itself.

Now every step a subagent takes is forwarded to the launching turn as a `tool-child` event addressed to its `task` card, and folded into that card's `children`. Collapsed, the card shows a live one-liner of what the delegate is doing and how many steps in it is; expanded, its whole transcript renders through MessageParts, so a nested tool card looks and behaves exactly like a top-level one.

Wrapping the child event (rather than prefixing its call id and emitting it flat) keeps the nesting explicit end-to-end. That also fixes a real correctness bug: those flat dotted-id parts were persisted and replayed by `reconstructAssistant` as `assistant.tool_calls` the parent model never made. Children are display-only; the model still sees only the report.

Also collapses the three hand-written copies of the event->parts fold (the local send handler, the remote mirror, and remote.ts's PartsAccumulator) into one pure `PartsFold` in shared/parts.ts. Three copies meant every new event type had to be written three times or a surface would silently drop it -- exactly the trap `tool-child` would have fallen into.

Nested output is capped (2k/tool, 400 parts/card): the sub session holds the full transcript, so the parent row stays a bounded summary rather than double-storing a runaway delegate's megabytes.

- streamSignature now counts nested activity, so the "thinking" indicator no longer fires while a subagent is visibly streaming inside its card
- a task card does NOT auto-expand while running (dozens of steps would bury the parent turn); the activity strip is the live view
- new `ticker-in` keyframe, keyed per STEP not per token, with a reduced-motion fallback
- 17 new smoke checks: nesting, concurrent subagents with colliding child ids, both caps, and that children never replay as parent tool history