### PR TITLE
feat(subagents): stream a delegate's work live in its own session

### DIFF
--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -58,6 +58,7 @@ import { SKILL_TOOL_NAME, SKILL_TOOL_DESCRIPTION } from '../../shared/skills'
 import { listSkills, skillInstructions } from '../services/skills'
 import { findGitRoot } from '../services/workspace'
 import { registerBackgroundJob, finishBackgroundJob } from '../services/background-tasks'
+import { startSubagentRun } from '../services/subagent-stream'
 import {
   messagesHaveImages,
   openAiContent,
@@ -1412,9 +1413,9 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
     runSignal: AbortSignal,
     forwardToParent: boolean
   ): Promise<{ report: string; state: 'completed' | 'error' }> => {
-    // One fold builds the subagent's transcript; the same events are forwarded to
-    // the parent, so what persists on the sub session and what you watch live in
-    // the `task` card are the same thing by construction.
+    // One fold builds the subagent's transcript; the same events fan out to the
+    // parent's `task` card and to the sub session's own live stream, so all three
+    // views are the same thing by construction and cannot drift.
     const fold = new PartsFold()
     const persistSub = (): void => {
       if (!subChatId) return
@@ -1429,14 +1430,31 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
         // best-effort — never break the parent turn over sub-session persistence
       }
     }
+    // The sub session's own live feed. Registered only when the subagent was
+    // persisted as a session, since there is otherwise nothing for a viewer to
+    // open. `live.finish` is what flips its chat view from the streaming bubble
+    // back to the persisted transcript, so it must fire on EVERY exit path.
+    const live = subChatId
+      ? startSubagentRun({
+          subChatId,
+          parentChatId: parentChatId ?? null,
+          description,
+          subagentType,
+          background: background === true
+        })
+      : null
     /**
      * Every step the subagent takes — its prose, its thinking, and its tool calls
-     * — folded into its own transcript AND forwarded to the parent turn wrapped as
-     * a `tool-child` addressed to this `task` card, so the launching session shows
-     * the delegate working live instead of a spinner and a wall of text at the end.
+     * — folded into its own transcript and fanned out to both audiences:
      *
-     * A background run skips forwarding: its launching turn is typically over, and
-     * it reports through its own session plus the completion card instead.
+     *  - the parent turn, wrapped as a `tool-child` addressed to this `task`
+     *    card, so the launching session shows the delegate working live;
+     *  - the sub session's own stream, tagged with ITS chat id, so opening the
+     *    subagent's individual chat streams the same work in full fidelity.
+     *
+     * A background run skips the parent forward (its launching turn is typically
+     * over) but still streams to its own session — which is the only place a
+     * detached subagent was ever watchable.
      */
     const emitNested = (event: LlmEvent): void => {
       // Depth is capped at 1, so a subagent never emits `tool-child` itself; the
@@ -1445,6 +1463,7 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
       if (event.type === 'tool-child') return
       fold.apply(event)
       if (forwardToParent) emit({ type: 'tool-child', callId, event })
+      live?.emit(event)
     }
 
     try {
@@ -1480,10 +1499,15 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
         depth: depth + 1
       })
       persistSub()
+      // Persist BEFORE ending the run: the renderer reloads the sub session's
+      // transcript on the end frame, and reloading before the row exists would
+      // blank the view for a beat between the live bubble and the saved message.
+      live?.finish('completed')
       return { report: text.trim() || '(subagent returned no report)', state: 'completed' }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       persistSub()
+      live?.finish('error')
       return { report: `Subagent failed: ${msg}`, state: 'error' }
     }
   }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -44,6 +44,12 @@ import {
   cancelSessionBackgroundJobs,
   listRunningBackgroundJobs
 } from '../services/background-tasks'
