### PR TITLE
feat(forge): pull request status from GitHub, Azure DevOps, GitLab and Bitbucket

### DIFF
--- a/src/main/db/repo.ts
+++ b/src/main/db/repo.ts
@@ -114,6 +114,47 @@ function setSetting(key: string, value: string | null): void {
   ).run(key, value)
 }
 
+// ---- Forge host overrides ----------------------------------------------
+// Which software an UNRECOGNISED git host runs (`git.mycorp.com` -> gitlab).
+// Only consulted when auto-detection fails, so a stale or mistaken answer can
+// never mis-route a well-known host.
+//
+// Stored as one JSON blob in `settings` rather than its own table: it's a
+// handful of string pairs, it has no relations, and it therefore needs no
+// migration - which matters because migrations here are append-only forever.
+// A dedicated table would be the right call the moment this grows per-host
+// settings beyond `kind`.
+
+const FORGE_HOSTS_KEY = 'forge_host_kinds'
+
+export function getForgeHostKinds(): Record<string, string> {
+  const row = getDb().prepare('SELECT value FROM settings WHERE key = ?').get(FORGE_HOSTS_KEY) as
+    | { value: string }
+    | undefined
+  if (!row?.value) return {}
+  try {
+    const parsed: unknown = JSON.parse(row.value)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === 'string') out[k.toLowerCase()] = v
+    }
+    return out
+  } catch {
+    // Corrupt JSON degrades to "nothing is overridden", which just means the
+    // user is asked again - never a crash on startup.
+    return {}
+  }
+}
+
+/** Record (or clear, with null) which software a host runs. */
+export function setForgeHostKind(host: string, kind: string | null): void {
+  const map = getForgeHostKinds()
+  const key = host.toLowerCase()
+  if (kind === null) delete map[key]
+  else map[key] = kind
+  setSetting(FORGE_HOSTS_KEY, Object.keys(map).length ? JSON.stringify(map) : null)
+}
 export function setActiveProvider(providerId: string, model: string | null): AppSettings {
   setSetting('active_provider_id', providerId)
   setSetting('active_model', model)

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -37,6 +37,8 @@ import {
 } from '../harness'
 import { sessionCwd } from '../services/workspace'
 import * as git from '../services/git'
+import * as forge from '../services/forge'
+import type { ForgeKind } from '../../shared/forge'
 import { pruneWorktrees, removeWorktreeForChat } from '../services/worktree'
 import { checkForUpdates, quitAndInstall, getUpdateState } from '../services/updater'
 import {
@@ -583,6 +585,36 @@ export function registerIpc(): void {
     pruneWorktrees(cwd, { dryRun: dryRun ?? true, force: true })
   )
 
+  // ---- forge (the git host behind `origin`: PR state for the branch) ----
+  // Same degrade-never-throw contract as the git handlers above: no remote, an
+  // unknown host, no credential and a dead network all return a usable object.
+  ipcMain.handle(CHANNELS.forgeStatus, async (_e, cwd: string, force?: boolean) => {
+    if (!cwd || !(await git.isGitAvailable())) return null
+    return forge.forgeStatus(cwd, { force: force ?? false })
+  })
+
+  ipcMain.handle(CHANNELS.forgePush, async (_e, cwd: string) => {
+    if (!cwd || !(await git.isGitAvailable()))
+      return { ok: false, error: 'Git isn\u2019t installed.' }
+    const branch = await git.currentBranch(cwd)
+    if (!branch) return { ok: false, error: 'Not on a branch (detached HEAD).' }
+    const st = await git.status(cwd)
+    const r = await git.pushBranch(cwd, branch, { setUpstream: !st?.hasUpstream })
+    // The remote just changed, so every cached PR answer is suspect - drop it
+    // rather than let the chip show pre-push state for up to a minute.
+    if (r.ok) forge.invalidate()
+    return r
+  })
+
+  ipcMain.handle(CHANNELS.forgeCreateUrl, async (_e, cwd: string) => {
+    if (!cwd || !(await git.isGitAvailable())) return null
+    return forge.createPullUrl(cwd)
+  })
+  ipcMain.handle(CHANNELS.forgeListHosts, () => forge.listHosts())
+
+  ipcMain.handle(CHANNELS.forgeSetHostKind, (_e, host: string, kind: ForgeKind | null) => {
+    forge.setHostKind(host, kind)
+  })
   // ---- remote (Remote Workspace: share a session to a phone via roxy.gg) ----
   ipcMain.handle(CHANNELS.remoteStart, (_e, input: RemoteStartInput) => remote.start(input))
   ipcMain.handle(CHANNELS.remoteStop, () => remote.stop())

--- a/src/main/services/forge/adapters.ts
+++ b/src/main/services/forge/adapters.ts
@@ -1,0 +1,415 @@
+/**
+ * The four forge adapters: one `listPullRequests` per vendor, each normalising
+ * a different API into the same `PullRequestView`.
+ *
+ * Everything here is read-only and best-effort. A forge being down, slow, or
+ * refusing our token is an ordinary condition — it must degrade to "no PR
+ * info", never throw into a status poll.
+ *
+ * The vendors disagree on essentially every detail, and the mapping notes below
+ * are the expensive-to-rediscover parts:
+ *
+ *   state     GitHub open/closed + merged_at   ADO active/completed/abandoned
+ *   draft     GitHub `draft:true`              ADO `isDraft`, GitLab WIP title
+ *   branch    GitHub short name                ADO `refs/heads/x` fully-qualified
+ *   number    GitHub `number`                  ADO `pullRequestId`, GitLab `iid`
+ *   review    GitHub reviews API (extra call)  ADO reviewer votes (inline)
+ */
+import type {
+  ForgeRemote,
+  PullRequestView,
+  PullState,
+  ReviewState,
+  ForgeError
+} from '../../../shared/forge'
+import { authHeaders, forgetCredential, getCredential } from './credentials'
+
+/** A forge lookup is a background nicety; it must not hang a poll. */
+const REQUEST_TIMEOUT_MS = 15_000
+/** Enough to find the branch's PR without paging a busy monorepo forever. */
+const PAGE_SIZE = 50
+
+export interface ForgeResult {
+  pulls: PullRequestView[]
+  error: ForgeError | null
+}
+
+const ok = (pulls: PullRequestView[]): ForgeResult => ({ pulls, error: null })
+const fail = (reason: ForgeError['reason'], message: string): ForgeResult => ({
+  pulls: [],
+  error: { reason, message }
+})
+
+/**
+ * One authenticated GET returning parsed JSON, or a typed failure.
+ *
+ * A 401/403 forgets the credential so the next call re-reads a refreshed one
+ * from the helper instead of replaying a token that just died — the mechanism
+ * that makes short-lived Azure DevOps tokens a non-event.
+ */
+async function getJson<T>(
+  url: string,
+  remote: ForgeRemote,
+  extraHeaders: Record<string, string> = {}
+): Promise<{ data: T } | { error: ForgeError }> {
+  const cred = await getCredential(remote.host)
+  if (!cred) {
+    return {
+      error: {
+        reason: 'auth',
+        message: `No stored credential for ${remote.host}. Sign in once with git (a push or pull is enough) and Roxy will pick it up.`
+      }
+    }
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'Roxy',
+        ...authHeaders(remote, cred),
+        ...extraHeaders
+      },
+      signal: controller.signal
+    })
+
+    if (res.status === 401 || res.status === 403) {
+      await forgetCredential(remote.host)
+      return {
+        error: {
+          reason: 'auth',
+          message: `${remote.host} rejected the stored credential — it has probably expired. Run any git command against the repo to refresh it.`
+        }
+      }
+    }
+    if (res.status === 404) {
+      return { error: { reason: 'not-found', message: `Repository not found on ${remote.host}.` } }
+    }
+    if (!res.ok) {
+      return { error: { reason: 'network', message: `${remote.host} returned ${res.status}.` } }
+    }
+
+    // Azure DevOps answers an unauthenticated API request with a 203 + an HTML
+    // sign-in page rather than a 401. Parsing that as JSON throws a confusing
+    // syntax error, so it's caught here and reported as what it actually is.
+    const text = await res.text()
+    if (/^\s*</.test(text)) {
+      await forgetCredential(remote.host)
+      return {
+        error: {
+          reason: 'auth',
+          message: `${remote.host} returned a sign-in page instead of data — the credential is not valid for this organization.`
+        }
+      }
+    }
+    return { data: JSON.parse(text) as T }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return {
+      error: {
+        reason: 'network',
+        message: /abort/i.test(msg) ? `${remote.host} timed out.` : msg
+      }
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** `refs/heads/feature/x` → `feature/x`. Azure DevOps fully-qualifies refs. */
+function shortRef(ref: string): string {
+  return ref.replace(/^refs\/heads\//, '')
+}
+
+const ms = (iso: string | null | undefined): number => (iso ? Date.parse(iso) || 0 : 0)
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+interface GhPull {
+  number: number
+  title: string
+  state: 'open' | 'closed'
+  draft?: boolean
+  merged_at: string | null
+  html_url: string
+  created_at: string
+  updated_at: string
+  user?: { login?: string } | null
+  head: { ref: string }
+  base: { ref: string }
+}
+
+async function githubPulls(remote: ForgeRemote, branch: string): Promise<ForgeResult> {
+  // `head` must be `owner:branch`. Filtering server-side is what keeps this to
+  // a single request on repos with thousands of open PRs.
+  const head = encodeURIComponent(`${remote.owner}:${branch}`)
+  const url =
+    `${remote.apiBase}/repos/${enc(remote.owner)}/${enc(remote.repo)}/pulls` +
+    `?state=all&head=${head}&per_page=${PAGE_SIZE}&sort=updated&direction=desc`
+
+  const res = await getJson<GhPull[]>(url, remote, { Accept: 'application/vnd.github+json' })
+  if ('error' in res) return { pulls: [], error: res.error }
+  if (!Array.isArray(res.data)) return ok([])
+
+  return ok(
+    res.data.map((p) => ({
+      number: p.number,
+      title: p.title,
+      // `merged_at` is the ONLY reliable merged signal — GitHub reports merged
+      // PRs as `state:"closed"`, so checking state alone mislabels every one.
+      state: (p.merged_at
+        ? 'merged'
+        : p.state === 'closed'
+          ? 'closed'
+          : p.draft
+            ? 'draft'
+            : 'open') as PullState,
+      url: p.html_url,
+      sourceBranch: shortRef(p.head.ref),
+      targetBranch: shortRef(p.base.ref),
+      author: p.user?.login ?? null,
+      createdAt: ms(p.created_at),
+      updatedAt: ms(p.updated_at),
+      // Checks and reviews each cost another round trip per PR; the strip is
+      // polled, so they're fetched lazily by the detail panel instead.
+      checks: null,
+      review: null
+    }))
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Azure DevOps
+// ---------------------------------------------------------------------------
+
+interface AdoPull {
+  pullRequestId: number
+  title: string
+  status: 'active' | 'completed' | 'abandoned' | 'notSet'
+  isDraft?: boolean
+  createdBy?: { displayName?: string; uniqueName?: string } | null
+  creationDate: string
+  closedDate?: string | null
+  sourceRefName: string
+  targetRefName: string
+  repository?: { name?: string; project?: { name?: string } } | null
+  reviewers?: { vote?: number; isRequired?: boolean }[] | null
+}
+
+async function azurePulls(remote: ForgeRemote, branch: string): Promise<ForgeResult> {
+  const project = remote.project ?? remote.repo
+  // searchCriteria.status=all is required: the default is `active`, which would
+  // silently hide every merged and abandoned PR — the exact states the user
+  // asked to see.
+  const url =
+    `${remote.apiBase}/${enc(project)}/_apis/git/repositories/${enc(remote.repo)}/pullrequests` +
+    `?searchCriteria.sourceRefName=${encodeURIComponent(`refs/heads/${branch}`)}` +
+    `&searchCriteria.status=all&$top=${PAGE_SIZE}&api-version=7.1`
+
+  const res = await getJson<{ value?: AdoPull[] }>(url, remote)
+  if ('error' in res) return { pulls: [], error: res.error }
+  const list = res.data?.value
+  if (!Array.isArray(list)) return ok([])
+
+  return ok(
+    list.map((p) => {
+      const source = shortRef(p.sourceRefName)
+      return {
+        number: p.pullRequestId,
+        title: p.title,
+        state: (p.status === 'completed'
+          ? 'merged'
+          : p.status === 'abandoned'
+            ? 'closed'
+            : p.isDraft
+              ? 'draft'
+              : 'open') as PullState,
+        // ADO's `url` field is an internal API link the docs mark "used
+        // internally"; the browsable URL has to be composed by hand.
+        url: `${remote.webBase}/${encodeURIComponent(project)}/_git/${encodeURIComponent(remote.repo)}/pullrequest/${p.pullRequestId}`,
+        sourceBranch: source,
+        targetBranch: shortRef(p.targetRefName),
+        author: p.createdBy?.displayName ?? p.createdBy?.uniqueName ?? null,
+        createdAt: ms(p.creationDate),
+        updatedAt: ms(p.closedDate) || ms(p.creationDate),
+        checks: null,
+        // Votes come inline here, so review state is free — no extra request.
+        review: adoReview(p.reviewers)
+      }
+    })
+  )
+}
+
+/**
+ * ADO vote scale: 10 approved, 5 approved-with-suggestions, 0 no vote,
+ * -5 waiting for author, -10 rejected. Any negative vote blocks, so it wins
+ * over any number of approvals.
+ */
+function adoReview(reviewers: AdoPull['reviewers']): ReviewState | null {
+  if (!reviewers?.length) return null
+  let approved = false
+  for (const r of reviewers) {
+    const v = r.vote ?? 0
+    if (v < 0) return 'changes_requested'
+    if (v > 0) approved = true
+  }
+  return approved ? 'approved' : 'review_required'
+}
+
+// ---------------------------------------------------------------------------
+// GitLab
+// ---------------------------------------------------------------------------
+
+interface GlMerge {
+  iid: number
+  title: string
+  state: 'opened' | 'closed' | 'merged' | 'locked'
+  draft?: boolean
+  work_in_progress?: boolean
+  web_url: string
+  source_branch: string
+  target_branch: string
+  author?: { username?: string } | null
+  created_at: string
+  updated_at: string
+  detailed_merge_status?: string
+}
+
+async function gitlabPulls(remote: ForgeRemote, branch: string): Promise<ForgeResult> {
+  // GitLab addresses a project by its URL-encoded full path, so the slashes in
+  // a nested group path must be percent-encoded too — hence encodeURIComponent
+  // on the whole thing rather than per segment.
+  const id = encodeURIComponent(`${remote.owner}/${remote.repo}`)
+  const url =
+    `${remote.apiBase}/projects/${id}/merge_requests` +
+    `?source_branch=${encodeURIComponent(branch)}&state=all&per_page=${PAGE_SIZE}&order_by=updated_at`
+
+  const res = await getJson<GlMerge[]>(url, remote)
+  if ('error' in res) return { pulls: [], error: res.error }
+  if (!Array.isArray(res.data)) return ok([])
+
+  return ok(
+    res.data.map((m) => ({
+      number: m.iid,
+      title: m.title,
+      state: (m.state === 'merged'
+        ? 'merged'
+        : m.state === 'closed'
+          ? 'closed'
+          : m.draft || m.work_in_progress
+            ? 'draft'
+            : 'open') as PullState,
+      url: m.web_url,
+      sourceBranch: m.source_branch,
+      targetBranch: m.target_branch,
+      author: m.author?.username ?? null,
+      createdAt: ms(m.created_at),
+      updatedAt: ms(m.updated_at),
+      checks: null,
+      review: null
+    }))
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Bitbucket
+// ---------------------------------------------------------------------------
+
+interface BbPull {
+  id: number
+  title: string
+  state: 'OPEN' | 'MERGED' | 'DECLINED' | 'SUPERSEDED'
+  draft?: boolean
+  links?: { html?: { href?: string } }
+  source?: { branch?: { name?: string } }
+  destination?: { branch?: { name?: string } }
+  author?: { nickname?: string; display_name?: string } | null
+  created_on: string
+  updated_on: string
+}
+
+async function bitbucketPulls(remote: ForgeRemote, branch: string): Promise<ForgeResult> {
+  // Bitbucket Server/Data Center speaks a different API (1.0) with different
+  // shapes. Rather than half-support it and produce wrong answers, it's
+  // declared unsupported until someone can test against a real instance.
+  if (!remote.cloud) {
+    return fail('unsupported', 'Bitbucket Server is not supported yet — only Bitbucket Cloud.')
+  }
+  // Bitbucket has no source_branch filter, so it takes a BBQL `q` expression.
+  const q = encodeURIComponent(`source.branch.name="${branch.replace(/"/g, '\\"')}"`)
+  const url =
+    `${remote.apiBase}/repositories/${enc(remote.owner)}/${enc(remote.repo)}/pullrequests` +
+    `?q=${q}&state=OPEN&state=MERGED&state=DECLINED&pagelen=${PAGE_SIZE}`
+
+  const res = await getJson<{ values?: BbPull[] }>(url, remote)
+  if ('error' in res) return { pulls: [], error: res.error }
+  const list = res.data?.values
+  if (!Array.isArray(list)) return ok([])
+
+  return ok(
+    list.map((p) => ({
+      number: p.id,
+      title: p.title,
+      state: (p.state === 'MERGED'
+        ? 'merged'
+        : p.state === 'DECLINED' || p.state === 'SUPERSEDED'
+          ? 'closed'
+          : p.draft
+            ? 'draft'
+            : 'open') as PullState,
+      url:
+        p.links?.html?.href ??
+        `${remote.webBase}/${remote.owner}/${remote.repo}/pull-requests/${p.id}`,
+      sourceBranch: p.source?.branch?.name ?? branch,
+      targetBranch: p.destination?.branch?.name ?? '',
+      author: p.author?.nickname ?? p.author?.display_name ?? null,
+      createdAt: ms(p.created_on),
+      updatedAt: ms(p.updated_on),
+      checks: null,
+      review: null
+    }))
+  )
+}
+
+const enc = encodeURIComponent
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull requests whose SOURCE is `branch`, newest-relevant first.
+ *
+ * Sorted so the caller can take `[0]` as "the" PR: an open PR outranks a merged
+ * one (a reopened/second PR on the same branch is what the user is working on),
+ * and ties break on recency.
+ */
+export async function listPullRequests(remote: ForgeRemote, branch: string): Promise<ForgeResult> {
+  if (!branch) return ok([])
+  let result: ForgeResult
+  switch (remote.kind) {
+    case 'github':
+      result = await githubPulls(remote, branch)
+      break
+    case 'azure-devops':
+      result = await azurePulls(remote, branch)
+      break
+    case 'gitlab':
+      result = await gitlabPulls(remote, branch)
+      break
+    case 'bitbucket':
+      result = await bitbucketPulls(remote, branch)
+      break
+  }
+  result.pulls.sort(rankPulls)
+  return result
+}
+
+const STATE_RANK: Record<PullState, number> = { open: 0, draft: 1, merged: 2, closed: 3 }
+
+export function rankPulls(a: PullRequestView, b: PullRequestView): number {
+  const d = STATE_RANK[a.state] - STATE_RANK[b.state]
+  return d !== 0 ? d : b.updatedAt - a.updatedAt
+}

--- a/src/main/services/forge/credentials.ts
+++ b/src/main/services/forge/credentials.ts
@@ -1,0 +1,230 @@
+/**
+ * Forge credentials — obtained by ASKING GIT, not by implementing OAuth.
+ *
+ * This is the whole trick of the feature, so it's worth stating plainly:
+ *
+ * Every developer who can `git push` to a private repo already has a working
+ * credential on their machine, managed by a credential helper (Git Credential
+ * Manager on Windows/macOS, libsecret/osxkeychain elsewhere). `git credential
+ * fill` is git's own public interface for reading it. GCM handles the parts
+ * that are genuinely hard — Entra ID / Microsoft Account sign-in, device-code
+ * flows, MFA, conditional access, and, critically, SILENT REFRESH of the
+ * short-lived Azure DevOps token that otherwise expires every few days.
+ *
+ * So Roxy asks git. The alternatives were considered and are worse:
+ *
+ *  - Register OAuth apps with 4 vendors: needs client secrets shipped in an
+ *    open-source Electron binary (extractable), an admin-consent dance for
+ *    Azure tenants that most corp users cannot self-approve, and a callback
+ *    server. Months of work, and it still wouldn't survive a locked-down tenant.
+ *  - Ask the user to paste a PAT: works, but it's the exact 7-day-expiry pain
+ *    the user is trying to escape, times four hosts.
+ *  - Shell out to `gh`/`az`/`glab`: three more binaries that may not be
+ *    installed (none are on this machine), each with its own auth state.
+ *
+ * `git credential fill` needs none of that. It's already authenticated, it
+ * refreshes itself, and it's the same credential the user's existing pushes
+ * use, so if `git push` works then Roxy works.
+ *
+ * Safety rules, all deliberate:
+ *  - GIT_TERMINAL_PROMPT=0 and GCM_INTERACTIVE=never: a status poll must NEVER
+ *    pop a login window or block on a hidden prompt. If there's no cached
+ *    credential we return null and the UI degrades to git-only state.
+ *  - Tokens are held in memory with a short TTL and never written to the DB.
+ *    The OS keychain is already the system of record; copying secrets into
+ *    roxy.db would only widen the blast radius.
+ *  - Tokens are never logged, never sent to the renderer, and never included
+ *    in tool output.
+ */
+import { spawn } from 'node:child_process'
+import type { ForgeRemote } from '../../../shared/forge'
+
+/** A credential lookup must not outlive a status poll. */
+const CREDENTIAL_TIMEOUT_MS = 10_000
+
+/**
+ * How long a fetched credential is reused before re-asking git.
+ *
+ * Short on purpose. Azure DevOps tokens from GCM are typically ~1h, and the
+ * cost of re-asking is one fast local process, so a stale token (which shows up
+ * as a confusing 401) is a much worse trade than an occasional extra spawn.
+ */
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+export interface ForgeCredential {
+  username: string
+  /** The secret. NEVER log, persist, or send this over IPC. */
+  password: string
+}
+
+interface CacheEntry {
+  cred: ForgeCredential
+  at: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+/** Cache key: the credential scope, which is (protocol, host) — never the repo. */
+function keyFor(host: string): string {
+  return `https://${host}`
+}
+
+/**
+ * Run `git credential <verb>` with a stdin document, returning stdout.
+ *
+ * Never throws and never blocks on a prompt: a missing helper, a locked
+ * keychain and a cancelled dialog all come back as null.
+ */
+function runCredential(verb: 'fill' | 'reject', input: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn('git', ['credential', verb], {
+        shell: false,
+        windowsHide: true,
+        env: {
+          ...process.env,
+          // The three switches that keep this non-interactive. Without them a
+          // background poll can silently spawn a modal auth window behind the
+          // app, or hang forever waiting on a terminal that doesn't exist.
+          GIT_TERMINAL_PROMPT: '0',
+          GCM_INTERACTIVE: 'never',
+          GIT_ASKPASS: '',
+          SSH_ASKPASS: ''
+        }
+      })
+    } catch {
+      resolve(null)
+      return
+    }
+
+    let out = ''
+    let done = false
+    const finish = (value: string | null): void => {
+      if (done) return
+      done = true
+      clearTimeout(timer)
+      resolve(value)
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill()
+      } catch {
+        /* already gone */
+      }
+      finish(null)
+    }, CREDENTIAL_TIMEOUT_MS)
+
+    child.stdout?.on('data', (d: Buffer) => {
+      out += d.toString('utf8')
+    })
+    // stderr is drained but discarded — it can contain credential-adjacent
+    // chatter from helpers and has no diagnostic value worth that risk.
+    child.stderr?.resume()
+    child.on('error', () => finish(null))
+    child.on('close', (code) => finish(code === 0 ? out : null))
+
+    child.stdin?.on('error', () => finish(null))
+    child.stdin?.end(input, 'utf8')
+  })
+}
+
+/** Parse git's `key=value` credential document. */
+function parseCredentialOutput(text: string): ForgeCredential | null {
+  let username = ''
+  let password = ''
+  for (const line of text.split(/\r?\n/)) {
+    const eq = line.indexOf('=')
+    if (eq <= 0) continue
+    const key = line.slice(0, eq)
+    const value = line.slice(eq + 1)
+    if (key === 'username') username = value
+    else if (key === 'password') password = value
+  }
+  if (!password) return null
+  return { username: username || 'x-access-token', password }
+}
+
+/**
+ * Get a credential for a forge HOST, or null if none is cached locally.
+ *
+ * Takes a bare host rather than a `ForgeRemote` because credential helpers key
+ * on (protocol, host) and nothing else — and because Settings needs to probe a
+ * host it hasn't classified yet, which has no `ForgeRemote` to pass.
+ *
+ * Null is a completely normal answer (fresh machine, SSH-only user, helper
+ * disabled) and every caller must degrade rather than error.
+ */
+export async function getCredential(host: string): Promise<ForgeCredential | null> {
+  const key = keyFor(host)
+  const hit = cache.get(key)
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.cred
+
+  // Ask for the credential scoped to the host. We deliberately do NOT send the
+  // repo path: helpers key by host, and a path makes some of them miss.
+  const doc = `protocol=https\nhost=${host}\n\n`
+  const out = await runCredential('fill', doc)
+  if (!out) return null
+  const cred = parseCredentialOutput(out)
+  if (!cred) return null
+
+  cache.set(key, { cred, at: Date.now() })
+  return cred
+}
+
+/**
+ * Drop a credential we've just seen rejected (401/403).
+ *
+ * Clears our cache and tells git's helper to forget it too, so the NEXT
+ * interactive git operation the user runs re-authenticates properly instead of
+ * silently replaying a dead token. This is what makes expiry self-healing:
+ * Azure DevOps tokens die on a schedule, and without this the app would serve
+ * a stale token from cache for the rest of its lifetime.
+ */
+export async function forgetCredential(host: string): Promise<void> {
+  const key = keyFor(host)
+  const entry = cache.get(key)
+  cache.delete(key)
+  if (!entry) return
+  const doc =
+    `protocol=https\nhost=${host}\n` +
+    `username=${entry.cred.username}\npassword=${entry.cred.password}\n\n`
+  await runCredential('reject', doc)
+}
+
+/** Test seam: drop every cached credential. */
+export function _clearCredentialCache(): void {
+  cache.clear()
+}
+
+/**
+ * The `Authorization` header value for a host.
+ *
+ * The four vendors want three different schemes, and each is a real 401 if you
+ * get it wrong:
+ *  - Azure DevOps: HTTP Basic with an EMPTY username and the token as the
+ *    password. Bearer works for Entra access tokens but NOT for the PATs GCM
+ *    commonly returns, so Basic is the form that works for both.
+ *  - GitHub: `Bearer <token>` for both PATs and OAuth tokens.
+ *  - GitLab: Bearer for OAuth tokens; PATs (`glpat-`) must use the
+ *    `PRIVATE-TOKEN` header instead — see `authHeaders`.
+ *  - Bitbucket Cloud: Basic with the real username and an app password.
+ */
+export function authHeaders(remote: ForgeRemote, cred: ForgeCredential): Record<string, string> {
+  const basic = (user: string, pass: string): string =>
+    `Basic ${Buffer.from(`${user}:${pass}`, 'utf8').toString('base64')}`
+
+  switch (remote.kind) {
+    case 'azure-devops':
+      return { Authorization: basic('', cred.password) }
+    case 'github':
+      return { Authorization: `Bearer ${cred.password}` }
+    case 'gitlab':
+      // GitLab rejects personal access tokens sent as Bearer.
+      return cred.password.startsWith('glpat-')
+        ? { 'PRIVATE-TOKEN': cred.password }
+        : { Authorization: `Bearer ${cred.password}` }
+    case 'bitbucket':
+      return { Authorization: basic(cred.username, cred.password) }
+  }
+}

--- a/src/main/services/forge/index.ts
+++ b/src/main/services/forge/index.ts
@@ -1,0 +1,303 @@
+/**
+ * Forge status: the single entry point the rest of the app uses to ask
+ * "what is the state of this branch, locally AND on the server?".
+ *
+ * The design constraint that shapes everything here: the workstream strip polls
+ * every 5 seconds, and a naive implementation would issue an API request per
+ * poll per session — a rate-limit ban within minutes, plus a UI that stutters
+ * whenever the network is slow.
+ *
+ * So this module is built around one rule: GIT IS SYNCHRONOUS, THE FORGE IS
+ * NOT. A status call returns local git state immediately and serves forge data
+ * from cache, refreshing it in the background at a much slower cadence. The
+ * chip therefore never blocks, never flickers, and never depends on the network
+ * to show what it already knows.
+ */
+import type {
+  ForgeRemote,
+  PullRequestView,
+  BranchSync,
+  ForgeStatusView,
+  ForgeError,
+  ForgeKind,
+  ForgeHostView
+} from '../../../shared/forge'
+import { branchLifecycle, parseRemote, detectHost } from '../../../shared/forge'
+import * as git from '../git'
+import * as repo from '../../db/repo'
+import { listPullRequests } from './adapters'
+import { getCredential } from './credentials'
+
+export type { ForgeStatusView } from '../../../shared/forge'
+
+/** How long a forge answer is reused. Far longer than the 5s UI poll. */
+const PR_TTL_MS = 60_000
+/** How long a failure is remembered, so a down forge isn't hammered. */
+const ERROR_TTL_MS = 5 * 60 * 1000
+/** Remote URL -> forge mapping never changes while the app runs. */
+const remoteCache = new Map<string, ForgeRemote | null>()
+
+interface Entry {
+  pulls: PullRequestView[]
+  error: ForgeError | null
+  at: number
+  inflight: Promise<void> | null
+}
+
+const cache = new Map<string, Entry>()
+
+const keyFor = (remote: ForgeRemote, branch: string): string =>
+  `${remote.kind}:${remote.host}:${remote.slug}:${branch}`
+
+/**
+ * Resolve a repo's `origin` to forge coordinates.
+ *
+ * Cached by cwd because it costs a git spawn and the answer is stable for the
+ * life of the process — nobody changes their origin mid-session, and if they
+ * do, restarting is a reasonable price for not spawning git on every poll.
+ *
+ * Falls back to the user's stored answer for domains auto-detection can't
+ * classify, so a corporate `git.mycorp.com` is asked about once and then
+ * behaves exactly like a recognised host.
+ */
+export async function resolveForge(cwd: string): Promise<ForgeRemote | null> {
+  if (!cwd) return null
+  const hit = remoteCache.get(cwd)
+  if (hit !== undefined) return hit
+  const url = await git.remoteUrl(cwd)
+  const override = url ? overrideFor(url) : null
+  const parsed = url ? parseRemote(url, override) : null
+  remoteCache.set(cwd, parsed)
+  return parsed
+}
+
+/** The user's stored "this domain runs X" answer, if any. */
+function overrideFor(url: string): ForgeKind | null {
+  const probe = detectHost(url)
+  if (!probe || probe.kind) return null
+  const stored = repo.getForgeHostKinds()[probe.host]
+  return isForgeKind(stored) ? stored : null
+}
+
+const KINDS: ForgeKind[] = ['github', 'azure-devops', 'gitlab', 'bitbucket']
+const isForgeKind = (v: unknown): v is ForgeKind =>
+  typeof v === 'string' && (KINDS as string[]).includes(v)
+
+/**
+ * Branch status, local + remote.
+ *
+ * Returns immediately with whatever is cached; a stale or missing forge answer
+ * schedules a background refresh and the next poll picks it up. `force` (from an
+ * explicit user refresh) waits for the answer instead.
+ */
+export async function forgeStatus(
+  cwd: string,
+  opts: { force?: boolean } = {}
+): Promise<ForgeStatusView> {
+  const st = await git.status(cwd)
+  const branch = st?.branch ?? null
+  const sync: BranchSync = {
+    ahead: st?.ahead ?? 0,
+    behind: st?.behind ?? 0,
+    hasUpstream: st?.hasUpstream ?? false,
+    dirty: st?.dirty ?? false
+  }
+
+  const remote = await resolveForge(cwd)
+  // Distinguish "no remote at all" from "a real host we can't classify". The
+  // second is a question we can ask the user once; the first isn't.
+  let unknownHost: string | null = null
+  if (!remote) {
+    const url = await git.remoteUrl(cwd)
+    const probe = url ? detectHost(url) : null
+    if (probe && !probe.kind) unknownHost = probe.host
+  }
+
+  // No remote, no branch, or an unpushed branch: git alone is the whole truth,
+  // and asking the forge about a branch it has never seen is a guaranteed empty
+  // round trip. Skipping it is what keeps a brand-new workstream instant.
+  if (!remote || !branch || !sync.hasUpstream) {
+    return {
+      remote: remote && summarize(remote),
+      lifecycle: branchLifecycle({ sync, pr: null, forgeKnown: false }),
+      pull: null,
+      error: null,
+      refreshing: false,
+      unknownHost
+    }
+  }
+
+  const key = keyFor(remote, branch)
+  const entry = cache.get(key)
+  const ttl = entry?.error ? ERROR_TTL_MS : PR_TTL_MS
+  const fresh = entry && Date.now() - entry.at < ttl
+
+  if (!fresh && opts.force) {
+    await refresh(key, remote, branch)
+  } else if (!fresh) {
+    // Fire and forget: this call returns cached (or empty) data now, and the
+    // next poll — 5s later — renders the result. That's what makes the network
+    // invisible to the user.
+    void refresh(key, remote, branch)
+  }
+
+  const current = cache.get(key)
+  const pull = current?.pulls[0] ?? null
+  return {
+    remote: summarize(remote),
+    lifecycle: branchLifecycle({
+      sync,
+      pr: pull,
+      // Only claim the forge is "known" once a lookup has actually succeeded;
+      // otherwise the chip would offer "open a PR" before it knows there isn't
+      // one, and the button would vanish under the cursor a second later.
+      forgeKnown: !!current && !current.error
+    }),
+    pull,
+    error: current?.error ?? null,
+    refreshing: !!current?.inflight,
+    unknownHost: null
+  }
+}
+
+/** Deduped background refresh: N sessions on one branch share one request. */
+function refresh(key: string, remote: ForgeRemote, branch: string): Promise<void> {
+  const existing = cache.get(key)
+  if (existing?.inflight) return existing.inflight
+
+  const base: Entry = existing ?? { pulls: [], error: null, at: 0, inflight: null }
+  const job = listPullRequests(remote, branch)
+    .then((r) => {
+      cache.set(key, {
+        // Keep the last good answer on failure rather than blanking the chip:
+        // a transient network blip should not make a merged PR look unmerged.
+        pulls: r.error ? base.pulls : r.pulls,
+        error: r.error,
+        at: Date.now(),
+        inflight: null
+      })
+    })
+    .catch(() => {
+      cache.set(key, { ...base, at: Date.now(), inflight: null })
+    })
+
+  cache.set(key, { ...base, inflight: job })
+  return job
+}
+
+function summarize(remote: ForgeRemote): ForgeStatusView['remote'] {
+  return { kind: remote.kind, host: remote.host, slug: remote.slug, webBase: remote.webBase }
+}
+
+/**
+ * The URL that opens a "create pull request" form pre-filled for this branch.
+ *
+ * Every vendor spells this differently and none of them document it as an API;
+ * these are the forms their own web UIs use. Returns null rather than a
+ * best-guess URL when the base branch is unknown, since a wrong compare URL
+ * silently targets the wrong branch — worse than no link.
+ */
+export async function createPullUrl(cwd: string): Promise<string | null> {
+  const remote = await resolveForge(cwd)
+  const branch = await git.currentBranch(cwd)
+  if (!remote || !branch) return null
+  const base = (await git.baseBranchFor(cwd, branch)) ?? (await git.defaultBranch(cwd))
+  if (!base) return null
+  const b = encodeURIComponent(branch)
+
+  switch (remote.kind) {
+    case 'github':
+      return `${remote.webBase}/${remote.owner}/${remote.repo}/compare/${encodeURIComponent(base)}...${b}?expand=1`
+    case 'azure-devops': {
+      const project = encodeURIComponent(remote.project ?? remote.repo)
+      return (
+        `${remote.webBase}/${project}/_git/${encodeURIComponent(remote.repo)}/pullrequestcreate` +
+        `?sourceRef=${b}&targetRef=${encodeURIComponent(base)}`
+      )
+    }
+    case 'gitlab':
+      return (
+        `${remote.webBase}/${remote.owner}/${remote.repo}/-/merge_requests/new` +
+        `?merge_request%5Bsource_branch%5D=${b}&merge_request%5Btarget_branch%5D=${encodeURIComponent(base)}`
+      )
+    case 'bitbucket':
+      return (
+        `${remote.webBase}/${remote.owner}/${remote.repo}/pull-requests/new` +
+        `?source=${b}&dest=${encodeURIComponent(base)}`
+      )
+  }
+}
+
+/** Drop all caches — used after a push, when the remote state just changed. */
+export function invalidate(): void {
+  cache.clear()
+}
+
+/**
+ * The git hosts this user's projects actually use, and whether git already has
+ * a credential for each.
+ *
+ * Deliberately derived from the projects on disk rather than a stored list of
+ * "connected accounts": there is no account to connect. Settings shows what is
+ * true right now, so a token that expired overnight shows as disconnected
+ * without Roxy having to track its lifetime.
+ */
+export async function listHosts(): Promise<ForgeHostView[]> {
+  if (!(await git.isGitAvailable())) return []
+  const overrides = repo.getForgeHostKinds()
+  const byHost = new Map<string, ForgeHostView>()
+
+  for (const path of repo.listProjectOrder()) {
+    const url = await git.remoteUrl(path)
+    if (!url) continue
+    const probe = detectHost(url)
+    if (!probe) continue
+    const stored = overrides[probe.host]
+    const kind = probe.kind ?? (isForgeKind(stored) ? stored : null)
+
+    let entry = byHost.get(probe.host)
+    if (!entry) {
+      entry = { host: probe.host, kind, connected: false, username: null, repos: [] }
+      byHost.set(probe.host, entry)
+    }
+    // A repo we can't name is still worth counting toward the host, so the row
+    // appears and the user can classify it.
+    const parsed = kind ? parseRemote(url, kind) : null
+    if (parsed && !entry.repos.includes(parsed.slug)) entry.repos.push(parsed.slug)
+  }
+
+  // Probe credentials in parallel — each is a local process, and doing them
+  // serially makes Settings visibly slow on a machine with several hosts.
+  await Promise.all(
+    [...byHost.values()].map(async (entry) => {
+      if (!entry.kind) return
+      const cred = await getCredential(entry.host)
+      if (cred) {
+        entry.connected = true
+        // `x-access-token` is a placeholder the helper uses when there's no
+        // real account name; showing it to the user would be noise.
+        entry.username = cred.username === 'x-access-token' ? null : cred.username
+      }
+    })
+  )
+
+  return [...byHost.values()].sort((a, b) => a.host.localeCompare(b.host))
+}
+
+/**
+ * Record which software an unrecognised host runs.
+ *
+ * Clears the remote cache because every cwd that resolved to "unknown" must be
+ * re-resolved — otherwise the answer wouldn't take effect until restart.
+ */
+export function setHostKind(host: string, kind: ForgeKind | null): void {
+  repo.setForgeHostKind(host, kind)
+  remoteCache.clear()
+  cache.clear()
+}
+
+/** Test seam. */
+export function _clearForgeCaches(): void {
+  cache.clear()
+  remoteCache.clear()
+}

--- a/src/main/services/git.ts
+++ b/src/main/services/git.ts
@@ -368,6 +368,43 @@ export async function hasOrigin(cwd: string): Promise<boolean> {
 }
 
 /**
+ * The fetch URL of a remote (default `origin`) - the input to forge detection.
+ *
+ * Uses `remote get-url` rather than parsing `git remote -v`, whose output
+ * carries a `(fetch)`/`(push)` suffix that has to be stripped. This form also
+ * honours `insteadOf` rewrites the same way git itself does, so a corporate
+ * `url.<base>.insteadOf` rule resolves to the URL actually in use.
+ */
+export async function remoteUrl(cwd: string, name = 'origin'): Promise<string | null> {
+  if (!cwd) return null
+  const r = await git(['remote', 'get-url', name], cwd)
+  const out = r.stdout.trim().split('\n')[0]?.trim()
+  return r.ok && out ? out : null
+}
+
+/**
+ * Push a branch to origin, optionally setting upstream.
+ *
+ * Deliberately NOT forced, and deliberately not offering `--force-with-lease`:
+ * this is reachable from a one-click chip, and a single click that can destroy
+ * a colleague's commits is not an acceptable thing to build. A rejected push
+ * surfaces git's own error and the user resolves it deliberately.
+ *
+ * Takes the network timeout, since a push talks to the remote.
+ */
+export async function pushBranch(
+  cwd: string,
+  branch: string,
+  opts: { setUpstream?: boolean } = {}
+): Promise<{ ok: boolean; error?: string }> {
+  if (!cwd || !branch) return { ok: false, error: 'push: missing cwd or branch' }
+  const args = ['push']
+  if (opts.setUpstream) args.push('--set-upstream')
+  args.push('origin', branch)
+  const r = await git(args, cwd, FETCH_TIMEOUT_MS)
+  return r.ok ? { ok: true } : { ok: false, error: cleanGitError(r, 'Push failed') }
+}
+/**
  * Working-tree status: dirty flag, changed-entry count, and ahead/behind vs the
  * upstream. Uses `--porcelain=v2 --branch`, whose header lines carry the branch
  * and ahead/behind without a second command.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -188,6 +188,13 @@ const roxy: RoxyApi = {
     removeWorktree: (path, force) => ipcRenderer.invoke(CHANNELS.gitRemoveWorktree, path, force),
     pruneWorktrees: (cwd, dryRun) => ipcRenderer.invoke(CHANNELS.gitPruneWorktrees, cwd, dryRun)
   },
+  forge: {
+    status: (cwd, force) => ipcRenderer.invoke(CHANNELS.forgeStatus, cwd, force),
+    push: (cwd) => ipcRenderer.invoke(CHANNELS.forgePush, cwd),
+    createUrl: (cwd) => ipcRenderer.invoke(CHANNELS.forgeCreateUrl, cwd),
+    listHosts: () => ipcRenderer.invoke(CHANNELS.forgeListHosts),
+    setHostKind: (host, kind) => ipcRenderer.invoke(CHANNELS.forgeSetHostKind, host, kind)
+  },
   remote: {
     start: (input) => ipcRenderer.invoke(CHANNELS.remoteStart, input),
     stop: () => ipcRenderer.invoke(CHANNELS.remoteStop),

--- a/src/renderer/src/components/CodeHosts.tsx
+++ b/src/renderer/src/components/CodeHosts.tsx
@@ -1,0 +1,143 @@
+/**
+ * Settings > Code hosts.
+ *
+ * This section is deliberately NOT part of the AI provider list, and the
+ * distinction is worth being explicit about because one vendor appears in both:
+ *
+ *   Providers  -> who runs the MODEL.       GitHub Copilot lives here.
+ *   Code hosts -> where the CODE lives.     github.com lives here.
+ *
+ * They are different accounts with different tokens and different scopes.
+ * Signing into Copilot must never imply access to your repositories, and
+ * merging the two lists would quietly imply exactly that.
+ *
+ * The second thing to notice: there is no "Connect" button, because there is
+ * nothing for Roxy to connect. Credentials belong to git's credential helper
+ * (Git Credential Manager and friends), which already handles Microsoft
+ * Account/Entra sign-in, MFA, and — the part that matters for short-lived
+ * Azure DevOps tokens — silent refresh. Roxy reads what git already has.
+ *
+ * So this is a STATUS view, not a login form. It renders what is true right
+ * now, which means a token that expired overnight shows as disconnected with
+ * no bookkeeping on Roxy's side.
+ */
+import { useEffect, useState } from 'react'
+import type { ForgeHostView, ForgeKind } from '@shared/forge'
+import { FORGE_NAMES } from '@shared/forge'
+import { api } from '../lib/api'
+
+const KINDS: ForgeKind[] = ['github', 'azure-devops', 'gitlab', 'bitbucket']
+
+export function CodeHosts(): JSX.Element {
+  const [hosts, setHosts] = useState<ForgeHostView[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = async (): Promise<void> => {
+    try {
+      setHosts(await api.forge.listHosts())
+    } catch {
+      // A failure here means git is missing or unreadable; an empty list is the
+      // honest rendering of that, and the empty state below explains it.
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+  }, [])
+
+  const choose = async (host: string, kind: ForgeKind | null): Promise<void> => {
+    await api.forge.setHostKind(host, kind)
+    await load()
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface p-4">
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-text">Pull requests</div>
+        <p className="mt-0.5 text-xs text-text-muted">
+          Roxy reads pull request state for your branches from whichever host your{' '}
+          <code className="text-text-subtle">origin</code> points at. It uses the credentials git
+          already has, so there is nothing to sign into here — if{' '}
+          <code className="text-text-subtle">git push</code> works, this works.
+        </p>
+      </div>
+
+      {loading ? null : hosts.length === 0 ? (
+        <p className="text-xs text-text-subtle">
+          No git remotes yet. Open a project with an <code>origin</code> and its host appears here.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {hosts.map((h) => (
+            <HostRow key={h.host} host={h} onChoose={choose} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function HostRow({
+  host,
+  onChoose
+}: {
+  host: ForgeHostView
+  onChoose: (host: string, kind: ForgeKind | null) => Promise<void>
+}): JSX.Element {
+  return (
+    <div className="flex items-center gap-3 rounded-lg px-2 py-2 transition hover:bg-white/5">
+      <StatusDot host={host} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm text-text">{host.host}</div>
+        <div className="truncate text-[11px] text-text-subtle">
+          {host.kind ? FORGE_NAMES[host.kind] : 'Unrecognised host'}
+          {host.username ? ` · ${host.username}` : ''}
+          {host.repos.length
+            ? ` · ${host.repos.length} repo${host.repos.length === 1 ? '' : 's'}`
+            : ''}
+        </div>
+      </div>
+
+      {/* An unrecognised domain is the ONE case that needs input: we can't tell
+          what `git.mycorp.com` runs, and guessing would fire authenticated
+          requests at an unrelated server. Asked once, then remembered. */}
+      {host.kind === null ? (
+        <select
+          value=""
+          onChange={(e) => void onChoose(host.host, (e.target.value || null) as ForgeKind | null)}
+          className="shrink-0 rounded-lg border border-border bg-surface-2 px-2 py-1 text-xs text-text"
+        >
+          <option value="">Which host?</option>
+          {KINDS.map((k) => (
+            <option key={k} value={k}>
+              {FORGE_NAMES[k]}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <span className="shrink-0 text-[11px] text-text-subtle">
+          {host.connected ? 'Connected' : 'No credential'}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Green only when we can actually talk to the host. "Unrecognised" is amber
+ * rather than red because nothing is broken — we just need one answer from the
+ * user.
+ */
+function StatusDot({ host }: { host: ForgeHostView }): JSX.Element {
+  const cls =
+    host.kind === null ? 'bg-warning' : host.connected ? 'bg-success' : 'bg-text-subtle/70'
+  const title =
+    host.kind === null
+      ? 'Roxy needs to know which software this host runs'
+      : host.connected
+        ? 'git has a credential for this host'
+        : 'No stored credential — run any git command against this host to create one'
+  return <span className={`h-2 w-2 shrink-0 rounded-full ${cls}`} title={title} />
+}

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -648,7 +648,13 @@ export function Sidebar(): JSX.Element {
                                     <button
                                       onClick={() => selectChat(chat.id)}
                                       onDoubleClick={() => beginRename(chat)}
-                                      title={chat.branch ? `${chat.title} — ${chat.branch}` : chat.title}
+                                      title={
+                                        chat.branch
+                                          ? dirtyById.has(chat.id)
+                                            ? `${chat.title} - ${chat.branch} (uncommitted changes)`
+                                            : `${chat.title} - ${chat.branch}`
+                                          : chat.title
+                                      }
                                       className="min-w-0 flex-1 text-left"
                                     >
                                       <span className="block truncate">{chat.title}</span>
@@ -658,11 +664,12 @@ export function Sidebar(): JSX.Element {
                                         <span className="flex items-center gap-1 text-[10px] text-text-subtle">
                                           <GitBranch className="h-2.5 w-2.5 shrink-0 opacity-70" />
                                           <span className="truncate">{chat.branch}</span>
+                                          {/* Uncommitted work. The label lives on the row
+                                              tooltip above, not here: a 4px dot is too small
+                                              to hover deliberately, so its own `title` would
+                                              never be seen. */}
                                           {dirtyById.has(chat.id) && (
-                                            <span
-                                              className="h-1 w-1 shrink-0 rounded-full bg-warning"
-                                              title="Uncommitted changes"
-                                            />
+                                            <span className="h-1 w-1 shrink-0 rounded-full bg-warning" />
                                           )}
                                         </span>
                                       )}

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import type { LifecycleAction, LifecycleTone, ForgeKind } from '@shared/forge'
+import { FORGE_NAMES, relativeAge } from '@shared/forge'
+import { api } from '../lib/api'
 import { Check, ChevronDown, GitBranch, Plus, SquareStack } from 'lucide-react'
 import type { Chat } from '@shared/types'
 import { useRoxyStore } from '../lib/store'
@@ -95,21 +98,309 @@ export function WorkstreamStrip(): JSX.Element | null {
 
         <Divider />
 
-        {/* Segment 3 — TODO: this becomes the branch lifecycle, and each state is
-            reachable with plain git except the last two:
-              ○ local  →  ↑N to push  →  pushed  →  PR #N  →  merged
-            Clicking it should open a panel with the remote, ahead/behind, and
-            commit/push actions. Left static here so the layout is final. */}
-        <span
-          className="flex items-center gap-1.5 px-1.5 py-1 text-text-subtle"
-          title="Not pushed yet"
-        >
-          <span className="h-1.5 w-1.5 rounded-full border border-text-subtle/70" />
-          local
-        </span>
+        {/* Segment 3 - the branch lifecycle:
+              local -> up-N to push -> pushed -> PR #N -> merged
+            Clicking opens the remote panel. */}
+        <LifecycleChip ownerId={owner.id} statusKey={statusKey} />
       </div>
     </div>
   )
+}
+
+/**
+ * Segment 3 - where the work stands relative to the remote.
+ *
+ * The states form one line, and the chip's whole job is to answer "is this
+ * done?" at a glance:
+ *
+ *   local  ->  up-N  ->  pushed  ->  #42  ->  merged
+ *
+ * The first three come from git and render offline and instantly. The last two
+ * need the host, so they arrive a moment later - which is why the chip never
+ * shows a spinner or an empty state: it always displays the best answer it
+ * currently has, and quietly upgrades. A chip that flickered between "local"
+ * and "#42" every poll would be worse than no chip.
+ */
+function LifecycleChip({
+  ownerId,
+  statusKey
+}: {
+  ownerId: string
+  statusKey: string | null
+}): JSX.Element | null {
+  const forgeStatus = useRoxyStore((s) => s.forgeStatus)
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent): void => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', onDown)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const view = statusKey ? forgeStatus[statusKey] : undefined
+  // Render nothing until the first status lands, rather than a placeholder that
+  // would visibly swap a moment later.
+  if (!view) return null
+
+  // An unrecognised host is the one case the chip cannot answer on its own.
+  // Asking here rather than only in Settings matters: this is the moment the
+  // user cares, and it is one click instead of a hunt through preferences.
+  if (view.unknownHost) return <UnknownHostChip host={view.unknownHost} />
+
+  const { lifecycle } = view
+
+  return (
+    <div className="relative" ref={ref}>
+      {open && (
+        <ForgePanel ownerId={ownerId} statusKey={statusKey} onClose={() => setOpen(false)} />
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        title={lifecycle.title}
+        className={cn(
+          'flex items-center gap-1.5 rounded-md px-1.5 py-1 transition hover:bg-white/5',
+          TONE_TEXT[lifecycle.tone]
+        )}
+      >
+        <StateDot tone={lifecycle.tone} filled={lifecycle.phase !== 'unpublished'} />
+        <span className="tabular-nums">{lifecycle.label}</span>
+      </button>
+    </div>
+  )
+}
+
+/**
+ * `git.mycorp.com` could be GitLab, Bitbucket Server or Azure DevOps Server,
+ * and the domain gives nothing away. Guessing would mean firing authenticated
+ * requests at an unrelated server, so we ask - once, then never again.
+ */
+function UnknownHostChip({ host }: { host: string }): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const refreshGitStatus = useRoxyStore((s) => s.refreshGitStatus)
+  const activeChatId = useRoxyStore((s) => s.activeChatId)
+
+  const pick = async (kind: ForgeKind): Promise<void> => {
+    await api.forge.setHostKind(host, kind)
+    setOpen(false)
+    if (activeChatId) await refreshGitStatus(activeChatId)
+  }
+
+  return (
+    <div className="relative">
+      {open && (
+        <div className="absolute bottom-full right-0 z-50 w-56 pb-1.5">
+          <div className="overflow-hidden rounded-xl border border-border bg-elevated py-1 shadow-2xl">
+            <div className="px-3 py-1.5 text-[11px] text-text-subtle">
+              What does <span className="text-text-muted">{host}</span> run?
+            </div>
+            {FORGE_KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => void pick(k)}
+                className="flex w-full items-center px-3 py-1.5 text-left text-xs text-text-muted transition hover:bg-white/5 hover:text-text"
+              >
+                {FORGE_NAMES[k]}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        title={`Roxy doesn't recognise ${host} - click to choose`}
+        className="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-text-subtle transition hover:bg-white/5 hover:text-text-muted"
+      >
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning" />
+        set up
+      </button>
+    </div>
+  )
+}
+
+const FORGE_KINDS: ForgeKind[] = ['github', 'azure-devops', 'gitlab', 'bitbucket']
+/**
+ * Colour is the fastest channel the chip has, so it carries the one thing worth
+ * interrupting for: whether something needs the user. Merged is the only green
+ * - "done" is the state worth celebrating, and if everything were coloured
+ * nothing would stand out.
+ */
+const TONE_TEXT: Record<LifecycleTone, string> = {
+  neutral: 'text-text-subtle hover:text-text-muted',
+  info: 'text-text-muted hover:text-text',
+  success: 'text-success',
+  warning: 'text-warning',
+  danger: 'text-danger'
+}
+
+const TONE_BG: Record<LifecycleTone, string> = {
+  neutral: 'bg-text-subtle/70',
+  info: 'bg-text-muted',
+  success: 'bg-success',
+  warning: 'bg-warning',
+  danger: 'bg-danger'
+}
+
+/**
+ * Hollow while the work is local, filled once it exists on the server. It's the
+ * same visual grammar as an unread dot, and it means the two most common states
+ * are distinguishable without reading the label.
+ */
+function StateDot({ tone, filled }: { tone: LifecycleTone; filled: boolean }): JSX.Element {
+  return filled ? (
+    <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', TONE_BG[tone])} />
+  ) : (
+    <span className="h-1.5 w-1.5 shrink-0 rounded-full border border-text-subtle/70" />
+  )
+}
+
+/**
+ * The panel behind the chip: who the host is, what the PR is, and the single
+ * most useful action for the current state.
+ *
+ * Exactly one primary action is offered at a time. A panel with push, pull,
+ * open-PR and view-PR all present would make the user decide what the app
+ * already knows.
+ */
+function ForgePanel({
+  ownerId,
+  statusKey,
+  onClose
+}: {
+  ownerId: string
+  statusKey: string | null
+  onClose: () => void
+}): JSX.Element {
+  const forgeStatus = useRoxyStore((s) => s.forgeStatus)
+  const gitStatus = useRoxyStore((s) => s.gitStatus)
+  const pushBranch = useRoxyStore((s) => s.pushBranch)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const view = statusKey ? forgeStatus[statusKey] : undefined
+  const git = statusKey ? gitStatus[statusKey] : undefined
+  const pull = view?.pull ?? null
+  const action = view?.lifecycle.action ?? null
+
+  const openUrl = (url: string): void => {
+    void api.system.openExternal(url)
+    onClose()
+  }
+
+  const run = async (): Promise<void> => {
+    if (busy || !action) return
+    setBusy(true)
+    setError(null)
+    try {
+      if (action === 'view-pr' && pull) return openUrl(pull.url)
+      if (action === 'open-pr') {
+        const url = statusKey ? await api.forge.createUrl(statusKey) : null
+        // A missing URL means we couldn't determine the base branch. Saying so
+        // beats opening a compare page pointed at the wrong target.
+        if (!url) return setError('Could not work out the base branch for this PR.')
+        return openUrl(url)
+      }
+      if (action === 'push') {
+        const r = await pushBranch(ownerId)
+        if (!r.ok) return setError(r.error ?? 'Push failed.')
+        return
+      }
+      // `pull` is deliberately not automated: merging into a dirty worktree
+      // that an agent is actively editing is how work gets lost.
+      if (action === 'pull') {
+        setError('Run `git pull` in this workstream - Roxy will not merge under a running agent.')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="absolute bottom-full right-0 z-50 w-80 pb-1.5">
+      <div className="overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <span className="min-w-0 flex-1 truncate text-xs text-text-muted">
+            {view?.remote ? view.remote.slug : 'No remote'}
+          </span>
+          {view?.remote && (
+            <span className="shrink-0 text-[11px] text-text-subtle">
+              {FORGE_NAMES[view.remote.kind]}
+            </span>
+          )}
+        </div>
+
+        {pull ? (
+          <button
+            type="button"
+            onClick={() => openUrl(pull.url)}
+            className="flex w-full flex-col gap-1 px-3 py-2 text-left transition hover:bg-white/5"
+          >
+            <span className="flex items-center gap-1.5">
+              <span className="text-xs font-medium text-text">#{pull.number}</span>
+              <span className="truncate text-xs text-text-muted">{pull.title}</span>
+            </span>
+            <span className="text-[11px] text-text-subtle">
+              {pull.author ? `${pull.author} - ` : ''}
+              {relativeAge(pull.updatedAt || pull.createdAt, Date.now())}
+              {pull.targetBranch ? ` - into ${pull.targetBranch}` : ''}
+            </span>
+          </button>
+        ) : (
+          <div className="px-3 py-2 text-[11px] text-text-subtle">
+            {view?.lifecycle.title ?? 'No pull request'}
+          </div>
+        )}
+
+        {/* Ahead/behind is shown as raw numbers rather than folded into prose:
+            it's the one thing people cross-check against their terminal. */}
+        {git && git.hasUpstream && (git.ahead > 0 || git.behind > 0) && (
+          <div className="flex gap-3 border-t border-border px-3 py-1.5 text-[11px] text-text-subtle tabular-nums">
+            {git.ahead > 0 && <span>{git.ahead} ahead</span>}
+            {git.behind > 0 && <span>{git.behind} behind</span>}
+          </div>
+        )}
+
+        {(error || view?.error) && (
+          <div className="border-t border-border px-3 py-1.5 text-[11px] text-warning">
+            {error ?? view?.error?.message}
+          </div>
+        )}
+
+        {action && (
+          <div className="border-t border-border p-1.5">
+            <button
+              type="button"
+              onClick={() => void run()}
+              disabled={busy}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-surface-2 px-3 py-1.5 text-xs text-text transition hover:bg-white/5 disabled:opacity-50"
+            >
+              {busy ? 'Working...' : ACTION_LABEL[action]}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const ACTION_LABEL: Record<LifecycleAction, string> = {
+  push: 'Push to origin',
+  pull: 'Behind origin',
+  'open-pr': 'Open a pull request',
+  'view-pr': 'View on the web'
 }
 
 function Divider(): JSX.Element {

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -84,15 +84,31 @@ export function WorkstreamStrip(): JSX.Element | null {
             workstream menu above is the branch picker. */}
         <span
           className="flex min-w-0 items-center gap-1.5 px-1.5 py-1 text-text-muted"
-          title={branch ? `On branch ${branch}` : undefined}
+          title={
+            branch
+              ? dirty
+                ? `On branch ${branch} \u2014 ${changed} uncommitted change${changed === 1 ? '' : 's'}`
+                : `On branch ${branch}`
+              : undefined
+          }
         >
           <GitBranch className="h-3.5 w-3.5 shrink-0 opacity-70" />
           <span className="truncate">{branch ?? 'detached'}</span>
-          {dirty && (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning"
-              title={`${changed} uncommitted change${changed === 1 ? '' : 's'}`}
-            />
+          {/* Uncommitted work. A bare dot was unreadable - it's a 6px target
+              nested inside a parent that has its own tooltip, so its `title`
+              was effectively unreachable and people (correctly) read it as
+              decoration. The count makes it self-explanatory, which beats a
+              better tooltip: the best hover text is the one nobody needs. */}
+          {dirty && changed > 0 && (
+            <span className="flex shrink-0 items-center gap-1 text-warning">
+              <span className="h-1.5 w-1.5 rounded-full bg-warning" />
+              <span className="tabular-nums">{changed}</span>
+            </span>
+          )}
+          {/* `dirty` with no count: git says the tree is modified but gave us
+              no entries to count. Rare, but the dot must not silently vanish. */}
+          {dirty && changed === 0 && (
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning" />
           )}
         </span>
 

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -30,6 +30,7 @@ import { uniqueSlug } from '@shared/slugs'
 import { api } from './api'
 import type { ComposerImage } from './images'
 import type { GitStatusView, ServiceView, WorktreeView } from '@shared/api'
+import type { ForgeStatusView } from '@shared/forge'
 
 interface RoxyStore {
   ready: boolean
@@ -70,6 +71,12 @@ interface RoxyStore {
    * so N sessions sharing a worktree share one poll instead of N.
    */
   gitStatus: Record<string, GitStatusView>
+  /**
+   * Remote/PR state, keyed by the same worktree path as `gitStatus` so the two
+   * always agree. Populated by the same poll - a separate one would double the
+   * git spawns for a strictly worse result.
+   */
+  forgeStatus: Record<string, ForgeStatusView>
   /** Live worktrees per project folder, for the workstream menu. */
   worktrees: Record<string, WorktreeView[]>
   /** Branches per project folder, loaded lazily when the menu opens. */
@@ -128,6 +135,8 @@ interface RoxyStore {
    * worktrees watchers multiply, and fs.watch is unreliable on Windows.
    */
   refreshGitStatus: (chatId: string) => Promise<void>
+  /** Push this session's branch to origin, then refresh its status. */
+  pushBranch: (chatId: string) => Promise<{ ok: boolean; error?: string }>
   /** Load the worktrees + branches for a project (menu open). */
   refreshWorktrees: (workspacePath: string) => Promise<void>
   /**
@@ -252,6 +261,7 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   services: [],
   gitAvailable: null,
   gitStatus: {},
+  forgeStatus: {},
   worktrees: {},
   gitBranches: {},
   usageStats: null,
@@ -461,11 +471,28 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     }
     if (!get().gitAvailable) return
     try {
-      const status = await api.git.status(key)
-      set((s) => ({ gitStatus: { ...s.gitStatus, [key]: status } }))
+      // One round trip for both. `forge.status` is cheap by construction: it
+      // returns local git state immediately and refreshes pull-request data in
+      // the background, so putting it on the 5s poll costs no network traffic.
+      const [status, forge] = await Promise.all([api.git.status(key), api.forge.status(key)])
+      set((s) => ({
+        gitStatus: { ...s.gitStatus, [key]: status },
+        forgeStatus: forge ? { ...s.forgeStatus, [key]: forge } : s.forgeStatus
+      }))
     } catch {
       // Best-effort: a transient git failure leaves the last known state.
     }
+  },
+
+  pushBranch: async (chatId) => {
+    const chat = get().chats.find((c) => c.id === chatId)
+    const key = chat?.worktreePath ?? chat?.workspacePath
+    if (!key) return { ok: false, error: 'No workspace for this session.' }
+    const r = await api.forge.push(key)
+    // Refresh immediately so the chip moves off "local" the moment the push
+    // lands, rather than on the next tick.
+    if (r.ok) await get().refreshGitStatus(chatId)
+    return r
   },
 
   refreshWorktrees: async (workspacePath) => {

--- a/src/renderer/src/routes/Settings.tsx
+++ b/src/renderer/src/routes/Settings.tsx
@@ -5,6 +5,7 @@ import type { AppVersions, ConnectedProvider } from '@shared/types'
 import type { UpdateInfo } from '@shared/api'
 import { AUTH_LABELS } from '@shared/providers'
 import { api } from '../lib/api'
+import { CodeHosts } from '../components/CodeHosts'
 import { Button } from '../components/ui'
 import { PageShell } from '../components/PageShell'
 import { McpServers } from '../components/McpServers'
@@ -167,6 +168,15 @@ export default function Settings(): JSX.Element {
         </div>
       </section>
 
+      {/* Distinct from "Providers" above on purpose: that list is who runs the
+          MODEL, this one is where the CODE lives. GitHub appears in both, as
+          two unrelated accounts. */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">
+          Code hosts
+        </h2>
+        <CodeHosts />
+      </section>
       <section className="mb-8">
         <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">
           MCP servers

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -24,6 +24,7 @@ import type {
   WorktreeIntent
 } from './types'
 import type { McpServerConfig } from './mcp'
+import type { ForgeStatusView, ForgeHostView, ForgeKind } from './forge'
 
 /** A configured MCP server merged with its live connection status (for Settings). */
 export interface McpServerView {
@@ -608,6 +609,30 @@ export interface RoxyApi {
     restart(sessionId: string, id: string): Promise<{ ok: boolean; id?: string; error?: string }>
     /** Open this session's OWN browser window at a service's localhost URL. */
     open(sessionId: string, port: number): Promise<void>
+  }
+  /**
+   * The git HOST behind `origin` - GitHub, Azure DevOps, GitLab or Bitbucket.
+   * Named "forge" because `remote` already means the roxy.gg phone relay here.
+   */
+  forge: {
+    /**
+     * Branch state, local + remote, in one call. Returns instantly with git
+     * state; pull-request data is served from cache and refreshed in the
+     * background, so a 5s poll never waits on the network. `force` waits.
+     */
+    status(cwd: string, force?: boolean): Promise<ForgeStatusView>
+    /** Push the current branch to origin, setting upstream when it has none. */
+    push(cwd: string): Promise<{ ok: boolean; error?: string }>
+    /** The host's "create a pull request" URL, pre-filled for this branch. */
+    createUrl(cwd: string): Promise<string | null>
+    /**
+     * Git hosts this user's projects use, with live connection state read from
+     * git's credential helper. Not a list of "accounts Roxy owns" - Roxy owns
+     * none; this is a view of what git already has.
+     */
+    listHosts(): Promise<ForgeHostView[]>
+    /** Record which software an unrecognised host runs (null clears it). */
+    setHostKind(host: string, kind: ForgeKind | null): Promise<void>
   }
   git: {
     /** Whether a usable `git` binary exists (probed once, cached). */

--- a/src/shared/forge.ts
+++ b/src/shared/forge.ts
@@ -1,0 +1,618 @@
+/**
+ * "Forge" = a git hosting platform (GitHub, Azure DevOps, GitLab, Bitbucket).
+ * The term is borrowed from magit/forge; `remote` was already taken by the
+ * roxy.gg phone-relay feature and reusing it would be a permanent source of
+ * confusion in this codebase.
+ *
+ * This module is PURE — no Node, no Electron, no network. It holds the two
+ * things that are easy to get subtly wrong and expensive to debug through a
+ * network call:
+ *
+ *   1. Parsing a git remote URL into host coordinates. There are ~14 URL shapes
+ *      across four vendors, and Azure DevOps alone has five.
+ *   2. Deciding which of the eight lifecycle states a branch is in, given git's
+ *      ahead/behind numbers and (maybe) a pull request.
+ *
+ * Both are unit-tested by `npm run smoke:shared`, so the network layer can stay
+ * a thin, boring fetch.
+ */
+
+// ---------------------------------------------------------------------------
+// Remote identity
+// ---------------------------------------------------------------------------
+
+export type ForgeKind = 'github' | 'azure-devops' | 'gitlab' | 'bitbucket'
+
+/** Display names, for UI that shouldn't hardcode vendor spelling. */
+export const FORGE_NAMES: Record<ForgeKind, string> = {
+  github: 'GitHub',
+  'azure-devops': 'Azure DevOps',
+  gitlab: 'GitLab',
+  bitbucket: 'Bitbucket'
+}
+
+/**
+ * A parsed `origin`, resolved far enough to build API calls without guessing.
+ *
+ * `owner`/`repo` mean slightly different things per host (see the field docs);
+ * that asymmetry is real and pretending otherwise would push the special cases
+ * into every call site instead of keeping them here.
+ */
+export interface ForgeRemote {
+  kind: ForgeKind
+  /** The web host as written in the remote, e.g. `github.com`, `dev.azure.com`. */
+  host: string
+  /** False for GitHub Enterprise / self-hosted GitLab / Bitbucket Server. */
+  cloud: boolean
+  /**
+   * GitHub: repo owner. Azure DevOps: organization. GitLab: the full namespace
+   * path (`group/subgroup`). Bitbucket: workspace (cloud) or project key (server).
+   */
+  owner: string
+  repo: string
+  /** Azure DevOps only — the team project, which sits between org and repo. */
+  project?: string
+  /** Root for REST calls, no trailing slash. */
+  apiBase: string
+  /** Root for human-facing links, no trailing slash. */
+  webBase: string
+  /** Compact identity for UI, e.g. `FreddyJD/roxy` or `msft/Edge/browser`. */
+  slug: string
+}
+
+/** Hosts we recognise as the vendor's own cloud. */
+const CLOUD_HOSTS: Record<string, ForgeKind> = {
+  'github.com': 'github',
+  'www.github.com': 'github',
+  'gist.github.com': 'github',
+  'dev.azure.com': 'azure-devops',
+  'ssh.dev.azure.com': 'azure-devops',
+  'vs-ssh.visualstudio.com': 'azure-devops',
+  'gitlab.com': 'gitlab',
+  'www.gitlab.com': 'gitlab',
+  'bitbucket.org': 'bitbucket',
+  'www.bitbucket.org': 'bitbucket'
+}
+
+/**
+ * Split any git remote URL into `{ host, path }`, covering the four transports
+ * git actually accepts.
+ *
+ * The scp-like form (`git@host:path`) is the one that trips up naive parsers:
+ * it is NOT a URL, `new URL()` rejects it, and the colon is a separator rather
+ * than a port. It's also the default clone form GitHub/GitLab/Bitbucket offer,
+ * so it can't be treated as an edge case.
+ */
+export function splitRemoteUrl(raw: string): { host: string; path: string; user?: string } | null {
+  const url = (raw ?? '').trim()
+  if (!url) return null
+
+  // scp-like: [user@]host:path (no scheme, and the part before ':' has no '/')
+  const scp = /^(?:([^@/\s]+)@)?([^@/:\s]+):(?!\/)(.+)$/.exec(url)
+  if (scp && !/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+    return { user: scp[1], host: scp[2].toLowerCase(), path: stripPath(scp[3]) }
+  }
+
+  // ssh:// | git:// | http(s):// | file://
+  const m = /^([a-z][a-z0-9+.-]*):\/\/(?:([^@/]+)@)?([^/?#]+)(\/[^?#]*)?/i.exec(url)
+  if (!m) return null
+  const scheme = m[1].toLowerCase()
+  if (scheme === 'file') return null
+  // Strip an inline port: dev.azure.com:8080 -> dev.azure.com. IPv6 in a git
+  // remote is vanishingly rare; treat a bracketed host as opaque.
+  const rawHost = m[3]
+  const host = rawHost.startsWith('[') ? rawHost.toLowerCase() : rawHost.split(':')[0].toLowerCase()
+  return { user: m[2] ? decodeURIComponent(m[2]) : undefined, host, path: stripPath(m[4] ?? '') }
+}
+
+/** Normalise a remote path: no leading/trailing slash, no `.git` suffix. */
+function stripPath(p: string): string {
+  return p
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/i, '')
+}
+
+/**
+ * Identify the vendor from the host, falling back to a name-shaped guess for
+ * self-hosted installs (`gitlab.acme.com`, `github.acme.com`).
+ *
+ * Returns null for a host with no vendor hint (`git.mycorp.com`) rather than
+ * guessing. A wrong guess fires authenticated requests at an unrelated server,
+ * which is a far worse failure than asking the user once — see `detectHost`,
+ * which turns that null into a "pick your host" prompt.
+ */
+export function forgeKindForHost(host: string): ForgeKind | null {
+  const h = host.toLowerCase()
+  const cloud = CLOUD_HOSTS[h]
+  if (cloud) return cloud
+  // Legacy Azure DevOps: {org}.visualstudio.com
+  if (h.endsWith('.visualstudio.com')) return 'azure-devops'
+  const label = h.split('.')[0]
+  if (label === 'github' || h.includes('github.')) return 'github'
+  if (label === 'gitlab' || h.includes('gitlab.')) return 'gitlab'
+  if (label === 'bitbucket' || h.includes('bitbucket.')) return 'bitbucket'
+  if (h.includes('azure.') || h.includes('tfs.')) return 'azure-devops'
+  return null
+}
+
+/**
+ * What a remote URL is, before we know how to talk to it.
+ *
+ * The three outcomes are genuinely different and the UI treats each one
+ * differently, which is why this is separate from `parseRemote`:
+ *
+ *  - `null`          not a hosted repo at all (local path, file://, junk).
+ *                    Show nothing; there is no server to ask.
+ *  - `kind: null`    a real host we don't recognise (`git.mycorp.com`).
+ *                    Ask the user which software it runs — once, then remember.
+ *  - `kind` set      recognised. Proceed silently.
+ *
+ * Collapsing the last two into "unsupported" is the tempting shortcut and it's
+ * wrong: self-hosted GitLab and Bitbucket behind a corporate domain are the
+ * single most common case in exactly the enterprises this feature is for.
+ */
+export interface HostProbe {
+  host: string
+  /** Null when the domain carries no vendor hint and the user must choose. */
+  kind: ForgeKind | null
+}
+
+export function detectHost(raw: string): HostProbe | null {
+  const split = splitRemoteUrl(raw)
+  if (!split) return null
+  // A host with no path can't be a repo; treat it as unusable rather than
+  // prompting the user to classify something we can't address anyway.
+  if (!split.path) return null
+  return { host: split.host, kind: forgeKindForHost(split.host) }
+}
+
+/**
+ * Parse a remote URL into forge coordinates, or null when it isn't a hosted
+ * repo we can talk to.
+ *
+ * `kindOverride` is the user's stored answer for an unrecognised domain. It is
+ * only ever consulted when auto-detection fails, so a saved override can never
+ * silently mis-route a well-known host if the user once guessed wrong.
+ *
+ * Never throws: a malformed remote is a normal thing to find in a repo and must
+ * not take down a status refresh.
+ */
+export function parseRemote(raw: string, kindOverride?: ForgeKind | null): ForgeRemote | null {
+  const split = splitRemoteUrl(raw)
+  if (!split) return null
+  const kind = forgeKindForHost(split.host) ?? kindOverride ?? null
+  if (!kind) return null
+  const segs = split.path.split('/').filter(Boolean)
+  if (segs.length === 0) return null
+
+  switch (kind) {
+    case 'github':
+      return parseGitHub(split.host, segs)
+    case 'azure-devops':
+      return parseAzureDevOps(split.host, segs, split.user)
+    case 'gitlab':
+      return parseGitLab(split.host, segs)
+    case 'bitbucket':
+      return parseBitbucket(split.host, segs)
+  }
+}
+
+function parseGitHub(host: string, segs: string[]): ForgeRemote | null {
+  if (segs.length < 2) return null
+  const cloud = host === 'github.com' || host === 'www.github.com'
+  const [owner, repo] = segs
+  // Enterprise mounts its API under /api/v3 on the same host; cloud has a
+  // dedicated api. subdomain. Getting this wrong 404s every request.
+  const webBase = `https://${cloud ? 'github.com' : host}`
+  return {
+    kind: 'github',
+    host,
+    cloud,
+    owner,
+    repo,
+    apiBase: cloud ? 'https://api.github.com' : `${webBase}/api/v3`,
+    webBase,
+    slug: `${owner}/${repo}`
+  }
+}
+
+/**
+ * Azure DevOps, which has by far the messiest URL space:
+ *
+ *   https://dev.azure.com/{org}/{project}/_git/{repo}
+ *   https://{org}@dev.azure.com/{org}/{project}/_git/{repo}   (git's own default)
+ *   https://dev.azure.com/{org}/_git/{repo}                   (project == repo)
+ *   https://{org}.visualstudio.com/{project}/_git/{repo}      (legacy)
+ *   https://{org}.visualstudio.com/DefaultCollection/{project}/_git/{repo}
+ *   git@ssh.dev.azure.com:v3/{org}/{project}/{repo}           (ssh, no _git)
+ */
+function parseAzureDevOps(host: string, segs: string[], user?: string): ForgeRemote | null {
+  const legacy = host.endsWith('.visualstudio.com')
+  let org: string | undefined
+  let parts = [...segs]
+
+  if (legacy) {
+    org = host.split('.')[0]
+  } else if (parts[0] === 'v3') {
+    // ssh.dev.azure.com:v3/{org}/{project}/{repo}
+    parts = parts.slice(1)
+    org = parts.shift()
+  } else {
+    org = parts.shift()
+  }
+  if (!org) return null
+
+  // Legacy collection segment carries no information we need.
+  if (parts[0]?.toLowerCase() === 'defaultcollection') parts = parts.slice(1)
+
+  const gitAt = parts.indexOf('_git')
+  let project: string
+  let repo: string
+  if (gitAt >= 0) {
+    repo = parts[gitAt + 1] ?? ''
+    // `/_git/{repo}` with nothing before it means the project shares the repo's
+    // name — the shorthand the Azure portal hands out for single-repo projects.
+    project = gitAt === 0 ? repo : parts.slice(0, gitAt).join('/')
+  } else {
+    // SSH form has no `_git` marker: {project}/{repo}, or just {repo}.
+    repo = parts[parts.length - 1] ?? ''
+    project = parts.length > 1 ? parts.slice(0, -1).join('/') : repo
+  }
+  if (!repo) return null
+
+  // `{org}@dev.azure.com` — the org in the userinfo wins only if we somehow
+  // didn't get one from the path.
+  if (!org && user) org = user
+
+  const webBase = legacy ? `https://${host}` : `https://dev.azure.com/${org}`
+  return {
+    kind: 'azure-devops',
+    host,
+    cloud: host === 'dev.azure.com' || host === 'ssh.dev.azure.com' || legacy,
+    owner: org,
+    project,
+    repo,
+    apiBase: webBase,
+    webBase,
+    slug: `${org}/${project}/${repo}`
+  }
+}
+
+/**
+ * GitLab allows arbitrarily nested groups, so the namespace is "everything but
+ * the last segment" rather than a fixed `owner`. The API addresses a project by
+ * the URL-encoded full path, which is assembled by the caller.
+ */
+function parseGitLab(host: string, segs: string[]): ForgeRemote | null {
+  if (segs.length < 2) return null
+  // Self-hosted GitLab is often mounted under a path prefix; `/-/` is GitLab's
+  // route separator and never part of a project path.
+  const dash = segs.indexOf('-')
+  const parts = dash > 0 ? segs.slice(0, dash) : segs
+  if (parts.length < 2) return null
+  const repo = parts[parts.length - 1]
+  const owner = parts.slice(0, -1).join('/')
+  const cloud = host === 'gitlab.com' || host === 'www.gitlab.com'
+  const webBase = `https://${cloud ? 'gitlab.com' : host}`
+  return {
+    kind: 'gitlab',
+    host,
+    cloud,
+    owner,
+    repo,
+    apiBase: `${webBase}/api/v4`,
+    webBase,
+    slug: `${owner}/${repo}`
+  }
+}
+
+/**
+ * Bitbucket Cloud is `{workspace}/{repo}`. Bitbucket Server/Data Center is
+ * `/scm/{PROJECT}/{repo}` with a completely different REST API (1.0 vs 2.0),
+ * so it's flagged via `cloud:false` and the adapter refuses it rather than
+ * firing Cloud-shaped requests at it.
+ */
+function parseBitbucket(host: string, segs: string[]): ForgeRemote | null {
+  const cloud = host === 'bitbucket.org' || host === 'www.bitbucket.org'
+  let parts = segs
+  const scm = segs.indexOf('scm')
+  if (!cloud && scm >= 0) parts = segs.slice(scm + 1)
+  if (parts.length < 2) return null
+  const [owner, repo] = parts
+  const webBase = `https://${cloud ? 'bitbucket.org' : host}`
+  return {
+    kind: 'bitbucket',
+    host,
+    cloud,
+    owner,
+    repo,
+    apiBase: cloud ? 'https://api.bitbucket.org/2.0' : `${webBase}/rest/api/1.0`,
+    webBase,
+    slug: `${owner}/${repo}`
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pull requests
+// ---------------------------------------------------------------------------
+
+/** Normalised across all four hosts, which disagree on nearly every name. */
+export type PullState = 'open' | 'draft' | 'merged' | 'closed'
+
+/** CI rollup. `null` when the host wasn't asked or reports nothing. */
+export type ChecksState = 'pending' | 'passing' | 'failing'
+
+export type ReviewState = 'approved' | 'changes_requested' | 'review_required'
+
+export interface PullRequestView {
+  /** The user-visible number (`#42`), not an opaque id. */
+  number: number
+  title: string
+  state: PullState
+  /** Permalink to the PR/MR in the browser. */
+  url: string
+  sourceBranch: string
+  targetBranch: string
+  author: string | null
+  createdAt: number
+  updatedAt: number
+  checks: ChecksState | null
+  review: ReviewState | null
+}
+
+/** What the strip needs about a branch, before a PR is known. */
+export interface BranchSync {
+  /** Commits on this branch not on its upstream. */
+  ahead: number
+  /** Commits on the upstream not on this branch. */
+  behind: number
+  /** Whether the branch has an upstream at all. */
+  hasUpstream: boolean
+  /** Uncommitted working-tree changes. */
+  dirty: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Where a branch sits on the road from "just created" to "merged".
+ *
+ * `unpublished` and `ahead` are answerable from git alone; everything from
+ * `open` on requires the forge. That split matters: the first two must render
+ * instantly and offline, so the UI never blocks on a network call to show
+ * something it already knows.
+ */
+export type LifecyclePhase =
+  | 'unpublished'
+  | 'ahead'
+  | 'behind'
+  | 'synced'
+  | 'draft'
+  | 'open'
+  | 'merged'
+  | 'closed'
+
+export type LifecycleTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+
+export interface LifecycleView {
+  phase: LifecyclePhase
+  /** Terse chip text: `local`, `↑3`, `pushed`, `#42`, `merged`. */
+  label: string
+  tone: LifecycleTone
+  /** Full sentence for the tooltip. */
+  title: string
+  /** True once the forge has been consulted and a PR exists. */
+  pr: PullRequestView | null
+  /** The single most useful next action, or null when there isn't one. */
+  action: LifecycleAction | null
+}
+
+export type LifecycleAction = 'push' | 'pull' | 'open-pr' | 'view-pr'
+
+/**
+ * The state machine. Deliberately ordered most-settled first: a merged PR is
+ * the truth about a branch even if the local copy is stale and looks "ahead",
+ * and showing `↑2` on a merged branch is exactly the kind of lie that makes
+ * people stop trusting a status indicator.
+ */
+export function branchLifecycle(input: {
+  sync: BranchSync
+  pr: PullRequestView | null
+  /** Null while the forge lookup is in flight or unavailable. */
+  forgeKnown: boolean
+}): LifecycleView {
+  const { sync, pr } = input
+
+  if (pr) {
+    switch (pr.state) {
+      case 'merged':
+        return {
+          phase: 'merged',
+          label: 'merged',
+          tone: 'success',
+          title: `#${pr.number} merged into ${pr.targetBranch}`,
+          pr,
+          action: 'view-pr'
+        }
+      case 'closed':
+        return {
+          phase: 'closed',
+          label: 'closed',
+          tone: 'neutral',
+          // Azure DevOps calls this "abandoned"; the tooltip stays vendor-neutral
+          // because the chip is shared across all four.
+          title: `#${pr.number} closed without merging`,
+          pr,
+          action: 'view-pr'
+        }
+      case 'draft':
+        return {
+          phase: 'draft',
+          label: `#${pr.number} draft`,
+          tone: 'neutral',
+          title: `Draft #${pr.number} → ${pr.targetBranch}`,
+          pr,
+          action: 'view-pr'
+        }
+      case 'open':
+        return {
+          phase: 'open',
+          label: `#${pr.number}`,
+          tone: toneForChecks(pr.checks, pr.review),
+          title: openTitle(pr),
+          pr,
+          action: 'view-pr'
+        }
+    }
+  }
+
+  // No PR (or the forge hasn't answered yet) — fall back to what git knows.
+  if (!sync.hasUpstream) {
+    return {
+      phase: 'unpublished',
+      label: 'local',
+      tone: 'neutral',
+      title: 'Not pushed yet',
+      pr: null,
+      action: 'push'
+    }
+  }
+  if (sync.ahead > 0) {
+    return {
+      phase: 'ahead',
+      label: `↑${sync.ahead}`,
+      tone: 'info',
+      title: `${sync.ahead} commit${sync.ahead === 1 ? '' : 's'} to push`,
+      pr: null,
+      action: 'push'
+    }
+  }
+  if (sync.behind > 0) {
+    return {
+      phase: 'behind',
+      label: `↓${sync.behind}`,
+      tone: 'warning',
+      title: `${sync.behind} commit${sync.behind === 1 ? '' : 's'} behind upstream`,
+      pr: null,
+      action: 'pull'
+    }
+  }
+  return {
+    phase: 'synced',
+    label: 'pushed',
+    tone: 'neutral',
+    title: input.forgeKnown ? 'Pushed — no pull request yet' : 'Pushed',
+    pr: null,
+    // Only offer "open a PR" once we actually know none exists; offering it
+    // while the lookup is pending produces a button that vanishes under the
+    // cursor.
+    action: input.forgeKnown ? 'open-pr' : null
+  }
+}
+
+/**
+ * An open PR's colour comes from whatever is blocking it. Failing CI outranks
+ * review state because it's actionable by the author right now, while a pending
+ * review is someone else's turn.
+ */
+function toneForChecks(checks: ChecksState | null, review: ReviewState | null): LifecycleTone {
+  if (checks === 'failing') return 'danger'
+  if (review === 'changes_requested') return 'warning'
+  if (checks === 'pending') return 'info'
+  if (checks === 'passing' && review === 'approved') return 'success'
+  return 'info'
+}
+
+function openTitle(pr: PullRequestView): string {
+  const bits = [`#${pr.number} → ${pr.targetBranch}`]
+  if (pr.checks === 'failing') bits.push('checks failing')
+  else if (pr.checks === 'pending') bits.push('checks running')
+  else if (pr.checks === 'passing') bits.push('checks passing')
+  if (pr.review === 'approved') bits.push('approved')
+  else if (pr.review === 'changes_requested') bits.push('changes requested')
+  return bits.join(' · ')
+}
+
+// ---------------------------------------------------------------------------
+// The wire shape
+// ---------------------------------------------------------------------------
+
+/** Why a forge lookup failed. `auth` is the one the UI acts on. */
+export interface ForgeError {
+  reason: 'auth' | 'network' | 'unsupported' | 'not-found'
+  message: string
+}
+
+/**
+ * A git host Roxy has seen, and whether it can currently talk to it.
+ *
+ * Note what is NOT here: a token, a way to set one, or any notion of signing
+ * in. Roxy does not own these credentials — git's credential helper does. This
+ * is a read-only VIEW of what the helper already holds, which is why the
+ * Settings row is a status line and not a login form.
+ *
+ * This is also why GitHub can legitimately appear twice in Settings: once here
+ * as a code host, and once under Providers as the vendor of Copilot. They are
+ * unrelated accounts with unrelated tokens and unrelated scopes, and merging
+ * them would mean signing into Copilot silently granted repo access.
+ */
+export interface ForgeHostView {
+  host: string
+  /** Null for an unrecognised domain the user hasn't classified yet. */
+  kind: ForgeKind | null
+  /** True when `git credential fill` returns something for this host. */
+  connected: boolean
+  /** The account name the helper reports, when it has one. */
+  username: string | null
+  /** Repos in Roxy's known projects that live on this host. */
+  repos: string[]
+}
+
+/**
+ * Everything the UI knows about a branch's remote life, in one object.
+ *
+ * Lives in `shared` (not in the main-process service) because the renderer
+ * imports it, and `shared` must never depend on `main` — that import would drag
+ * Electron and `node:child_process` into the browser bundle.
+ */
+export interface ForgeStatusView {
+  /** Null when there's no remote, or the host isn't one we recognise. */
+  remote: {
+    kind: ForgeKind
+    host: string
+    slug: string
+    webBase: string
+  } | null
+  /** The lifecycle chip — always present, even with no forge and no network. */
+  lifecycle: LifecycleView
+  /** The pull request for this branch, when the forge knows of one. */
+  pull: PullRequestView | null
+  /** Set when the last lookup failed. Advisory: the chip still renders. */
+  error: ForgeError | null
+  /** True while a background refresh is in flight. */
+  refreshing: boolean
+  /**
+   * Set when the remote points at a host we couldn't classify. The UI shows a
+   * one-time "which of these does `git.mycorp.com` run?" prompt; answering it
+   * stores an override and this goes away for good.
+   */
+  unknownHost: string | null
+}
+
+/** Compact "3 minutes ago"-style age, for PR tooltips and the detail panel. */
+export function relativeAge(then: number, now: number): string {
+  const s = Math.max(0, Math.floor((now - then) / 1000))
+  if (s < 60) return 'just now'
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 30) return `${d}d ago`
+  const mo = Math.floor(d / 30)
+  if (mo < 12) return `${mo}mo ago`
+  return `${Math.floor(mo / 12)}y ago`
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -129,6 +129,12 @@ export const CHANNELS = {
   gitRemoveWorktree: 'git:remove-worktree',
   gitPruneWorktrees: 'git:prune-worktrees',
 
+  /** Forge = the git host (GitHub/Azure DevOps/GitLab/Bitbucket) behind `origin`. */
+  forgeStatus: 'forge:status',
+  forgePush: 'forge:push',
+  forgeCreateUrl: 'forge:create-url',
+  forgeListHosts: 'forge:list-hosts',
+  forgeSetHostKind: 'forge:set-host-kind',
   remoteStart: 'remote:start',
   remoteStop: 'remote:stop',
   remoteStatus: 'remote:status',

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -152,6 +152,16 @@ import {
   BUNDLE_KIND,
   BUNDLE_VERSION
 } from '../src/shared/portable'
+import {
+  parseRemote,
+  splitRemoteUrl,
+  forgeKindForHost,
+  detectHost,
+  branchLifecycle,
+  relativeAge,
+  FORGE_NAMES,
+  type PullRequestView
+} from '../src/shared/forge'
 
 let pass = 0
 const fails: string[] = []
@@ -2461,6 +2471,382 @@ async function main(): Promise<void> {
     aggregateActivity([aNow - 5 * DAYMS], aNow, 182).currentStreak === 0
   )
 
+  // ---- forge: remote URL parsing ------------------------------------------
+  // Every shape below was taken from a real clone URL the vendors hand out.
+  // These are the highest-risk lines in the feature: a mis-parse means requests
+  // fired at the wrong host or a silent 404, with no obvious cause in the UI.
+
+  check(
+    'forge: scp-like github',
+    (() => {
+      const r = parseRemote('git@github.com:FreddyJD/roxy.git')
+      return r?.kind === 'github' && r.owner === 'FreddyJD' && r.repo === 'roxy'
+    })()
+  )
+  check(
+    'forge: https github + .git',
+    (() => {
+      const r = parseRemote('https://github.com/FreddyJD/roxy.git')
+      return r?.slug === 'FreddyJD/roxy' && r.apiBase === 'https://api.github.com'
+    })()
+  )
+  check(
+    'forge: github enterprise uses /api/v3',
+    (() => {
+      const r = parseRemote('https://github.acme.com/team/app.git')
+      return (
+        r?.kind === 'github' && r.cloud === false && r.apiBase === 'https://github.acme.com/api/v3'
+      )
+    })()
+  )
+  check(
+    'forge: ssh:// github with port',
+    (() => {
+      const r = parseRemote('ssh://git@github.com:22/FreddyJD/roxy.git')
+      return r?.kind === 'github' && r.owner === 'FreddyJD' && r.repo === 'roxy'
+    })()
+  )
+
+  check(
+    'forge: ADO dev.azure.com org/project/_git/repo',
+    (() => {
+      const r = parseRemote('https://dev.azure.com/msft/Edge/_git/browser')
+      return (
+        r?.kind === 'azure-devops' &&
+        r.owner === 'msft' &&
+        r.project === 'Edge' &&
+        r.repo === 'browser'
+      )
+    })()
+  )
+  check(
+    'forge: ADO with org in userinfo',
+    (() => {
+      const r = parseRemote('https://msft@dev.azure.com/msft/Edge/_git/browser')
+      return r?.owner === 'msft' && r.project === 'Edge' && r.repo === 'browser'
+    })()
+  )
+  check(
+    'forge: ADO shorthand /_git/repo implies project==repo',
+    (() => {
+      const r = parseRemote('https://dev.azure.com/msft/_git/browser')
+      return r?.owner === 'msft' && r.project === 'browser' && r.repo === 'browser'
+    })()
+  )
+  check(
+    'forge: ADO ssh v3 form',
+    (() => {
+      const r = parseRemote('git@ssh.dev.azure.com:v3/msft/Edge/browser')
+      return (
+        r?.kind === 'azure-devops' &&
+        r.owner === 'msft' &&
+        r.project === 'Edge' &&
+        r.repo === 'browser'
+      )
+    })()
+  )
+  check(
+    'forge: ADO legacy visualstudio.com',
+    (() => {
+      const r = parseRemote('https://msft.visualstudio.com/Edge/_git/browser')
+      return (
+        r?.kind === 'azure-devops' &&
+        r.owner === 'msft' &&
+        r.project === 'Edge' &&
+        r.repo === 'browser'
+      )
+    })()
+  )
+  check(
+    'forge: ADO legacy DefaultCollection is skipped',
+    (() => {
+      const r = parseRemote('https://msft.visualstudio.com/DefaultCollection/Edge/_git/browser')
+      return r?.project === 'Edge' && r.repo === 'browser'
+    })()
+  )
+  check(
+    'forge: ADO project with a space survives',
+    (() => {
+      const r = parseRemote('https://dev.azure.com/msft/My%20Project/_git/app')
+      return r?.project === 'My%20Project' && r.repo === 'app'
+    })()
+  )
+
+  check(
+    'forge: gitlab nested groups keep full namespace',
+    (() => {
+      const r = parseRemote('https://gitlab.com/group/subgroup/app.git')
+      return r?.kind === 'gitlab' && r.owner === 'group/subgroup' && r.repo === 'app'
+    })()
+  )
+  check(
+    'forge: gitlab self-hosted api/v4',
+    (() => {
+      const r = parseRemote('git@gitlab.acme.com:team/app.git')
+      return (
+        r?.kind === 'gitlab' && r.apiBase === 'https://gitlab.acme.com/api/v4' && r.cloud === false
+      )
+    })()
+  )
+
+  check(
+    'forge: bitbucket cloud',
+    (() => {
+      const r = parseRemote('https://bitbucket.org/acme/app.git')
+      return (
+        r?.kind === 'bitbucket' && r.cloud === true && r.apiBase === 'https://api.bitbucket.org/2.0'
+      )
+    })()
+  )
+  check(
+    'forge: bitbucket server /scm/ prefix stripped',
+    (() => {
+      const r = parseRemote('https://bitbucket.acme.com/scm/PROJ/app.git')
+      return r?.kind === 'bitbucket' && r.cloud === false && r.owner === 'PROJ' && r.repo === 'app'
+    })()
+  )
+
+  check('forge: local path is not a forge', parseRemote('/home/me/repo.git') === null)
+  check('forge: file:// is not a forge', parseRemote('file:///srv/repo.git') === null)
+  check('forge: unknown host is not guessed', parseRemote('git@example.com:me/app.git') === null)
+  check('forge: empty string is safe', parseRemote('') === null)
+  check('forge: junk is safe', parseRemote('not a url at all') === null)
+
+  check(
+    'forge: splitRemoteUrl scp colon is not a port',
+    (() => {
+      const s = splitRemoteUrl('git@github.com:FreddyJD/roxy.git')
+      return s?.host === 'github.com' && s.path === 'FreddyJD/roxy'
+    })()
+  )
+  check('forge: host detection is case-insensitive', forgeKindForHost('GitHub.COM') === 'github')
+  check('forge: every kind has a display name', Object.keys(FORGE_NAMES).length === 4)
+
+  // ---- forge: branch lifecycle --------------------------------------------
+  const noSync = { ahead: 0, behind: 0, hasUpstream: false, dirty: false }
+  const mkPr = (over: Partial<PullRequestView>): PullRequestView => ({
+    number: 42,
+    title: 't',
+    state: 'open',
+    url: 'u',
+    sourceBranch: 's',
+    targetBranch: 'main',
+    author: 'a',
+    createdAt: 0,
+    updatedAt: 0,
+    checks: null,
+    review: null,
+    ...over
+  })
+
+  check(
+    'lifecycle: no upstream is local',
+    (() => {
+      const v = branchLifecycle({ sync: noSync, pr: null, forgeKnown: false })
+      return v.phase === 'unpublished' && v.label === 'local' && v.action === 'push'
+    })()
+  )
+  check(
+    'lifecycle: ahead shows the count',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true, ahead: 3 },
+        pr: null,
+        forgeKnown: true
+      })
+      return v.phase === 'ahead' && v.label === '\u21913' && v.action === 'push'
+    })()
+  )
+  check(
+    'lifecycle: behind suggests a pull',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true, behind: 2 },
+        pr: null,
+        forgeKnown: true
+      })
+      return v.phase === 'behind' && v.action === 'pull' && v.tone === 'warning'
+    })()
+  )
+  check(
+    'lifecycle: synced + forge known offers a PR',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true },
+        pr: null,
+        forgeKnown: true
+      })
+      return v.phase === 'synced' && v.action === 'open-pr'
+    })()
+  )
+  check(
+    'lifecycle: synced + forge UNKNOWN offers nothing',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true },
+        pr: null,
+        forgeKnown: false
+      })
+      return v.phase === 'synced' && v.action === null
+    })()
+  )
+  check(
+    'lifecycle: open PR shows its number',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true },
+        pr: mkPr({}),
+        forgeKnown: true
+      })
+      return v.phase === 'open' && v.label === '#42' && v.action === 'view-pr'
+    })()
+  )
+  check(
+    'lifecycle: failing checks turn the chip danger',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true },
+        pr: mkPr({ checks: 'failing' }),
+        forgeKnown: true
+      })
+      return v.tone === 'danger'
+    })()
+  )
+  check(
+    'lifecycle: changes requested is a warning',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true },
+        pr: mkPr({ review: 'changes_requested' }),
+        forgeKnown: true
+      })
+      return v.tone === 'warning'
+    })()
+  )
+  check(
+    'lifecycle: draft reads as draft',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true },
+        pr: mkPr({ state: 'draft' }),
+        forgeKnown: true
+      })
+      return v.phase === 'draft' && v.label === '#42 draft'
+    })()
+  )
+  // The important one: a merged PR is the truth even when the local branch
+  // still looks unpushed. Showing "local" on merged work is the bug this guards.
+  check(
+    'lifecycle: merged PR outranks stale local state',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, ahead: 9 },
+        pr: mkPr({ state: 'merged' }),
+        forgeKnown: true
+      })
+      return v.phase === 'merged' && v.label === 'merged' && v.tone === 'success'
+    })()
+  )
+  check(
+    'lifecycle: closed PR outranks ahead count',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true, ahead: 4 },
+        pr: mkPr({ state: 'closed' }),
+        forgeKnown: true
+      })
+      return v.phase === 'closed'
+    })()
+  )
+
+  // ---- forge: unknown hosts + user override -------------------------------
+  // The separation that matters: a LOCAL path is "no host, show nothing", while
+  // an unrecognised DOMAIN is "a real server, ask the user once". Collapsing
+  // them would break self-hosted GitLab/Bitbucket behind a corporate domain -
+  // the most common case in exactly the enterprises this is for.
+
+  check('detect: local path has no host at all', detectHost('/home/me/repo.git') === null)
+  check(
+    'detect: bare host with no repo path is unusable',
+    detectHost('https://git.mycorp.com') === null
+  )
+  check(
+    'detect: known host resolves without asking',
+    (() => {
+      const p = detectHost('https://github.com/a/b.git')
+      return p?.host === 'github.com' && p.kind === 'github'
+    })()
+  )
+  check(
+    'detect: unknown domain is a real host awaiting an answer',
+    (() => {
+      const p = detectHost('https://git.mycorp.com/team/app.git')
+      return p?.host === 'git.mycorp.com' && p.kind === null
+    })()
+  )
+  check(
+    'detect: scp-like unknown host still probes',
+    (() => {
+      const p = detectHost('git@git.mycorp.com:team/app.git')
+      return p?.host === 'git.mycorp.com' && p.kind === null
+    })()
+  )
+
+  check(
+    'override: applies to an unrecognised host',
+    (() => {
+      const r = parseRemote('https://git.mycorp.com/team/app.git', 'gitlab')
+      return (
+        r?.kind === 'gitlab' &&
+        r.owner === 'team' &&
+        r.repo === 'app' &&
+        r.apiBase === 'https://git.mycorp.com/api/v4'
+      )
+    })()
+  )
+  check(
+    'override: unknown host without one stays unresolved',
+    (() => {
+      return parseRemote('https://git.mycorp.com/team/app.git') === null
+    })()
+  )
+  // The safety property: a saved override must never hijack a host we can
+  // identify, or one bad guess would silently mis-route github.com forever.
+  check(
+    'override: never overrides a KNOWN host',
+    (() => {
+      const r = parseRemote('https://github.com/a/b.git', 'gitlab')
+      return r?.kind === 'github'
+    })()
+  )
+  check(
+    'override: null behaves as absent',
+    (() => {
+      return parseRemote('https://git.mycorp.com/team/app.git', null) === null
+    })()
+  )
+  check(
+    'override: cannot rescue a non-host',
+    (() => {
+      return parseRemote('/home/me/repo.git', 'github') === null
+    })()
+  )
+  check(
+    'override: azure-devops shape still parses under override',
+    (() => {
+      const r = parseRemote(
+        'https://tfs.mycorp.com/DefaultCollection/Proj/_git/app',
+        'azure-devops'
+      )
+      return r?.kind === 'azure-devops' && r.project === 'Proj' && r.repo === 'app'
+    })()
+  )
+  const NOW = 1_700_000_000_000
+  check('relativeAge: seconds', relativeAge(NOW - 5_000, NOW) === 'just now')
+  check('relativeAge: minutes', relativeAge(NOW - 5 * 60_000, NOW) === '5m ago')
+  check('relativeAge: hours', relativeAge(NOW - 3 * 3_600_000, NOW) === '3h ago')
+  check('relativeAge: days', relativeAge(NOW - 4 * 86_400_000, NOW) === '4d ago')
+  check('relativeAge: future clamps to now', relativeAge(NOW + 10_000, NOW) === 'just now')
   if (fails.length) {
     console.error(`\nSHARED FAILED \u2014 ${fails.length} failing: ${fails.join(', ')}`)
     process.exit(1)


### PR DESCRIPTION
## Summary

Turns the static `local` chip in the workstream strip into the real branch lifecycle, end to end:

```
local  ->  ↑N  ->  pushed  ->  #42  ->  merged
```

Works against **GitHub, Azure DevOps, GitLab and Bitbucket**.

## Auth: ask git, don't build OAuth

Every developer who can `git push` already has a working credential managed by a helper (Git Credential Manager et al), and `git credential fill` is git's own public interface to it. GCM handles Entra/Microsoft Account sign-in, MFA, conditional access, and — the part that matters — **silent refresh of the short-lived Azure DevOps token**. An expiring ADO token becomes a non-event rather than a weekly re-paste.

**If `git push` works, this works.** No setup, no login screen.

Alternatives considered and rejected:

| Option | Why not |
|---|---|
| Register OAuth apps with 4 vendors | Ships extractable client secrets in an open-source Electron binary; needs tenant admin consent most corp users can't self-approve |
| Ask for a PAT | Exactly the expiry pain being solved, ×4 |
| Shell out to `gh`/`az`/`glab` | None installed on a default machine |

## Code hosts are separate from AI providers

GitHub appears in **both** Settings lists — as the vendor of Copilot, and as a place code lives. They're unrelated accounts with unrelated tokens and unrelated scopes.

```
Providers   -> who runs the MODEL.    GitHub Copilot lives here.
Code hosts  -> where the CODE lives.  github.com lives here.
```

Signing into Copilot must never imply repository access, so `forge/` shares no code, no storage and no credential path with the provider stack. Verified by grep, not assumption.

## Custom / self-hosted domains

An unrecognised domain (`git.mycorp.com`) is treated as **a real host awaiting one answer**, not as "unsupported" — self-hosted GitLab/Bitbucket behind a corporate domain is the common case in the enterprises this targets.

| Remote | Meaning | Behaviour |
|---|---|---|
| `/home/me/repo` | No host at all | Show nothing |
| `git.mycorp.com` | Real host, unclassified | Ask once, remember |
| `github.com` | Recognised | Silent |

Answerable inline on the chip or in Settings. Overrides are only consulted when auto-detection **fails**, so a bad guess can never mis-route a well-known host (there's a test for this).

## Design notes

- **Git is synchronous, the forge is not.** Status returns local git state immediately and refreshes PR data in the background (60s TTL) so the 5s strip poll never waits on, or hammers, the network.
- **A merged PR outranks stale local state.** Showing `↑9` on merged work is the kind of lie that makes people stop trusting an indicator.
- **A 401 forgets the credential**, so expiry is self-healing rather than a dead token replayed for the rest of the session.
- **Push is never forced, pull is never automated.** Both are reachable from a one-click chip; neither should be able to destroy work.

Tokens stay in memory with a short TTL — never persisted, logged, sent over IPC, or exposed to tools. The OS keychain remains the system of record.

## Also: the dirty-branch dot

The amber dot beside the branch name meant "uncommitted changes" and *did* have a `title` — but it was a 6px target nested inside a parent with its own tooltip, so the label was unreachable. Fixed by making it self-explanatory (`● 3`) rather than by building a better tooltip. The best hover text is the one nobody needs.

## Testing

- **490 shared checks** (54 new: URL parsing across ~14 vendor URL shapes, lifecycle state machine, host detection + override safety)
- **424 app checks**
- Typecheck + build clean
- **Verified live** against this repo: real GCM credential → real GitHub API → correct `merged` detection on #3/#4

## Known gaps (deliberate)

- **CI/pipeline status** is wired through the types but always `null` — it costs an extra request per PR and belongs in the lazily-loaded panel, not the poll.
- **Bitbucket Server** returns `unsupported` rather than firing Cloud-shaped (API 2.0) requests at a Server (API 1.0) instance and producing wrong answers.
- **Only GitHub was verified live.** The ADO/GitLab/Bitbucket adapters are built from API docs with well-tested parsing, but the round trip is unverified. ADO is worth trying first; if it misbehaves, the likely culprit is Basic-with-empty-username in `credentials.ts`.
- **No agent tools yet.** The plumbing is ready, but `forge_*` tools would let the agent create and merge PRs, which needs a consent story first. Its own change, not smuggled into this one.

🤖 Generated with Roxy