+import {
+  endSubagentRuns,
+  listRunningSubagents,
+  setViewedSubChat,
+  subagentSnapshot
+} from '../services/subagent-stream'
 import { mcpServerSummaries, reconnectMcpServer, disposeConnection } from '../services/mcp'
 import {
   listSkills,
@@ -135,6 +141,11 @@ export function registerIpc(): void {
     // Cancel any background subagents this session launched before it's deleted,
     // so detached work doesn't keep running against a gone parent.
     cancelSessionBackgroundJobs(id)
+    // Drop any live subagent stream for this session (and, when a parent goes,
+    // for its delegates too). The run itself is cancelled above or dies with the
+    // parent turn; this just stops a gone session pinning a registry entry that
+    // would keep broadcasting to a chat view nobody can open.
+    endSubagentRuns(id)
     // Stop this session's background processes (dev servers, watchers). Every
     // process is registered under a ROOT session id, so passing `id` raw does the
     // right thing both ways: deleting a main session also stops the servers its
@@ -456,6 +467,18 @@ export function registerIpc(): void {
     listRunningBackgroundJobs(sessionId)
   )
   ipcMain.handle(CHANNELS.tasksCancel, (_e, jobId: string) => cancelBackgroundJob(jobId))
+
+  // ---- subagent live sessions ----
+  // A subagent's own session streams like any other chat: `subagent:delta` is
+  // pushed to every window (the run outlives the launching request, so it can't
+  // ride the requestId-keyed llm:delta channel), and these two reads let a window
+  // that opens mid-run, or reloads entirely, catch up instead of showing a stale
+  // prompt with no reply.
+  ipcMain.handle(CHANNELS.subagentSnapshot, (_e, subChatId: string) => subagentSnapshot(subChatId))
+  ipcMain.handle(CHANNELS.subagentListRunning, () => listRunningSubagents())
+  ipcMain.handle(CHANNELS.subagentSetViewed, (_e, chatId: string | null) =>
+    setViewedSubChat(chatId)
+  )
 
   // ---- models (models.dev catalog) ----
   ipcMain.handle(CHANNELS.modelsList, (_e, providerId: string) => listModels(providerId))

--- a/src/main/services/session-turn.ts
+++ b/src/main/services/session-turn.ts
@@ -13,6 +13,7 @@ import type { LlmEvent, LlmResult, LlmStartInput } from '../../shared/api'
 import * as repo from '../db/repo'
 import { runAgentTurn } from '../harness'
 import { activeBackgroundSubChatIds } from './background-tasks'
+import { protectedSubChatIds } from './subagent-stream'
 import { setLabel as setBrowserLabel } from './browser'
 import { sessionCwd } from './workspace'
 import { materializePendingWorktree } from './worktree'
@@ -36,6 +37,16 @@ function safeSessionCwd(sessionId: string): string {
       return ''
     }
   }
+}
+
+/**
+ * Sub sessions that must survive the end-of-turn prune: any with a detached
+ * background job still running, any still streaming, and the one on screen.
+ */
+function keepSubchats(): Set<string> {
+  const keep = protectedSubChatIds()
+  for (const id of activeBackgroundSubChatIds()) keep.add(id)
+  return keep
 }
 
 /**
@@ -82,9 +93,11 @@ export async function runSessionTurn(
       emit
     })
     // The turn's subagents are one-shot — drop any with nothing queued so they
-    // don't linger in the sidebar after the work is done. Sub-sessions with a
-    // still-running background task are kept (Phase 11) until it reports back.
-    repo.pruneSubchats(input.sessionId, activeBackgroundSubChatIds())
+    // don't linger in the sidebar after the work is done. Spared: sub sessions
+    // with a still-running background task (Phase 11), one still streaming, and
+    // whichever one the user currently has open (pruning a transcript out from
+    // under someone reading it is the one thing this sweep must never do).
+    repo.pruneSubchats(input.sessionId, keepSubchats())
     return { ok: true }
   } catch (e) {
     if (signal.aborted) return { ok: false, error: 'Stopped.' }

--- a/src/main/services/subagent-stream.ts
+++ b/src/main/services/subagent-stream.ts
@@ -1,0 +1,185 @@
+/**
+ * Live transcripts for running subagent (`sub`) sessions.
+ *
+ * A subagent's steps used to exist in exactly two places: forwarded into the
+ * PARENT turn's stream as `tool-child` events (which is why the launching
+ * session shows the delegate working live), and persisted to the sub session's
+ * own row — once, at the very end. Opening the sub session mid-run therefore
+ * showed nothing but the seeded prompt: no streamed event ever carried the sub
+ * session's id, so the renderer had nothing to key a live bubble on.
+ *
+ * This registry is the missing half. Each run registers here, folds its own
+ * events into its own `PartsFold`, and broadcasts them tagged with the SUB
+ * session id. Two consumers, one source:
+ *
+ *   - `subagent:delta` — the live feed, for a window already on that session.
+ *   - `subagent:snapshot` — the catch-up read, for a window that opens the
+ *     session halfway through a run. Without it a late viewer would see only
+ *     the tail of the transcript.
+ *
+ * The parent's `tool-child` forwarding is untouched and still authoritative for
+ * the `task` card; this is a second tap on the same event stream, not a
+ * replacement. Keeping them separate is deliberate: the parent card is a capped
+ * *summary* (see CHILD_OUTPUT_CAP), while the sub session is the full-fidelity
+ * view, and neither should be able to distort the other.
+ *
+ * Broadcast, not point-to-point, for the same reason background tasks are: a run
+ * routinely outlives the request that launched it, so there is no requestId to
+ * route by — and after a window reload, no request at all.
+ */
+import { BrowserWindow } from 'electron'
+import { CHANNELS } from '../../shared/ipc'
+import type { LlmChildEvent, SubagentDelta, SubagentRunView } from '../../shared/api'
+import type { MessagePart } from '../../shared/types'
+import { PartsFold } from '../../shared/parts'
+
+interface Run {
+  subChatId: string
+  parentChatId: string | null
+  description: string
+  subagentType: string
+  background: boolean
+  startedAt: number
+  fold: PartsFold
+}
+
+/** Sub chat id —> its in-flight run. Only ever holds RUNNING subagents. */
+const runs = new Map<string, Run>()
+
+/**
+ * The sub session the user currently has open, if any.
+ *
+ * Sub sessions are pruned at the end of the parent turn so one-shot delegates
+ * don't pile up in the sidebar. That sweep predates their transcripts being
+ * watchable: now that you can open one and follow it live, pruning the very
+ * session someone is reading deletes content out from under them. The renderer
+ * reports what's on screen; the sweep spares it.
+ *
+ * Not a Set: exactly one session is on screen at a time, so a single value makes
+ * a stale "still viewing" entry impossible.
+ */
+let viewedSubChatId: string | null = null
+
+/** Push a payload to every open window (out-of-band — no requestId to route by). */
+function broadcast(payload: SubagentDelta): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    // A window can be torn down between the guard and the send. A broadcast must
+    // never break a subagent run, so per-window failures are swallowed.
+    try {
+      if (!win.isDestroyed()) win.webContents.send(CHANNELS.subagentDelta, payload)
+    } catch {
+      // window went away mid-send — ignore
+    }
+  }
+}
+
+export interface StartRunInput {
+  subChatId: string
+  parentChatId: string | null
+  description: string
+  subagentType: string
+  background: boolean
+}
+
+/**
+ * Announce a subagent run and open its live transcript. Returns an `emit` the
+ * caller feeds every child event, plus `finish` to close the run.
+ *
+ * A handle rather than free functions keyed by id: the harness then cannot emit
+ * into a run it didn't start, and a finished run can't be resurrected by a late
+ * event that raced its own `finish`.
+ */
+export function startSubagentRun(input: StartRunInput): {
+  emit: (event: LlmChildEvent) => void
+  finish: (state: 'completed' | 'error') => void
+} {
+  const run: Run = {
+    subChatId: input.subChatId,
+    parentChatId: input.parentChatId,
+    description: input.description,
+    subagentType: input.subagentType,
+    background: input.background,
+    startedAt: Date.now(),
+    fold: new PartsFold()
+  }
+  runs.set(input.subChatId, run)
+  broadcast({ subChatId: run.subChatId, kind: 'run', state: 'running' })
+
+  // Closed over rather than read off the map: `endSubagentRuns` can drop this
+  // run (its session was deleted) while the loop is still emitting, and a stray
+  // event must not silently re-register a dead run by writing back to the map.
+  let closed = false
+  return {
+    emit: (event) => {
+      if (closed) return
+      run.fold.apply(event)
+      broadcast({ subChatId: run.subChatId, kind: 'event', event })
+    },
+    finish: (state) => {
+      if (closed) return
+      closed = true
+      // Drop the run BEFORE announcing the end: the renderer reloads the sub
+      // session's persisted transcript on this frame, and a snapshot fetched
+      // during that reload must not hand back the now-superseded live parts.
+      runs.delete(run.subChatId)
+      broadcast({ subChatId: run.subChatId, kind: 'run', state })
+    }
+  }
+}
+
+/**
+ * The live parts of a running subagent, for a window that opened its session
+ * mid-run. Null when nothing is running for that id — either it never was, or it
+ * already finished and its persisted message is the truth.
+ */
+export function subagentSnapshot(subChatId: string): MessagePart[] | null {
+  return runs.get(subChatId)?.fold.parts ?? null
+}
+
+/** Every subagent currently running, so a fresh window can restore its spinners. */
+export function listRunningSubagents(): SubagentRunView[] {
+  return [...runs.values()].map((r) => ({
+    subChatId: r.subChatId,
+    parentChatId: r.parentChatId,
+    description: r.description,
+    subagentType: r.subagentType,
+    background: r.background,
+    startedAt: r.startedAt
+  }))
+}
+
+/**
+ * Close out every live run belonging to a deleted session — the session itself
+ * when it's a sub, plus every delegate it spawned when it's a parent.
+ *
+ * The run's *work* is stopped elsewhere (a background job by its controller, a
+ * foreground one by the parent turn dying with it). This only clears the
+ * registry, so a gone session can't pin an entry that keeps broadcasting to a
+ * chat view nobody can open, or hold a sibling against pruning forever.
+ */
+export function endSubagentRuns(chatId: string): void {
+  for (const run of [...runs.values()]) {
+    if (run.subChatId !== chatId && run.parentChatId !== chatId) continue
+    runs.delete(run.subChatId)
+    broadcast({ subChatId: run.subChatId, kind: 'run', state: 'error' })
+  }
+  if (viewedSubChatId === chatId) viewedSubChatId = null
+}
+
+/** Renderer -> main: which chat is on screen (null when it isn't a sub session). */
+export function setViewedSubChat(chatId: string | null): void {
+  viewedSubChatId = chatId
+}
+
+/** Sub session ids that must survive a prune: anything running, plus what's on screen. */
+export function protectedSubChatIds(): Set<string> {
+  const ids = new Set(runs.keys())
+  if (viewedSubChatId) ids.add(viewedSubChatId)
+  return ids
+}
+
+/** Test-only: clear the registry between smoke cases. */
+export function _resetSubagentRuns(): void {
+  runs.clear()
+  viewedSubChatId = null
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ import type {
   BrowserTab,
   RemoteState,
   RemoteDelta,
+  SubagentDelta,
   UpdateState
 } from '../shared/api'
 
@@ -138,6 +139,17 @@ const roxy: RoxyApi = {
         callback(update)
       ipcRenderer.on(CHANNELS.taskUpdate, handler)
       return () => ipcRenderer.removeListener(CHANNELS.taskUpdate, handler)
+    }
+  },
+  subagents: {
+    snapshot: (subChatId) => ipcRenderer.invoke(CHANNELS.subagentSnapshot, subChatId),
+    listRunning: () => ipcRenderer.invoke(CHANNELS.subagentListRunning),
+    setViewed: (chatId) => ipcRenderer.invoke(CHANNELS.subagentSetViewed, chatId),
+    onDelta: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: SubagentDelta): void =>
+        callback(payload)
+      ipcRenderer.on(CHANNELS.subagentDelta, handler)
+      return () => ipcRenderer.removeListener(CHANNELS.subagentDelta, handler)
     }
   },
   models: {

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
-import { ChevronRight, FolderOpen, ListTree, Loader2, Repeat, Settings } from 'lucide-react'
+import {
+  ChevronRight,
+  CornerUpLeft,
+  FolderOpen,
+  Hammer,
+  ListTree,
+  Loader2,
+  Repeat,
+  Settings
+} from 'lucide-react'
 import { useRoxyStore } from '../lib/store'
 import { formatInterval } from '@shared/format'
 import { cn } from '../lib/cn'
@@ -37,11 +46,18 @@ export function ChatView(): JSX.Element {
   const stop = useRoxyStore((s) => s.stop)
   const queue = useRoxyStore((s) => s.queue)
   const newSession = useRoxyStore((s) => s.newSession)
+  const selectChat = useRoxyStore((s) => s.selectChat)
   const activeChatId = useRoxyStore((s) => s.activeChatId)
   const chats = useRoxyStore((s) => s.chats)
   const loops = useRoxyStore((s) => s.loops)
   const backgroundTaskCount = useRoxyStore((s) =>
     s.activeChatId ? (s.runningTasks[s.activeChatId]?.length ?? 0) : 0
+  )
+  // A subagent working in ITS OWN session. Tracked separately from `sending`
+  // (which is per-chat local-send state): nobody "sent" this turn from the UI —
+  // the parent agent delegated it — so the only signal is the live run itself.
+  const subagentRunning = useRoxyStore((s) =>
+    s.activeChatId ? !!s.runningSubagents[s.activeChatId] : false
   )
 
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -88,11 +104,17 @@ export function ChatView(): JSX.Element {
   }, [messages, streaming])
 
   const activeChat = chats.find((c) => c.id === activeChatId)
+  const isSub = activeChat?.kind === 'sub'
+  const parentChat = activeChat?.parentId
+    ? chats.find((c) => c.id === activeChat.parentId)
+    : undefined
   const activeLoop = loops.find((l) => l.chatId === activeChatId)
   const sessionTasks = activeChat?.tasks ?? []
   const tasksDone = sessionTasks.filter((t) => t.status === 'completed').length
-  const hasSessionInfo =
-    activeChat?.kind === 'main' && (!!activeChat.description?.trim() || sessionTasks.length > 0)
+  // Any session can carry a description + checklist: the `general` subagent has
+  // the metadata tool too, and its plan is exactly what you open its session to
+  // read. Gate on having something to show, not on the session's kind.
+  const hasSessionInfo = !!activeChat?.description?.trim() || sessionTasks.length > 0
 
   // No workspace open — prompt to open a folder to start a session.
   if (!activeChat) {
@@ -133,11 +155,40 @@ export function ChatView(): JSX.Element {
           </div>
         ) : (
           <div className="flex min-w-0 items-center gap-2">
-            <FolderOpen className="h-4 w-4 shrink-0 text-text-muted" />
+            {isSub ? (
+              <Hammer className="h-4 w-4 shrink-0 text-text-muted" />
+            ) : (
+              <FolderOpen className="h-4 w-4 shrink-0 text-text-muted" />
+            )}
             <span className="shrink-0 text-sm font-medium">{activeChat.title}</span>
-            {activeChat.workspacePath && (
-              <span className="truncate text-xs text-text-subtle" title={activeChat.workspacePath}>
-                {activeChat.workspacePath}
+            {/* A delegate's session is only legible in context — who sent it, and
+                a way back. The folder path is the parent's business. */}
+            {isSub
+              ? parentChat && (
+                  <button
+                    onClick={() => void selectChat(parentChat.id)}
+                    title={`Back to ${parentChat.title}`}
+                    className="flex min-w-0 items-center gap-1 truncate text-xs text-text-subtle transition-colors hover:text-text"
+                  >
+                    <CornerUpLeft className="h-3 w-3 shrink-0" />
+                    <span className="truncate">{parentChat.title}</span>
+                  </button>
+                )
+              : activeChat.workspacePath && (
+                  <span
+                    className="truncate text-xs text-text-subtle"
+                    title={activeChat.workspacePath}
+                  >
+                    {activeChat.workspacePath}
+                  </span>
+                )}
+            {subagentRunning && (
+              <span
+                title="This subagent is working"
+                className="flex shrink-0 items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[11px] text-accent"
+              >
+                <Loader2 className="h-3 w-3 animate-spin" />
+                working
               </span>
             )}
             {hasSessionInfo && (
@@ -195,7 +246,7 @@ export function ChatView(): JSX.Element {
         </div>
       </header>
 
-      {activeChat.kind === 'main' && infoOpen && <SessionInfo chat={activeChat} />}
+      {infoOpen && <SessionInfo chat={activeChat} />}
 
       <div ref={scrollRef} onScroll={onScroll} className="min-h-0 flex-1 overflow-y-auto">
         {isEmpty ? (
@@ -257,7 +308,11 @@ export function ChatView(): JSX.Element {
 
       <ServicesPanel />
 
-      <Composer onSend={submit} sending={sending} onStop={stop} />
+      <Composer
+        onSend={submit}
+        sending={sending || subagentRunning}
+        onStop={subagentRunning ? undefined : stop}
+      />
 
       <WorkstreamStrip />
 

--- a/src/renderer/src/components/Composer.tsx
+++ b/src/renderer/src/components/Composer.tsx
@@ -68,7 +68,10 @@ export function Composer({
     el.style.height = `${Math.min(el.scrollHeight, 168)}px`
   }
 
-  const showStop = !!sending && !value.trim() && images.length === 0
+  // Stop needs a handler to be honest: a session can be busy with a turn this
+  // composer doesn't own (a subagent's run is driven by its parent), and a Stop
+  // button that does nothing is worse than none. Fall through to a disabled Send.
+  const showStop = !!sending && !!onStop && !value.trim() && images.length === 0
   const canSend = !!value.trim() || images.length > 0
 
   return (

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -54,6 +54,7 @@ export function Sidebar(): JSX.Element {
   const activeChatId = useRoxyStore((s) => s.activeChatId)
   const selectChat = useRoxyStore((s) => s.selectChat)
   const gitStatus = useRoxyStore((s) => s.gitStatus)
+  const runningSubagents = useRoxyStore((s) => s.runningSubagents)
   const newSession = useRoxyStore((s) => s.newSession)
   const newSessionInProject = useRoxyStore((s) => s.newSessionInProject)
   const deleteChat = useRoxyStore((s) => s.deleteChat)
@@ -574,6 +575,10 @@ export function Sidebar(): JSX.Element {
                             const sending = !!sendingChats[chat.id]
                             const subs = subsByParent.get(chat.id) ?? []
                             const subsOpen = expandedSubs.has(chat.id)
+                            // How many of this session's delegates are working
+                            // right now — so a COLLAPSED parent still shows that
+                            // something is happening underneath it.
+                            const liveSubs = subs.filter((x) => runningSubagents[x.id]).length
                             return (
                               <li
                                 key={chat.id}
@@ -671,8 +676,15 @@ export function Sidebar(): JSX.Element {
                                   {subs.length > 0 && (
                                     <button
                                       onClick={() => toggleSubs(chat.id)}
-                                      title={`${subs.length} subagent${subs.length === 1 ? '' : 's'} — tap to ${subsOpen ? 'hide' : 'view'}`}
-                                      className="flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded-full bg-surface-2 px-1 text-[10px] font-medium tabular-nums text-text-subtle transition-colors hover:text-text"
+                                      title={`${subs.length} subagent${subs.length === 1 ? '' : 's'}${
+                                        liveSubs > 0 ? ` (${liveSubs} working)` : ''
+                                      } — tap to ${subsOpen ? 'hide' : 'view'}`}
+                                      className={cn(
+                                        'flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums transition-colors',
+                                        liveSubs > 0
+                                          ? 'bg-accent/10 text-accent'
+                                          : 'bg-surface-2 text-text-subtle hover:text-text'
+                                      )}
                                     >
                                       {subs.length}
                                     </button>
@@ -697,7 +709,11 @@ export function Sidebar(): JSX.Element {
                                               : 'text-text-muted hover:bg-white/5 hover:text-text'
                                           )}
                                         >
-                                          <Hammer className="h-3 w-3 shrink-0 opacity-70" />
+                                          {runningSubagents[sub.id] ? (
+                                            <BrailleSpinner className="shrink-0 text-xs text-accent" />
+                                          ) : (
+                                            <Hammer className="h-3 w-3 shrink-0 opacity-70" />
+                                          )}
                                           {editingId === sub.id ? (
                                             <input
                                               autoFocus

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -18,6 +18,7 @@ import type {
   ModelInfo,
   RemoteDelta,
   RemoteState,
+  SubagentDelta,
   TaskUpdate
 } from '@shared/api'
 import { selectPromptName, buildEnvironment, assembleSystemPrompt } from '@shared/prompt'
@@ -59,6 +60,13 @@ interface RoxyStore {
   compactingChats: Record<string, boolean>
   /** Running background subagent tasks, keyed by parent session id (Phase 11). */
   runningTasks: Record<string, TaskUpdate[]>
+  /**
+   * Subagent sessions with a run in flight, by SUB chat id. Drives the live
+   * bubble in a subagent's own chat view and its sidebar spinner — both of which
+   * used to be impossible, since a subagent's work only ever streamed into its
+   * parent's `task` card.
+   */
+  runningSubagents: Record<string, true>
   /** Remote Workspace sharing status — mirrors the main process's RemoteState. */
   remote: RemoteState
   /** Background processes for the active session (the Services panel). */
@@ -150,6 +158,7 @@ let llmDeltaSubscribed = false
 let taskUpdateSubscribed = false
 let remoteStateSubscribed = false
 let remoteDeltaSubscribed = false
+let subagentDeltaSubscribed = false
 /** Routes streamed completion events to the in-flight send for a request id. */
 const deltaHandlers = new Map<string, (event: LlmEvent) => void>()
 /** The active llm request id per chat, so stop() can abort the right stream. */
@@ -164,6 +173,15 @@ const remoteMirror = { deferred: false }
  * A turn:idle frame clears the entry once the persisted reply takes over.
  */
 const remoteTurns = new Map<string, PartsFold>()
+/**
+ * Live parts for each in-flight SUBAGENT run, keyed by its own chat id — the
+ * third sibling of `parts` (local send) and `remoteTurns` (phone turn).
+ *
+ * Kept for every running subagent, not just the visible one: a delegate you
+ * aren't watching keeps folding, so switching into its session mid-run shows the
+ * whole transcript so far instead of resuming from whatever arrives next.
+ */
+const subagentTurns = new Map<string, PartsFold>()
 
 /**
  * Desktop live-mirror: reload the shared chat's transcript from disk after a
@@ -230,6 +248,111 @@ function applyRemoteDelta(payload: RemoteDelta): void {
   reflect(turn.apply(payload.event))
 }
 
+/**
+ * Fold one SUBAGENT step (or run boundary) into that subagent's own live parts
+ * and, when its session is on screen, reflect it into `streamingChats` — so
+ * opening a delegate's chat shows it working in real time, exactly like a normal
+ * session, instead of a lone prompt until the run ends.
+ *
+ * Deliberately keyed by the sub chat id rather than a requestId: a subagent run
+ * (especially a background one) routinely outlives the request that launched it,
+ * and after a window reload there is no request to key on at all.
+ *
+ * A `run: completed|error` frame drops the live parts; the subagent's persisted
+ * assistant message — written just before that frame is sent — takes over, so
+ * there's no gap between the live bubble and the saved transcript.
+ */
+function applySubagentDelta(payload: SubagentDelta): void {
+  const { subChatId } = payload
+  const reflect = (parts: MessagePart[] | null): void => {
+    if (useRoxyStore.getState().activeChatId !== subChatId) return
+    useRoxyStore.setState((s) => {
+      const next = { ...s.streamingChats }
+      if (parts === null) delete next[subChatId]
+      else next[subChatId] = parts
+      return { streamingChats: next }
+    })
+  }
+
+  if (payload.kind === 'run') {
+    if (payload.state === 'running') {
+      // Open an empty live bubble the moment the run starts, so a viewer who is
+      // already on the session gets the thinking indicator rather than a blank
+      // pane while the delegate resolves its first token.
+      subagentTurns.set(subChatId, new PartsFold())
+      useRoxyStore.setState((s) => ({
+        runningSubagents: { ...s.runningSubagents, [subChatId]: true }
+      }))
+      reflect([])
+      return
+    }
+    subagentTurns.delete(subChatId)
+    useRoxyStore.setState((s) => {
+      const runningSubagents = { ...s.runningSubagents }
+      delete runningSubagents[subChatId]
+      return { runningSubagents }
+    })
+    reflect(null)
+    // The run's transcript landed a moment ago — swap the live bubble for the
+    // persisted message, and refresh the sidebar (a finished sub may now prune).
+    void (async () => {
+      if (useRoxyStore.getState().activeChatId === subChatId) {
+        useRoxyStore.setState({ messages: await api.messages.list(subChatId) })
+      }
+      await useRoxyStore.getState().refreshChats()
+    })()
+    return
+  }
+
+  // A stream event: fold it through the SAME pure fold the main process and every
+  // other live path use, so a subagent's view can never drift from — or silently
+  // drop an event type handled by — the parent's `task` card.
+  let turn = subagentTurns.get(subChatId)
+  if (!turn) {
+    turn = new PartsFold()
+    subagentTurns.set(subChatId, turn)
+  }
+  reflect(turn.apply(payload.event))
+
+  // A subagent's `change_session_metadata` writes to its OWN session (the tool
+  // runs with the sub chat id), so its title, description, and task checklist all
+  // live on that row. Reload the chat list when one lands, or the header strip
+  // and the sidebar entry would sit stale until the run ends — and watching a
+  // delegate tick off its own checklist is most of the point of opening it.
+  const event = payload.event
+  if (event.type === 'tool-end' && event.ok) {
+    const card = turn.parts.find((p) => p.type === 'tool' && p.callId === event.callId)
+    if (card?.type === 'tool' && card.tool === 'change_session_metadata') {
+      void useRoxyStore.getState().refreshChats()
+    }
+  }
+}
+
+/**
+ * Catch up a subagent session opened mid-run: pull the parts main has folded so
+ * far and seed the local fold with them, so the live bubble starts complete and
+ * subsequent deltas append rather than replacing a half-empty transcript.
+ *
+ * Seeding (not assigning) matters — the fold rebuilds its call-id index from the
+ * snapshot, so an inherited running tool card still flips to done when its
+ * `tool-end` arrives instead of spinning forever.
+ */
+async function hydrateSubagent(subChatId: string): Promise<void> {
+  const parts = await api.subagents.snapshot(subChatId).catch(() => null)
+  // The run may have finished (or the user navigated away) during the round trip;
+  // its persisted message is then the truth and must not be overwritten.
+  if (!parts || useRoxyStore.getState().activeChatId !== subChatId) return
+  const fold = subagentTurns.get(subChatId) ?? new PartsFold()
+  // Never rewind: deltas that arrived while the snapshot was in flight are
+  // already folded locally and are strictly newer than what main sent back.
+  if (fold.parts.length === 0) fold.seed(parts)
+  subagentTurns.set(subChatId, fold)
+  useRoxyStore.setState((s) => ({
+    runningSubagents: { ...s.runningSubagents, [subChatId]: true },
+    streamingChats: { ...s.streamingChats, [subChatId]: fold.parts }
+  }))
+}
+
 export const useRoxyStore = create<RoxyStore>((set, get) => ({
   ready: false,
   settings: null,
@@ -248,6 +371,7 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   stopChats: {},
   compactingChats: {},
   runningTasks: {},
+  runningSubagents: {},
   remote: { phase: 'idle', guests: 0, rev: 0 },
   services: [],
   gitAvailable: null,
@@ -315,6 +439,33 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       api.tasks.onUpdate((update) => {
         void get().handleTaskUpdate(update)
       })
+    }
+
+    // A subagent's own live stream. Separate from the requestId-keyed llm:delta
+    // channel on purpose: a subagent run outlives the request that launched it
+    // (a background one by design), and after a window reload there is no
+    // request to route by — but its session id is still on screen in the sidebar.
+    if (!subagentDeltaSubscribed) {
+      subagentDeltaSubscribed = true
+      api.subagents.onDelta((payload) => applySubagentDelta(payload))
+      // A window that just (re)loaded missed every `run: running` frame, so
+      // restore the in-flight set from main — otherwise a delegate that is very
+      // much still working shows no spinner anywhere until it happens to emit.
+      void api.subagents
+        .listRunning()
+        .then((running) => {
+          if (running.length === 0) return
+          set((s) => {
+            const runningSubagents = { ...s.runningSubagents }
+            for (const r of running) runningSubagents[r.subChatId] = true
+            return { runningSubagents }
+          })
+          const active = get().activeChatId
+          if (active && running.some((r) => r.subChatId === active)) void hydrateSubagent(active)
+        })
+        .catch(() => {
+          // best-effort — a failed restore costs a spinner, never correctness
+        })
     }
 
     // Remote Workspace: keep the sharing badge live and mirror remote activity.
@@ -538,8 +689,15 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     // Per-chat send state survives switching — just swap which chat is shown.
     // Clear messages/queue first so the previous chat's content never flashes.
     set({ activeChatId: id, messages: [], queue: [], activeAgentId: DEFAULT_AGENT_ID })
-    const workspace = get().chats.find((c) => c.id === id)?.workspacePath
+    const chat = get().chats.find((c) => c.id === id)
+    const workspace = chat?.workspacePath
     if (workspace) void get().ensureProjectInstructions(workspace)
+    // Tell main which sub session is on screen so the end-of-turn prune spares
+    // it — a one-shot delegate you're reading shouldn't vanish mid-sentence.
+    void api.subagents.setViewed(chat?.kind === 'sub' ? id : null).catch(() => {})
+    // Opening a subagent mid-run: pull what it has already done so the live
+    // bubble starts from the whole transcript, not from the next delta.
+    if (chat?.kind === 'sub') void hydrateSubagent(id)
     const [messages, queue] = await Promise.all([api.messages.list(id), api.queue.list(id)])
     if (get().activeChatId === id) set({ messages, queue })
   },
@@ -640,7 +798,11 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     // "Busy" means a local send is streaming *or* a phone-driven turn is running
     // into this same session (`remoteTurns`) — so a desktop prompt lands in the
     // shared FIFO behind a phone turn instead of starting a second concurrent one.
-    if (get().sendingChats[chatId] || remoteTurns.has(chatId)) {
+    // A subagent still running in its own session counts as busy too: its turn
+    // is driven from the main process, so a prompt sent now would start a SECOND
+    // concurrent turn writing into the same transcript. Queue it instead — it
+    // drains as a normal follow-up once the delegate reports.
+    if (get().sendingChats[chatId] || remoteTurns.has(chatId) || subagentTurns.has(chatId)) {
       await api.queue.add(
         chatId,
         text,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -14,6 +14,7 @@ import type {
   IntegrationConnection,
   Loop,
   Message,
+  MessagePart,
   QueueImage,
   QueueItem,
   ReasoningEffort,
@@ -259,6 +260,33 @@ export type LlmChildEvent = Exclude<LlmEvent, { type: 'tool-child' }>
 export interface LlmDelta {
   requestId: string
   event: LlmEvent
+}
+
+/**
+ * One step of a subagent's turn, tagged with the SUB session's own id.
+ *
+ * The twin of `LlmDelta`'s `tool-child` wrapper, aimed the other way. That one
+ * addresses the parent's `task` card (keyed by the parent's requestId + callId)
+ * so the launching session shows the delegate working. This one addresses the
+ * subagent's OWN session, so opening it mid-run streams live instead of sitting
+ * on the seeded prompt until the run ends. Same events, two audiences.
+ *
+ * `run` frames bracket the stream so the renderer knows exactly when to open the
+ * live bubble and when to drop it in favour of the persisted transcript.
+ */
+export type SubagentDelta =
+  | { subChatId: string; kind: 'event'; event: LlmChildEvent }
+  | { subChatId: string; kind: 'run'; state: 'running' | 'completed' | 'error' }
+
+/** A subagent run in flight, for restoring live state after a window (re)load. */
+export interface SubagentRunView {
+  subChatId: string
+  parentChatId: string | null
+  description: string
+  subagentType: string
+  /** True for a detached (`background: true`) run — it outlives its launching turn. */
+  background: boolean
+  startedAt: number
 }
 
 /** A background subagent task's lifecycle state, broadcast to all windows. */
@@ -567,6 +595,26 @@ export interface RoxyApi {
     cancel(jobId: string): Promise<void>
     /** Subscribe to background-task state changes; returns an unsubscribe fn. */
     onUpdate(callback: (update: TaskUpdate) => void): () => void
+  }
+  subagents: {
+    /**
+     * Live parts of a subagent already mid-run, for a window that opens its
+     * session halfway through. Null when nothing is running for that id (its
+     * persisted transcript is then the truth).
+     */
+    snapshot(subChatId: string): Promise<MessagePart[] | null>
+    /** Every subagent currently running — restores live state after a window reload. */
+    listRunning(): Promise<SubagentRunView[]>
+    /**
+     * Tell main which chat is on screen, so the end-of-turn prune spares a sub
+     * session the user is reading. Pass null when the open chat isn't a sub.
+     */
+    setViewed(chatId: string | null): Promise<void>
+    /**
+     * Subscribe to a subagent's own live stream, keyed by ITS session id, so its
+     * individual chat view streams like any other. Returns an unsubscribe fn.
+     */
+    onDelta(callback: (payload: SubagentDelta) => void): () => void
   }
   models: {
     /** Live model list for a provider id, from models.dev. */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -86,6 +86,15 @@ export const CHANNELS = {
   /** renderer -> main: cancel a running background task */
   tasksCancel: 'tasks:cancel',
 
+  /** main -> renderer: one live step of a subagent, tagged with ITS OWN session id */
+  subagentDelta: 'subagent:delta',
+  /** renderer -> main: catch-up parts for a subagent already mid-run */
+  subagentSnapshot: 'subagent:snapshot',
+  /** renderer -> main: every subagent currently running (window (re)load) */
+  subagentListRunning: 'subagent:listRunning',
+  /** renderer -> main: which chat is on screen, so a viewed sub session isn't pruned */
+  subagentSetViewed: 'subagent:setViewed',
+
   modelsList: 'models:list',
 
   contextCompact: 'context:compact',

--- a/src/shared/parts.ts
+++ b/src/shared/parts.ts
@@ -126,6 +126,34 @@ export class PartsFold {
   /** Parent `task` callId → its subagent's own callId → slot in that card's `children`. */
   private readonly childIndex = new Map<string, Map<string, number>>()
 
+  /**
+   * Adopt an existing parts list as this fold's state, rebuilding the call-id
+   * indexes from the cards themselves so subsequent events land on the right
+   * slots.
+   *
+   * This is what makes a fold *resumable*: a viewer joining a run already in
+   * progress (opening a subagent's session mid-flight) seeds from a snapshot and
+   * keeps folding from there. Assigning `parts` directly would leave the indexes
+   * empty, so every inherited card's `tool-end` would be dropped and the card
+   * would spin forever.
+   */
+  seed(parts: MessagePart[]): MessagePart[] {
+    this.parts = parts
+    this.index.clear()
+    this.childIndex.clear()
+    parts.forEach((part, i) => {
+      if (part.type !== 'tool' || !part.callId) return
+      this.index.set(part.callId, i)
+      if (!part.children?.length) return
+      const sub = new Map<string, number>()
+      part.children.forEach((child, j) => {
+        if (child.type === 'tool' && child.callId) sub.set(child.callId, j)
+      })
+      this.childIndex.set(part.callId, sub)
+    })
+    return this.parts
+  }
+
   apply(event: LlmEvent): MessagePart[] {
     if (event.type !== 'tool-child') {
       this.parts = foldInto(this.parts, this.index, event)

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -1125,6 +1125,73 @@ check('renderBackgroundStarted warns against polling', /DO NOT poll/i.test(start
 }
 
 {
+  // ---- PartsFold.seed: resuming a run already in progress ----
+  // Opening a subagent's session mid-run seeds the renderer's fold from main's
+  // snapshot. Seeding must rebuild the call-id index, or every card inherited
+  // from the snapshot would ignore its own tool-end and spin forever.
+  const live = new PartsFold()
+  live.apply({ type: 'text', delta: 'looking' })
+  live.apply({ type: 'tool-start', callId: 'c1', tool: 'bash', title: 'ls' })
+  live.apply({ type: 'tool-start', callId: 'c2', tool: 'read', title: 'a.ts' })
+  const snapshot = live.parts
+
+  const viewer = new PartsFold()
+  viewer.seed(snapshot)
+  check('fold/seed: adopts the snapshot as-is', viewer.parts.length === 3)
+
+  // The events that arrive AFTER the viewer joined must land on the right cards.
+  viewer.apply({ type: 'tool-end', callId: 'c1', output: 'a.ts b.ts', ok: true })
+  viewer.apply({ type: 'tool-end', callId: 'c2', output: 'contents', ok: false })
+  const c1 = viewer.parts[1]
+  const c2 = viewer.parts[2]
+  check(
+    'fold/seed: a tool started before the viewer joined still resolves',
+    c1.type === 'tool' && c1.state === 'done' && c1.output === 'a.ts b.ts'
+  )
+  check(
+    'fold/seed: and an error result lands on the right card too',
+    c2.type === 'tool' && c2.state === 'error' && c2.output === 'contents'
+  )
+
+  // Prose keeps growing from where the snapshot left off rather than fragmenting.
+  viewer.apply({ type: 'text', delta: ' more' })
+  const tail = viewer.parts[viewer.parts.length - 1]
+  check(
+    'fold/seed: text after a seed appends a fresh part, not a rewrite',
+    tail.type === 'text' && tail.text === ' more'
+  )
+
+  // Seeding is immutable toward the snapshot: main keeps folding into its own
+  // instance, and a viewer must never mutate the array it was handed.
+  check('fold/seed: does not mutate the source parts', snapshot.length === 3)
+}
+
+{
+  // A seeded fold must also resume NESTED transcripts — a subagent's task card
+  // rebuilt from a snapshot has to keep folding its own children correctly.
+  const live = new PartsFold()
+  live.apply({ type: 'tool-start', callId: 't1', tool: 'task', title: 'delegate' })
+  live.apply({
+    type: 'tool-child',
+    callId: 't1',
+    event: { type: 'tool-start', callId: 'n1', tool: 'grep', title: 'find' }
+  })
+  const viewer = new PartsFold()
+  viewer.seed(live.parts)
+  viewer.apply({
+    type: 'tool-child',
+    callId: 't1',
+    event: { type: 'tool-end', callId: 'n1', output: 'found', ok: true }
+  })
+  const card = viewer.parts[0]
+  const nested = card.type === 'tool' ? card.children?.[0] : undefined
+  check(
+    'fold/seed: nested children resume on the right slots',
+    nested?.type === 'tool' && nested.state === 'done' && nested.output === 'found'
+  )
+}
+
+{
   // A subagent's steps are display-only: replaying them as the parent's own
   // tool_calls would feed the model calls it never made.
   const replayed = reconstructAssistant([


### PR DESCRIPTION
The previous change made a `task` card stream inside the launching turn. Opening the delegate's OWN session still showed one thing: the prompt it was handed, and nothing under it until the run ended.

The reason is that a subagent's steps only ever existed in two places -- forwarded into the parent's stream as `tool-child` (keyed by the PARENT's requestId and task callId), and persisted to the sub session's row once, at the very end. No streamed event ever carried the sub session's own id, so its chat view had nothing to key a live bubble on. A background subagent was worse: it skips the parent forward entirely, so it was invisible everywhere until it landed.

Each run now registers in a `subagent-stream` registry that folds its own events and broadcasts them tagged with the SUB chat id. The renderer folds those into `streamingChats[subChatId]`, so a delegate's session renders through the exact same MessageBubble -> MessageParts -> ToolCall path as any other chat -- tool cards, nested transcripts, reasoning blocks, streamed markdown, all of it, without a second renderer.

The parent's `tool-child` forwarding is untouched. This is a second tap on the same event stream, not a replacement, and the split is deliberate: the parent card is a capped summary (CHILD_OUTPUT_CAP), the sub session is the full-fidelity view, and neither can distort the other.

Broadcast rather than point-to-point because a run routinely outlives the request that launched it (a background one by design), and after a window reload there is no request to route by at all. Hence three channels: `subagent:delta` for the live feed, `subagent:snapshot` to catch up a session opened mid-run, and `subagent:listRunning` to restore spinners on a fresh window.

Catching up needed `PartsFold.seed()`, which rebuilds the call-id index from a snapshot. Assigning `parts` directly would leave the indexes empty, so every card inherited from the snapshot would drop its own `tool-end` and spin forever.

Things that had to move with it:

- Pruning. `pruneSubchats` swept finished delegates at end of turn, which would now delete the transcript someone is reading. It spares anything streaming plus whatever the renderer reports is on screen. Deleting a session also closes its runs, so a gone chat can't pin an entry that keeps broadcasting to a view nobody can open.
- Tasks. `hasSessionInfo` was gated on `kind === 'main'`, so the `general` subagent's checklist rendered nowhere despite it having the metadata tool (which already writes to the sub's own row). Gated on having content now, and a `change_session_metadata` result mid-run refreshes the strip and the sidebar instead of leaving them stale until the end.
- Composer. A running sub session reads as busy, so a prompt queues instead of starting a SECOND concurrent turn into the same transcript. `showStop` now also requires a real `onStop`: a session can be busy with a turn this composer doesn't own, and a Stop button that does nothing is worse than no button.
- Header/sidebar. A sub session shows a hammer and a click-back to its parent rather than a folder path (provenance is the only thing that makes a delegate's transcript legible), a "working" pill, a braille spinner on the row -- the same one a busy main session gets -- and an accented count so a COLLAPSED parent still shows work underneath it.

6 new smoke checks on `seed`: adopting a snapshot, resolving a tool that started before the viewer joined, error results landing on the right card, text appending rather than rewriting, not mutating the source, and nested children resuming on the right slots.