### PR TITLE
Make model/mode/effort/context per-session, inherited from last used

### DIFF
--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -347,6 +347,26 @@ export const MIGRATIONS: Migration[] = [
   // folder). Idempotent for the same reason as v15.
   (db) => {
     addColumnIfMissing(db, 'chats', 'worktree_pending', 'TEXT')
+  },
+
+  // ---- v17: per-session inference config ----
+  // Model/mode/effort/context used to be GLOBAL, so switching the model in one
+  // session switched it everywhere - including sessions mid-conversation on a
+  // different model. Each session now pins its own config, stamped from the
+  // global settings at create time (see repo.createChat + seedSessionConfig),
+  // which makes both behaviours users expect fall out at once: sessions stay
+  // independent, and a new one starts from whatever you last chose.
+  //
+  // `provider_id` and `model` already existed from v1 but were DEAD columns -
+  // written as NULL by createChat and never read except by the usage backfill.
+  // They go live here; the three below join them.
+  //
+  // NULL everywhere means "never chosen" and resolves to the global default, so
+  // every session that predates this keeps behaving exactly as it did before.
+  (db) => {
+    addColumnIfMissing(db, 'chats', 'agent_id', 'TEXT')
+    addColumnIfMissing(db, 'chats', 'reasoning_effort', 'TEXT')
+    addColumnIfMissing(db, 'chats', 'context_limit', 'INTEGER')
   }
 ]
 
@@ -379,6 +399,10 @@ export function repairSchema(db: Database): void {
   addColumnIfMissing(db, 'chats', 'branch', 'TEXT')
   addColumnIfMissing(db, 'chats', 'dev_port', 'INTEGER')
   addColumnIfMissing(db, 'chats', 'worktree_pending', 'TEXT')
+  // v17's per-session inference config.
+  addColumnIfMissing(db, 'chats', 'agent_id', 'TEXT')
+  addColumnIfMissing(db, 'chats', 'reasoning_effort', 'TEXT')
+  addColumnIfMissing(db, 'chats', 'context_limit', 'INTEGER')
   // `projects` is derived state — one row per workspace folder its sessions use
   // — so a restored table can be rebuilt from the chats themselves, exactly as
   // v13 did on first upgrade. Only when empty, so a hand-ordered project list is

--- a/src/main/db/repo.ts
+++ b/src/main/db/repo.ts
@@ -25,6 +25,11 @@ import type {
   WorktreeIntent
 } from '../../shared/types'
 import type { CreateChatInput, CreateLoopInput } from '../../shared/api'
+import {
+  parseReasoningEffort,
+  seedSessionConfig,
+  type SessionConfigPatch
+} from '../../shared/session-config'
 import { getDb } from './database'
 import { decryptSecret, encryptSecret } from '../services/secure'
 
@@ -48,6 +53,9 @@ interface ChatRow {
   kind: string
   provider_id: string | null
   model: string | null
+  agent_id: string | null
+  reasoning_effort: string | null
+  context_limit: number | null
   workspace_path: string | null
   worktree_path: string | null
   worktree_pending: string | null
@@ -91,6 +99,7 @@ export function getSettings(): AppSettings {
     onboardingCompleted: map.get('onboarding_completed') === '1',
     activeProviderId: map.get('active_provider_id') ?? null,
     activeModel: map.get('active_model') ?? null,
+    activeAgentId: map.get('active_agent_id') ?? null,
     reasoningEffort: ((): ReasoningEffort => {
       const v = map.get('reasoning_effort')
       return v === 'low' || v === 'medium' || v === 'high' || v === 'xhigh' || v === 'max'
@@ -158,6 +167,15 @@ export function setForgeHostKind(host: string, kind: string | null): void {
 export function setActiveProvider(providerId: string, model: string | null): AppSettings {
   setSetting('active_provider_id', providerId)
   setSetting('active_model', model)
+  return getSettings()
+}
+
+/**
+ * Remember the last-used primary agent (mode), so the NEXT new session opens in
+ * it. The open session keeps its own `agent_id`; this is only the template.
+ */
+export function setActiveAgent(agentId: string): AppSettings {
+  setSetting('active_agent_id', agentId)
   return getSettings()
 }
 
@@ -360,6 +378,9 @@ function rowToChat(row: ChatRow): Chat {
     kind: row.kind as SessionKind,
     providerId: row.provider_id,
     model: row.model,
+    agentId: row.agent_id,
+    reasoningEffort: parseReasoningEffort(row.reasoning_effort),
+    contextLimit: row.context_limit,
     workspacePath: row.workspace_path,
     worktreePath: row.worktree_path,
     worktreePending: parseWorktreeIntent(row.worktree_pending),
@@ -490,17 +511,30 @@ export function createChat(input: CreateChatInput = {}): Chat {
   // Parked, not acted on: the worktree is created on the first turn so an
   // abandoned session never leaves a directory behind.
   const pending = input.worktree ?? null
+  // Stamp the session with the config the user last chose, so a new session
+  // picks up where the previous one left off - and then owns that config
+  // independently, because it is a COPY: changing the model here later must
+  // never reach back into sessions already running on something else. An
+  // explicit input (the remote/test callers) wins over the inherited default.
+  const seed = seedSessionConfig(getSettings())
+  const providerId = input.providerId ?? seed.providerId
+  // Model follows its provider: pairing an explicit provider with the seeded
+  // model would cross e.g. anthropic with a `gpt-4o` id, which 404s the turn.
+  const model = input.model ?? (input.providerId ? null : seed.model)
   getDb()
     .prepare(
-      `INSERT INTO chats(id, title, kind, provider_id, model, workspace_path, worktree_pending, parent_id, sort_order, created_at, updated_at)
-       VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO chats(id, title, kind, provider_id, model, agent_id, reasoning_effort, context_limit, workspace_path, worktree_pending, parent_id, sort_order, created_at, updated_at)
+       VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       id,
       input.title?.trim() || 'New chat',
       input.kind ?? 'main',
-      input.providerId ?? null,
-      input.model ?? null,
+      providerId,
+      model,
+      seed.agentId,
+      seed.reasoningEffort,
+      seed.contextLimit,
       input.workspacePath ?? null,
       pending ? JSON.stringify(pending) : null,
       input.parentId ?? null,
@@ -591,6 +625,47 @@ export function setChatSummary(chatId: string, summary: string, throughAt: numbe
       'UPDATE chats SET context_summary = ?, context_summary_at = ?, updated_at = ? WHERE id = ?'
     )
     .run(summary, throughAt, Date.now(), chatId)
+  const chat = getChat(chatId)
+  if (!chat) throw new Error('Chat not found')
+  return chat
+}
+
+/**
+ * Pin part of a session's inference config (any subset). This is what the
+ * composer pickers write, alongside the matching global setting that seeds the
+ * next new session.
+ *
+ * `providerId` and `model` are written TOGETHER whenever either is present, so
+ * a session can never end up holding one provider with another's model id.
+ * Passing null for a field clears the override, returning that field to the
+ * global default.
+ */
+export function setChatConfig(chatId: string, patch: SessionConfigPatch): Chat {
+  const sets: string[] = []
+  const vals: (string | number | null)[] = []
+  if ('providerId' in patch || 'model' in patch) {
+    sets.push('provider_id = ?', 'model = ?')
+    vals.push(patch.providerId ?? null, patch.model ?? null)
+  }
+  if ('agentId' in patch) {
+    sets.push('agent_id = ?')
+    vals.push(patch.agentId ?? null)
+  }
+  if ('reasoningEffort' in patch) {
+    sets.push('reasoning_effort = ?')
+    vals.push(patch.reasoningEffort ?? null)
+  }
+  if ('contextLimit' in patch) {
+    sets.push('context_limit = ?')
+    vals.push(patch.contextLimit ?? null)
+  }
+  if (sets.length) {
+    // Deliberately does NOT touch updated_at: choosing a model is not activity,
+    // and bumping it would reshuffle the sidebar every time a picker is opened.
+    getDb()
+      .prepare(`UPDATE chats SET ${sets.join(', ')} WHERE id = ?`)
+      .run(...vals, chatId)
+  }
   const chat = getChat(chatId)
   if (!chat) throw new Error('Chat not found')
   return chat

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { CHANNELS } from '../../shared/ipc'
+import type { SessionConfigPatch } from '../../shared/session-config'
 import type {
   CreateChatInput,
   CreateLoopInput,
@@ -114,6 +115,9 @@ export function registerIpc(): void {
     CHANNELS.settingsSetActiveProvider,
     (_e, providerId: string, model: string | null) => repo.setActiveProvider(providerId, model)
   )
+  ipcMain.handle(CHANNELS.settingsSetActiveAgent, (_e, agentId: string) =>
+    repo.setActiveAgent(agentId)
+  )
   ipcMain.handle(CHANNELS.settingsSetReasoningEffort, (_e, level: ReasoningEffort) =>
     repo.setReasoningEffort(level)
   )
@@ -138,6 +142,9 @@ export function registerIpc(): void {
   ipcMain.handle(CHANNELS.chatsCreate, (_e, input?: CreateChatInput) => repo.createChat(input))
   ipcMain.handle(CHANNELS.chatsRename, (_e, id: string, title: string) =>
     repo.renameChat(id, title)
+  )
+  ipcMain.handle(CHANNELS.chatsSetConfig, (_e, id: string, patch: SessionConfigPatch) =>
+    repo.setChatConfig(id, patch)
   )
   ipcMain.handle(CHANNELS.chatsRemove, (_e, id: string) => {
     // Cancel any background subagents this session launched before it's deleted,

--- a/src/main/services/remote.ts
+++ b/src/main/services/remote.ts
@@ -32,7 +32,7 @@ import type { Message } from '../../shared/types'
 import { reconstructTurn } from '../../shared/tool-history'
 import { PartsFold, partsToContent } from '../../shared/parts'
 import { pruneToolMessages, KEEP_RECENT_TOKENS } from '../../shared/context'
-import { DEFAULT_AGENT_ID } from '../../shared/agents'
+import { contextBudgetFor, resolveSessionConfig } from '../../shared/session-config'
 import * as repo from '../db/repo'
 import { listModels } from './models'
 import { pickDefaultModel } from '../../shared/models'
@@ -453,11 +453,13 @@ async function runTurn(
     // user message was just persisted + bumped above; the reply streams next).
     broadcastDeltaFor(active, { sessionId, kind: 'turn', state: 'running' })
 
-    // Reproduce the renderer's provider/model/budget resolution in the main process.
+    // Resolve THIS SESSION's config, exactly as the renderer does - through the
+    // one shared resolver, so a phone turn runs on the model the desktop shows
+    // for that session rather than whatever was last picked globally.
     const settings = repo.getSettings()
+    const config = resolveSessionConfig(repo.getChat(sessionId), settings)
     const providers = repo.listConnectedProviders()
-    const provider =
-      providers.find((p) => p.id === settings.activeProviderId) ?? providers[0] ?? null
+    const provider = providers.find((p) => p.id === config.providerId) ?? providers[0] ?? null
     if (!provider) {
       sendFrameFor(active, { t: 'error', message: 'No provider is connected on the desktop.' })
       return
@@ -472,16 +474,13 @@ async function runTurn(
       // Offline model catalog — fall back to conservative defaults below.
     }
     const model =
-      settings.activeModel ||
+      (config.providerId === provider.id ? config.model : null) ||
       provider.defaultModel ||
       pickDefaultModel(catalog) ||
       (provider.id === 'github-copilot' ? 'gpt-4o' : 'gpt-4o-mini')
     const info = catalog.find((m) => m.id === model)
     const modelContext = info?.contextLimit ?? 128_000
-    const contextBudget = Math.min(
-      settings.contextLimit ?? Math.min(modelContext, 200_000),
-      modelContext
-    )
+    const contextBudget = contextBudgetFor(config.contextLimit, modelContext)
     const messages = buildRemoteMessages(sessionId, contextBudget, info?.outputLimit ?? 4096)
 
     const result = await runSessionTurn(
@@ -491,9 +490,11 @@ async function runTurn(
         providerId: provider.id,
         model,
         messages,
-        agentId: DEFAULT_AGENT_ID,
+        // The session's own mode: a session left in Plan mode stays read-only
+        // when it is driven from the phone.
+        agentId: config.agentId,
         reasoning: info?.reasoning ?? false,
-        reasoningEffort: settings.reasoningEffort ?? 'high',
+        reasoningEffort: config.reasoningEffort,
         contextLimit: contextBudget
       },
       (event) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,7 @@ const roxy: RoxyApi = {
     getAll: () => ipcRenderer.invoke(CHANNELS.settingsGetAll),
     setActiveProvider: (providerId, model) =>
       ipcRenderer.invoke(CHANNELS.settingsSetActiveProvider, providerId, model),
+    setActiveAgent: (agentId) => ipcRenderer.invoke(CHANNELS.settingsSetActiveAgent, agentId),
     setReasoningEffort: (level) => ipcRenderer.invoke(CHANNELS.settingsSetReasoningEffort, level),
     setContextLimit: (limit) => ipcRenderer.invoke(CHANNELS.settingsSetContextLimit, limit),
     setWebSearchApiKey: (key) => ipcRenderer.invoke(CHANNELS.settingsSetWebSearchApiKey, key),
@@ -38,7 +39,8 @@ const roxy: RoxyApi = {
     create: (input) => ipcRenderer.invoke(CHANNELS.chatsCreate, input),
     rename: (id, title) => ipcRenderer.invoke(CHANNELS.chatsRename, id, title),
     remove: (id) => ipcRenderer.invoke(CHANNELS.chatsRemove, id),
-    reorder: (workspacePath, ids) => ipcRenderer.invoke(CHANNELS.chatsReorder, workspacePath, ids)
+    reorder: (workspacePath, ids) => ipcRenderer.invoke(CHANNELS.chatsReorder, workspacePath, ids),
+    setConfig: (id, patch) => ipcRenderer.invoke(CHANNELS.chatsSetConfig, id, patch)
   },
   projects: {
     listOrder: () => ipcRenderer.invoke(CHANNELS.projectsListOrder),

--- a/src/renderer/src/components/InferenceControls.tsx
+++ b/src/renderer/src/components/InferenceControls.tsx
@@ -4,6 +4,12 @@ import type { MessagePart, ReasoningEffort } from '@shared/types'
 import type { ModelInfo } from '@shared/api'
 import { PRIMARY_AGENTS, getAgent, DEFAULT_AGENT_ID } from '@shared/agents'
 import { buildSystemPrompt, useRoxyStore } from '../lib/store'
+import {
+  contextBudgetFor,
+  effectiveContextMax,
+  resolveSessionConfig,
+  type SessionConfig
+} from '@shared/session-config'
 import { cn } from '../lib/cn'
 
 /** Close-on-outside-click / Escape for a small popover. */
@@ -32,20 +38,41 @@ function usePopover(): {
   return { open, setOpen, ref }
 }
 
-/** Resolve the active model's capabilities (reasoning + context window). */
+/**
+ * The OPEN SESSION's resolved inference config. Subscribes to the pieces that
+ * feed it (`chats`, `activeChatId`, `settings`) so every picker re-renders the
+ * moment the session changes or another value is picked - reading it through
+ * the store's getter alone would not re-render, since a getter isn't state.
+ */
+function useSessionConfig(): SessionConfig {
+  const chats = useRoxyStore((s) => s.chats)
+  const activeChatId = useRoxyStore((s) => s.activeChatId)
+  const settings = useRoxyStore((s) => s.settings)
+  return useMemo(
+    () =>
+      resolveSessionConfig(
+        chats.find((c) => c.id === activeChatId),
+        settings
+      ),
+    [chats, activeChatId, settings]
+  )
+}
+
+/** Resolve the open session's model capabilities (reasoning + context window). */
 function useActiveModelInfo(): ModelInfo | undefined {
   const providers = useRoxyStore((s) => s.providers)
-  const settings = useRoxyStore((s) => s.settings)
   const modelCatalog = useRoxyStore((s) => s.modelCatalog)
   const ensureModels = useRoxyStore((s) => s.ensureModels)
-  const activeProvider =
-    providers.find((p) => p.id === settings?.activeProviderId) ?? providers[0] ?? null
-  const activeModel = settings?.activeModel ?? null
+  const config = useSessionConfig()
+  const activeProvider = providers.find((p) => p.id === config.providerId) ?? providers[0] ?? null
   useEffect(() => {
     if (activeProvider) void ensureModels(activeProvider.id)
   }, [activeProvider, ensureModels])
-  if (!activeProvider || !activeModel) return undefined
-  return modelCatalog[activeProvider.id]?.find((m) => m.id === activeModel)
+  if (!activeProvider || !config.model) return undefined
+  // Only match within the resolved provider, so a session pinned to a model
+  // from another provider doesn't borrow its capabilities.
+  if (config.providerId && config.providerId !== activeProvider.id) return undefined
+  return modelCatalog[activeProvider.id]?.find((m) => m.id === config.model)
 }
 
 const triggerClass =
@@ -65,12 +92,12 @@ const EFFORTS: { value: ReasoningEffort; label: string }[] = [
 
 export function ThinkingPicker(): JSX.Element | null {
   const info = useActiveModelInfo()
-  const settings = useRoxyStore((s) => s.settings)
+  const config = useSessionConfig()
   const setReasoningEffort = useRoxyStore((s) => s.setReasoningEffort)
   const { open, setOpen, ref } = usePopover()
 
   if (!info?.reasoning) return null
-  const current = settings?.reasoningEffort ?? 'high'
+  const current = config.reasoningEffort
   const currentLabel = EFFORTS.find((e) => e.value === current)?.label ?? 'High'
 
   return (
@@ -166,7 +193,7 @@ export function AgentPicker(): JSX.Element {
                   key={a.id}
                   type="button"
                   onClick={() => {
-                    setActiveAgent(a.id)
+                    void setActiveAgent(a.id)
                     setOpen(false)
                   }}
                   className={cn(
@@ -211,21 +238,9 @@ function contextOptions(max: number): number[] {
   return Array.from(new Set(opts))
 }
 
-/**
- * The window the model can actually use. models.dev reports Claude's *base*
- * 200K, but the model (and VS Code's Copilot client) expose a 1M window —
- * Anthropic via the `context-1m` beta, Copilot server-side. Raise the ceiling
- * for these large reasoning models so the picker matches what they can do.
- */
-function effectiveContextMax(info: ModelInfo): number {
-  const base = info.contextLimit ?? 0
-  if (info.reasoning && base >= 180_000 && base <= 264_000) return 1_000_000
-  return base
-}
-
 export function ContextPicker(): JSX.Element | null {
   const info = useActiveModelInfo()
-  const settings = useRoxyStore((s) => s.settings)
+  const config = useSessionConfig()
   const setContextLimit = useRoxyStore((s) => s.setContextLimit)
   const { open, setOpen, ref } = usePopover()
 
@@ -233,7 +248,7 @@ export function ContextPicker(): JSX.Element | null {
   if (!max) return null
   const options = contextOptions(max)
   const defaultBudget = Math.min(max, 200_000)
-  const current = settings?.contextLimit ?? defaultBudget
+  const current = config.contextLimit ?? defaultBudget
 
   return (
     <div ref={ref} className="relative">
@@ -304,7 +319,7 @@ interface Category {
  */
 export function ContextMeter(): JSX.Element {
   const info = useActiveModelInfo()
-  const settings = useRoxyStore((s) => s.settings)
+  const config = useSessionConfig()
   const messages = useRoxyStore((s) => s.messages)
   const activeChatId = useRoxyStore((s) => s.activeChatId)
   const streaming = useRoxyStore((s) =>
@@ -350,9 +365,7 @@ export function ContextMeter(): JSX.Element {
   const used = messagesTokens + toolTokens + otherTokens + systemTokens + toolDefsTokens
 
   const modelCtx = info ? effectiveContextMax(info) : undefined
-  const total = modelCtx
-    ? Math.min(settings?.contextLimit ?? Math.min(modelCtx, 200_000), modelCtx)
-    : null
+  const total = modelCtx ? contextBudgetFor(config.contextLimit, modelCtx) : null
   const reserve = total ? Math.min(info?.outputLimit ?? 4096, Math.round(total * 0.25)) : 0
   const pct = total ? Math.min(100, Math.round((used / total) * 100)) : 0
   const reservePct = total ? Math.min(100 - pct, Math.round((reserve / total) * 100)) : 0

--- a/src/renderer/src/components/ModelPicker.tsx
+++ b/src/renderer/src/components/ModelPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Brain, Check, ChevronsUpDown, Search, Wrench } from 'lucide-react'
 import { useRoxyStore } from '../lib/store'
+import { resolveSessionConfig } from '@shared/session-config'
 import { ProviderLogo } from '../lib/providerLogos'
 import { cn } from '../lib/cn'
 
@@ -12,6 +13,8 @@ import { cn } from '../lib/cn'
 export function ModelPicker(): JSX.Element {
   const providers = useRoxyStore((s) => s.providers)
   const settings = useRoxyStore((s) => s.settings)
+  const chats = useRoxyStore((s) => s.chats)
+  const activeChatId = useRoxyStore((s) => s.activeChatId)
   const selectModel = useRoxyStore((s) => s.selectModel)
   const models = useRoxyStore((s) => s.modelCatalog)
   const ensureModels = useRoxyStore((s) => s.ensureModels)
@@ -20,9 +23,20 @@ export function ModelPicker(): JSX.Element {
   const [query, setQuery] = useState('')
   const rootRef = useRef<HTMLDivElement>(null)
 
-  const activeProvider =
-    providers.find((p) => p.id === settings?.activeProviderId) ?? providers[0] ?? null
-  const activeModel = settings?.activeModel ?? null
+  // The model shown is the OPEN SESSION's, not a global one: two sessions can
+  // sit on different models at once, and each remembers its own across
+  // restarts. A session with nothing pinned falls back to the last-used pair.
+  const config = resolveSessionConfig(
+    chats.find((c) => c.id === activeChatId),
+    settings
+  )
+  const activeProvider = providers.find((p) => p.id === config.providerId) ?? providers[0] ?? null
+  // Only show the session's model when it belongs to the provider we resolved.
+  // A session pinned to a provider that was since disconnected falls back to
+  // another one, and labelling that fallback with the old model would claim a
+  // pairing the turn will not actually use (the send path picks the fallback
+  // provider's own default instead).
+  const activeModel = activeProvider?.id === config.providerId ? config.model : null
   const loading = providers.some((p) => !models[p.id])
 
   // Lazy-load every connected provider's models into the shared catalog.
@@ -71,7 +85,9 @@ export function ModelPicker(): JSX.Element {
         onClick={() => setOpen((o) => !o)}
         className="press-scale flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1 text-xs text-text-muted hover:border-border-strong hover:text-text"
       >
-        {activeProvider && <ProviderLogo id={activeProvider.id} name={activeProvider.name} size={14} />}
+        {activeProvider && (
+          <ProviderLogo id={activeProvider.id} name={activeProvider.name} size={14} />
+        )}
         <span className="max-w-[200px] truncate">{triggerLabel}</span>
         <ChevronsUpDown className="h-3 w-3 shrink-0 opacity-60" />
       </button>
@@ -128,7 +144,8 @@ export function ModelPicker(): JSX.Element {
               })}
             {!loading && Object.values(models).every((l) => l.length === 0) && (
               <div className="px-3 py-3 text-xs text-text-subtle">
-                Couldn&apos;t load models from models.dev — you can still send with the current model.
+                Couldn&apos;t load models from models.dev — you can still send with the current
+                model.
               </div>
             )}
           </div>

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -27,6 +27,12 @@ import { reconstructTurn, REPLAY_OUTPUT_CAP } from '@shared/tool-history'
 import { PartsFold, partsToContent } from '@shared/parts'
 import { isOverflow, pruneToolMessages, KEEP_RECENT_TOKENS } from '@shared/context'
 import { pickDefaultModel } from '@shared/models'
+import {
+  contextBudgetFor,
+  resolveSessionConfig,
+  type SessionConfig,
+  type SessionConfigPatch
+} from '@shared/session-config'
 import { uniqueSlug } from '@shared/slugs'
 import { api } from './api'
 import type { ComposerImage } from './images'
@@ -46,7 +52,12 @@ interface RoxyStore {
   sendingChats: Record<string, boolean>
   /** In-progress assistant parts per chat while a reply streams in. */
   streamingChats: Record<string, MessagePart[]>
-  /** Active agent (mode) for the open session. */
+  /**
+   * The open session's mode, mirrored from its `chat.agentId` for synchronous
+   * reads (the composer + the context meter re-render on every keystroke, and
+   * a store lookup is cheaper than finding the chat each time). `selectChat`
+   * loads it from the session; `setActiveAgent` writes both back.
+   */
   activeAgentId: string
   /** Project instruction blocks (AGENTS.md etc.) cached per workspace path. */
   projectInstructions: Record<string, string[]>
@@ -97,6 +108,21 @@ interface RoxyStore {
   refreshLoops: () => Promise<void>
   refreshQueue: () => Promise<void>
   refreshProviders: () => Promise<void>
+  /**
+   * The config the OPEN session runs with: its own pinned values, falling back
+   * to the global last-used ones. The single read path for the composer
+   * pickers and the send path - never read `settings.activeModel` directly.
+   */
+  sessionConfig: () => SessionConfig
+  /**
+   * Change part of the open session's config.
+   *
+   * Writes TWICE, on purpose: the session row (so the change is scoped to this
+   * session and survives a restart) and the matching global setting (so the
+   * next NEW session inherits it). That is the whole feature - sessions are
+   * independent, and new ones start from whatever you last picked.
+   */
+  setSessionConfig: (patch: SessionConfigPatch) => Promise<void>
   selectModel: (providerId: string, model: string) => Promise<void>
   ensureModels: (providerId: string) => Promise<void>
   setReasoningEffort: (level: ReasoningEffort) => Promise<void>
@@ -109,7 +135,7 @@ interface RoxyStore {
   createLoop: (input: CreateLoopInput) => Promise<void>
   setLoopEnabled: (id: string, enabled: boolean) => Promise<void>
   removeLoop: (id: string) => Promise<void>
-  setActiveAgent: (id: string) => void
+  setActiveAgent: (id: string) => Promise<void>
   /** Load + cache a workspace's instruction files (AGENTS.md etc.) for sizing. */
   ensureProjectInstructions: (workspacePath: string) => Promise<void>
   deleteChat: (id: string) => Promise<void>
@@ -191,6 +217,40 @@ const remoteTurns = new Map<string, PartsFold>()
  * whole transcript so far instead of resuming from whatever arrives next.
  */
 const subagentTurns = new Map<string, PartsFold>()
+
+/**
+ * Record a config change as the new GLOBAL default - the template every new
+ * session is stamped from.
+ *
+ * The session itself is written separately (`api.chats.setConfig`); this half is
+ * what makes "the next session remembers what I last picked" true. Returns the
+ * refreshed settings, or null when the patch touched nothing global.
+ *
+ * Best-effort by design: a session whose config was saved must not appear to
+ * have failed because the template write did. The session row is what the
+ * turn actually runs on.
+ */
+async function persistGlobalConfig(patch: SessionConfigPatch): Promise<AppSettings | null> {
+  let latest: AppSettings | null = null
+  try {
+    if ('providerId' in patch && patch.providerId) {
+      latest = await api.settings.setActiveProvider(patch.providerId, patch.model ?? null)
+    }
+    if ('agentId' in patch && patch.agentId) {
+      latest = await api.settings.setActiveAgent(patch.agentId)
+    }
+    if ('reasoningEffort' in patch && patch.reasoningEffort) {
+      latest = await api.settings.setReasoningEffort(patch.reasoningEffort)
+    }
+    if ('contextLimit' in patch) {
+      latest = await api.settings.setContextLimit(patch.contextLimit ?? null)
+    }
+  } catch {
+    // The session keeps its own copy either way; only the inherited default
+    // for the *next* session is lost, which self-heals on the next change.
+  }
+  return latest
+}
 
 /**
  * Desktop live-mirror: reload the shared chat's transcript from disk after a
@@ -685,9 +745,42 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     }
   },
 
+  sessionConfig: () => {
+    const { chats, activeChatId, settings } = get()
+    return resolveSessionConfig(
+      chats.find((c) => c.id === activeChatId),
+      settings
+    )
+  },
+
+  setSessionConfig: async (patch) => {
+    const chatId = get().activeChatId
+    // Optimistic: the picker closes on click, so the trigger must already show
+    // the new value - a round-trip of visible lag reads as a dropped click.
+    // `undefined` is stripped so a partial patch can't blank a field the caller
+    // never named (the DB layer keys off `in`; null explicitly means "clear").
+    const applied = Object.fromEntries(
+      Object.entries(patch).filter(([, v]) => v !== undefined)
+    ) as SessionConfigPatch
+    if (chatId) {
+      set((s) => ({
+        chats: s.chats.map((c) => (c.id === chatId ? { ...c, ...applied } : c))
+      }))
+    }
+    // Persist to the session, and remember it globally for the next new one.
+    const [chat, settings] = await Promise.all([
+      chatId ? api.chats.setConfig(chatId, patch) : Promise.resolve(null),
+      persistGlobalConfig(patch)
+    ])
+    set((s) => ({
+      ...(settings ? { settings } : {}),
+      ...(chat ? { chats: s.chats.map((c) => (c.id === chat.id ? chat : c)) } : {})
+    }))
+  },
+
   selectModel: async (providerId, model) => {
-    const settings = await api.settings.setActiveProvider(providerId, model)
-    set({ settings })
+    // Provider + model always move together (see resolveSessionConfig).
+    await get().setSessionConfig({ providerId, model })
   },
 
   ensureModels: async (providerId) => {
@@ -698,13 +791,11 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   },
 
   setReasoningEffort: async (level) => {
-    const settings = await api.settings.setReasoningEffort(level)
-    set({ settings })
+    await get().setSessionConfig({ reasoningEffort: level })
   },
 
   setContextLimit: async (limit) => {
-    const settings = await api.settings.setContextLimit(limit)
-    set({ settings })
+    await get().setSessionConfig({ contextLimit: limit })
   },
 
   setWebSearchApiKey: async (key) => {
@@ -715,8 +806,18 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   selectChat: async (id) => {
     // Per-chat send state survives switching — just swap which chat is shown.
     // Clear messages/queue first so the previous chat's content never flashes.
-    set({ activeChatId: id, messages: [], queue: [], activeAgentId: DEFAULT_AGENT_ID })
+    //
+    // The mode comes from the session being opened, NOT a reset to 'build':
+    // config is per-session, so a session left in Plan mode is still in Plan
+    // mode when you come back to it. The model/effort/context pickers read the
+    // chat row directly via `resolveSessionConfig`, so they need no mirror here.
     const chat = get().chats.find((c) => c.id === id)
+    set({
+      activeChatId: id,
+      messages: [],
+      queue: [],
+      activeAgentId: chat?.agentId ?? DEFAULT_AGENT_ID
+    })
     const workspace = chat?.workspacePath
     if (workspace) void get().ensureProjectInstructions(workspace)
     // Tell main which sub session is on screen so the end-of-turn prune spares
@@ -737,7 +838,12 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       activeAgentId: DEFAULT_AGENT_ID
     }),
 
-  setActiveAgent: (id) => set({ activeAgentId: id }),
+  setActiveAgent: async (id) => {
+    // Mirror first so the picker updates instantly, then persist to the session
+    // (+ the global template for the next new one).
+    set({ activeAgentId: id })
+    await get().setSessionConfig({ agentId: id })
+  },
 
   ensureProjectInstructions: async (workspacePath) => {
     if (!workspacePath || get().projectInstructions[workspacePath]) return
@@ -1001,8 +1107,15 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     }
 
     // Real model: a connected provider with a usable credential streams the reply.
+    // Everything below resolves from THIS SESSION's pinned config (falling back
+    // to the global last-used values), so a turn always runs on the model the
+    // session shows - even if another session changed its picker mid-reply.
+    const config = resolveSessionConfig(
+      get().chats.find((c) => c.id === chatId),
+      settings
+    )
     const provider =
-      get().providers.find((p) => p.id === settings?.activeProviderId) ?? get().providers[0] ?? null
+      get().providers.find((p) => p.id === config.providerId) ?? get().providers[0] ?? null
     if (provider && (provider.hasCredential || provider.auth === 'none')) {
       // Resolve the model's capabilities (reasoning support + context window) so
       // we only send reasoning params when valid and cut history to the budget.
@@ -1011,24 +1124,24 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       // No model chosen? Take the provider's latest (tool-capable) model instead
       // of a hardcoded id that may not exist on this provider — the user never
       // has to type a model name for a connected provider to just work.
+      // Only trust the session's model when it belongs to the provider we
+      // actually resolved, so a stale pin can never cross providers.
       const model =
-        settings?.activeModel ||
+        (config.providerId === provider.id ? config.model : null) ||
         provider.defaultModel ||
         pickDefaultModel(catalog) ||
         (provider.id === 'github-copilot' ? 'gpt-4o' : 'gpt-4o-mini')
       const info = catalog.find((m) => m.id === model)
       const modelContext = info?.contextLimit ?? 128_000
-      const contextBudget = Math.min(
-        settings?.contextLimit ?? Math.min(modelContext, 200_000),
-        modelContext
-      )
+      const contextBudget = contextBudgetFor(config.contextLimit, modelContext)
+      const agentId = config.agentId
       // Auto-compact before the window overflows the model's *real* budget:
       // trigger once used tokens pass contextBudget minus the larger of the
       // reserved reply size or a safety buffer (mirrors opencode's
       // `context - max(output, buffer)` rather than a flat 80%). Compaction
       // summarizes older turns; buildChatMessages then sends summary + recent.
       if (!get().compactingChats[chatId]) {
-        const used = await estimateUsedTokens(chatId, model, get().activeAgentId)
+        const used = await estimateUsedTokens(chatId, model, agentId)
         if (isOverflow(used, contextBudget, info?.outputLimit ?? 4096)) {
           await get().compactConversation(chatId)
         }
@@ -1039,7 +1152,7 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
         contextBudget,
         info?.outputLimit ?? 4096,
         model,
-        get().activeAgentId
+        agentId
       )
       // Build parts live from the agent's event stream through the shared fold:
       // text grows the current text part, each tool call adds a card that flips
@@ -1094,9 +1207,9 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
         providerId: provider.id,
         model,
         messages: chatMessages,
-        agentId: get().activeAgentId,
+        agentId,
         reasoning: info?.reasoning ?? false,
-        reasoningEffort: settings?.reasoningEffort ?? 'high',
+        reasoningEffort: config.reasoningEffort,
         contextLimit: contextBudget
       })
       deltaHandlers.delete(requestId)
@@ -1189,12 +1302,17 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     const chatId = targetChatId ?? get().activeChatId
     if (!chatId || get().compactingChats[chatId]) return
     const { settings, providers } = get()
-    const provider =
-      providers.find((p) => p.id === settings?.activeProviderId) ?? providers[0] ?? null
+    // Compact with the SESSION's own model: compacting must not route a
+    // session's history through whatever model another session has selected.
+    const config = resolveSessionConfig(
+      get().chats.find((c) => c.id === chatId),
+      settings
+    )
+    const provider = providers.find((p) => p.id === config.providerId) ?? providers[0] ?? null
     if (!provider || !(provider.hasCredential || provider.auth === 'none')) return
     await get().ensureModels(provider.id)
     const model =
-      settings?.activeModel ||
+      (config.providerId === provider.id ? config.model : null) ||
       provider.defaultModel ||
       pickDefaultModel(get().modelCatalog[provider.id] ?? []) ||
       (provider.id === 'github-copilot' ? 'gpt-4o' : 'gpt-4o-mini')

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -26,6 +26,7 @@ import type {
 } from './types'
 import type { McpServerConfig } from './mcp'
 import type { ForgeStatusView, ForgeHostView, ForgeKind } from './forge'
+import type { SessionConfigPatch } from './session-config'
 
 /** A configured MCP server merged with its live connection status (for Settings). */
 export interface McpServerView {
@@ -85,6 +86,11 @@ export interface SkillInstallResult {
 export interface CreateChatInput {
   title?: string
   kind?: SessionKind
+  /**
+   * Pin this session to a provider/model instead of inheriting the last-used
+   * ones. Passed together or not at all - a provider without a model resolves
+   * to that provider's default rather than the previous provider's model id.
+   */
   providerId?: string | null
   model?: string | null
   workspacePath?: string | null
@@ -463,6 +469,8 @@ export interface RoxyApi {
   settings: {
     getAll(): Promise<AppSettings>
     setActiveProvider(providerId: string, model: string | null): Promise<AppSettings>
+    /** Remember the last-used mode, so the next NEW session opens in it. */
+    setActiveAgent(agentId: string): Promise<AppSettings>
     setReasoningEffort(level: ReasoningEffort): Promise<AppSettings>
     setContextLimit(limit: number | null): Promise<AppSettings>
     setWebSearchApiKey(key: string | null): Promise<AppSettings>
@@ -479,6 +487,8 @@ export interface RoxyApi {
     create(input?: CreateChatInput): Promise<Chat>
     rename(id: string, title: string): Promise<void>
     remove(id: string): Promise<void>
+    /** Pin part of one session's inference config (model / mode / effort / context). */
+    setConfig(id: string, patch: SessionConfigPatch): Promise<Chat>
     /** Reorder a project's sessions; `ids` is the full project session list, top-to-bottom. */
     reorder(workspacePath: string | null, ids: string[]): Promise<void>
   }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -2,6 +2,7 @@
 export const CHANNELS = {
   settingsGetAll: 'settings:getAll',
   settingsSetActiveProvider: 'settings:setActiveProvider',
+  settingsSetActiveAgent: 'settings:setActiveAgent',
   settingsSetReasoningEffort: 'settings:setReasoningEffort',
   settingsSetContextLimit: 'settings:setContextLimit',
   settingsSetWebSearchApiKey: 'settings:setWebSearchApiKey',
@@ -17,6 +18,8 @@ export const CHANNELS = {
   chatsRename: 'chats:rename',
   chatsRemove: 'chats:remove',
   chatsReorder: 'chats:reorder',
+  /** Pin part of a single session's inference config (model/mode/effort/context). */
+  chatsSetConfig: 'chats:setConfig',
 
   /** Project (workspace) display order — read + drag-to-reorder. */
   projectsListOrder: 'projects:listOrder',

--- a/src/shared/session-config.ts
+++ b/src/shared/session-config.ts
@@ -1,0 +1,119 @@
+/**
+ * Per-session inference config — the model, mode, thinking effort, and context
+ * budget a single session runs with.
+ *
+ * The rule, in one line: **a session owns its config; the global settings are
+ * only the template new sessions are stamped from.**
+ *
+ * Every session (a `chats` row) carries its own provider/model/agent/effort/
+ * context columns, seeded from `AppSettings` at create time. Changing a picker
+ * writes BOTH the open session's row and the global default, so:
+ *
+ *   - switching model in session A never touches session B, and
+ *   - the NEXT new session starts from whatever you last chose.
+ *
+ * Seeding is a snapshot, deliberately: editing a picker later must not
+ * retroactively rewrite sessions you already tuned. Sessions created before this
+ * existed have NULL columns and fall back to the globals here, so upgrading
+ * changes nothing until you touch a picker.
+ *
+ * This module is the SINGLE resolver. Three call sites used to duplicate this
+ * logic (the renderer's send path, its compaction path, and the main process's
+ * phone-driven turn) and drifted; they all route through `resolveSessionConfig`
+ * now so they cannot disagree about which model a session is on.
+ *
+ * Isomorphic: types and pure functions only, no Node/Electron/browser imports.
+ */
+import { DEFAULT_AGENT_ID } from './agents'
+import type { AppSettings, Chat, ReasoningEffort } from './types'
+
+/** The fully-resolved inference config for one session. */
+export interface SessionConfig {
+  providerId: string | null
+  model: string | null
+  /** Primary agent (mode) id, e.g. 'build' or 'plan'. Never null. */
+  agentId: string
+  reasoningEffort: ReasoningEffort
+  /** Context budget in tokens; null = use the model's own default. */
+  contextLimit: number | null
+}
+
+/** A partial config update — only the keys present are written. */
+export type SessionConfigPatch = Partial<SessionConfig>
+
+/** The subset of a Chat this resolver reads (so callers can pass a row or a Chat). */
+export type SessionConfigSource = Pick<
+  Chat,
+  'providerId' | 'model' | 'agentId' | 'reasoningEffort' | 'contextLimit'
+>
+
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'high'
+
+/** Narrow an untrusted string (DB column, IPC payload) to a ReasoningEffort. */
+export function parseReasoningEffort(v: unknown): ReasoningEffort | null {
+  return v === 'low' || v === 'medium' || v === 'high' || v === 'xhigh' || v === 'max' ? v : null
+}
+
+/**
+ * Resolve what a session actually runs with: its own columns first, then the
+ * global defaults, then hardcoded fallbacks.
+ *
+ * `providerId` and `model` resolve as an ATOMIC PAIR, keyed off the provider.
+ * Falling back field-by-field could pair one provider with another's model id
+ * (anthropic + `gpt-4o`), which 404s the turn. A session either pins both or
+ * inherits both.
+ */
+export function resolveSessionConfig(
+  chat: SessionConfigSource | null | undefined,
+  settings: AppSettings | null | undefined
+): SessionConfig {
+  // The provider pins the pair: a session with no provider of its own inherits
+  // the global provider AND the global model together.
+  const pinned = chat?.providerId ? chat : null
+  return {
+    providerId: pinned ? pinned.providerId : (settings?.activeProviderId ?? null),
+    model: pinned ? pinned.model : (settings?.activeModel ?? null),
+    agentId: chat?.agentId ?? DEFAULT_AGENT_ID,
+    reasoningEffort: chat?.reasoningEffort ?? settings?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+    contextLimit: chat?.contextLimit ?? settings?.contextLimit ?? null
+  }
+}
+
+/**
+ * The config a brand-new session is stamped with — i.e. "whatever the user last
+ * chose". Called by `createChat`; `agentId` is included so a session opened
+ * right after you switch to Plan stays in Plan.
+ */
+export function seedSessionConfig(settings: AppSettings | null | undefined): SessionConfig {
+  return {
+    providerId: settings?.activeProviderId ?? null,
+    model: settings?.activeModel ?? null,
+    agentId: settings?.activeAgentId ?? DEFAULT_AGENT_ID,
+    reasoningEffort: settings?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+    contextLimit: settings?.contextLimit ?? null
+  }
+}
+
+/**
+ * The window a model can actually use.
+ *
+ * models.dev reports Claude's *base* 200K, but the model (and VS Code's Copilot
+ * client) expose 1M — Anthropic via the `context-1m` beta, Copilot server-side.
+ * Raise the ceiling for those large reasoning models so the picker offers what
+ * they can really do. Shared so the picker, the meter, and the turn's budget
+ * math all agree on the maximum.
+ */
+export function effectiveContextMax(info: { reasoning?: boolean; contextLimit?: number }): number {
+  const base = info.contextLimit ?? 0
+  if (info.reasoning && base >= 180_000 && base <= 264_000) return 1_000_000
+  return base
+}
+
+/**
+ * The token budget a turn should build its window to, given the session's chosen
+ * limit and the model's real ceiling. Defaults to 200K (or the model max, if
+ * smaller) when the session has no explicit choice.
+ */
+export function contextBudgetFor(chosen: number | null, modelContext: number): number {
+  return Math.min(chosen ?? Math.min(modelContext, 200_000), modelContext)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -105,8 +105,25 @@ export interface Chat {
   id: string
   title: string
   kind: SessionKind
+  /**
+   * This session's own inference config. Sessions are CONFIG-ISOLATED: each row
+   * pins the provider/model/mode/effort/context it runs with, stamped from the
+   * global `AppSettings` at create time, so changing the model in one session
+   * never disturbs another. Null means "never chosen" - inherit the global
+   * default, which is what every session created before this existed does.
+   *
+   * `providerId` + `model` resolve as a PAIR (a provider pins its own model, so
+   * a fallback can never cross one provider with another's model id). Read them
+   * only through `resolveSessionConfig` in shared/session-config.ts.
+   */
   providerId: string | null
   model: string | null
+  /** Primary agent (mode) id, e.g. 'build' / 'plan'. Null = the default agent. */
+  agentId: string | null
+  /** Thinking effort for reasoning models. Null = inherit the global default. */
+  reasoningEffort: ReasoningEffort | null
+  /** Context budget in tokens. Null = inherit the global default. */
+  contextLimit: number | null
   workspacePath: string | null
   /**
    * This session's git worktree — an isolated checkout of the project's repo on
@@ -314,10 +331,21 @@ export interface SkillDef {
 /** Thinking/reasoning effort, mapped per provider (reasoning models only). */
 export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 
+/**
+ * Global app settings.
+ *
+ * For the inference fields (`activeProviderId`, `activeModel`, `activeAgentId`,
+ * `reasoningEffort`, `contextLimit`) this is the LAST-USED TEMPLATE, not the
+ * live config of any session: each session pins its own copy (see `Chat`), and
+ * changing a picker updates both the open session and this template, so the
+ * next new session starts where you left off.
+ */
 export interface AppSettings {
   onboardingCompleted: boolean
   activeProviderId: string | null
   activeModel: string | null
+  /** Last-used primary agent (mode) id, e.g. 'build' / 'plan'. */
+  activeAgentId: string | null
   /** Thinking effort applied to reasoning-capable models. */
   reasoningEffort: ReasoningEffort
   /** Chosen context-window budget in tokens; null = use the model default. */

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -56,6 +56,13 @@ import {
 } from '../src/shared/web'
 import { resolveWorktreeCwd } from '../src/shared/workspace'
 import {
+  contextBudgetFor,
+  effectiveContextMax,
+  parseReasoningEffort,
+  resolveSessionConfig,
+  seedSessionConfig
+} from '../src/shared/session-config'
+import {
   workstreamStripView,
   statusKeyForSession,
   type StripSession
@@ -2914,6 +2921,140 @@ async function main(): Promise<void> {
   check('relativeAge: hours', relativeAge(NOW - 3 * 3_600_000, NOW) === '3h ago')
   check('relativeAge: days', relativeAge(NOW - 4 * 86_400_000, NOW) === '4d ago')
   check('relativeAge: future clamps to now', relativeAge(NOW + 10_000, NOW) === 'just now')
+  // ---- per-session inference config (model/mode/effort/context) ----
+  //
+  // Two rules carry the whole feature, so both are pinned here:
+  //   1. a session that pinned a value keeps it, whatever the globals say
+  //   2. a session that pinned nothing follows the globals (the last-used
+  //      template), which is what every pre-upgrade session does.
+  const gSettings = {
+    onboardingCompleted: true,
+    activeProviderId: 'anthropic',
+    activeModel: 'claude-opus-5',
+    activeAgentId: 'plan',
+    reasoningEffort: 'max' as const,
+    contextLimit: 1_000_000,
+    webSearchApiKey: null
+  }
+  const bare = {
+    providerId: null,
+    model: null,
+    agentId: null,
+    reasoningEffort: null,
+    contextLimit: null
+  }
+
+  const inherited = resolveSessionConfig(bare, gSettings)
+  check(
+    'session config: an unpinned session inherits the global model',
+    inherited.providerId === 'anthropic' && inherited.model === 'claude-opus-5'
+  )
+  check(
+    'session config: an unpinned session inherits effort + context',
+    inherited.reasoningEffort === 'max' && inherited.contextLimit === 1_000_000
+  )
+  check(
+    'session config: mode falls back to the default agent, not the global',
+    resolveSessionConfig(bare, gSettings).agentId === DEFAULT_AGENT_ID
+  )
+
+  const pinned = resolveSessionConfig(
+    {
+      ...bare,
+      providerId: 'openai',
+      model: 'gpt-5',
+      agentId: 'build',
+      reasoningEffort: 'low' as const,
+      contextLimit: 64_000
+    },
+    gSettings
+  )
+  check(
+    'session config: a pinned session ignores the global model',
+    pinned.providerId === 'openai' && pinned.model === 'gpt-5'
+  )
+  check(
+    'session config: a pinned session ignores global effort + context',
+    pinned.reasoningEffort === 'low' && pinned.contextLimit === 64_000
+  )
+  check('session config: a pinned session keeps its own mode', pinned.agentId === 'build')
+
+  // provider + model are ONE decision: a session pinned to a provider must not
+  // borrow another provider's model id, which would 404 the turn.
+  const halfPinned = resolveSessionConfig({ ...bare, providerId: 'openai' }, gSettings)
+  check(
+    "session config: pinning a provider does not inherit the other provider's model",
+    halfPinned.providerId === 'openai' && halfPinned.model === null
+  )
+
+  // No settings at all (fresh install, before onboarding).
+  const empty = resolveSessionConfig(null, null)
+  check(
+    'session config: resolves with no chat and no settings',
+    empty.providerId === null &&
+      empty.model === null &&
+      empty.agentId === DEFAULT_AGENT_ID &&
+      empty.reasoningEffort === 'high' &&
+      empty.contextLimit === null
+  )
+
+  // The seed is what a NEW session is stamped with - the "next session
+  // remembers what I last picked" half of the feature. Unlike the resolver, it
+  // DOES take the global mode.
+  const seeded = seedSessionConfig(gSettings)
+  check(
+    'session seed: a new session inherits the last-used model + mode',
+    seeded.providerId === 'anthropic' &&
+      seeded.model === 'claude-opus-5' &&
+      seeded.agentId === 'plan'
+  )
+  check(
+    'session seed: a new session inherits the last-used effort + context',
+    seeded.reasoningEffort === 'max' && seeded.contextLimit === 1_000_000
+  )
+  check(
+    'session seed: no settings yields the plain defaults',
+    seedSessionConfig(null).agentId === DEFAULT_AGENT_ID &&
+      seedSessionConfig(null).reasoningEffort === 'high'
+  )
+
+  // parseReasoningEffort guards the DB column + IPC payloads.
+  check(
+    'session config: parseReasoningEffort accepts the ladder',
+    parseReasoningEffort('low') === 'low' &&
+      parseReasoningEffort('xhigh') === 'xhigh' &&
+      parseReasoningEffort('max') === 'max'
+  )
+  check(
+    'session config: parseReasoningEffort rejects junk',
+    parseReasoningEffort('turbo') === null &&
+      parseReasoningEffort(null) === null &&
+      parseReasoningEffort(7) === null
+  )
+
+  // Claude reports a 200K base but really exposes 1M - the picker's ceiling.
+  check(
+    'context max: a large reasoning model is raised to 1M',
+    effectiveContextMax({ reasoning: true, contextLimit: 200_000 }) === 1_000_000
+  )
+  check(
+    'context max: a non-reasoning model keeps its real window',
+    effectiveContextMax({ reasoning: false, contextLimit: 200_000 }) === 200_000
+  )
+  check(
+    'context max: a small model is left alone',
+    effectiveContextMax({ reasoning: true, contextLimit: 128_000 }) === 128_000
+  )
+  check(
+    'context budget: defaults to 200K, capped by the model window',
+    contextBudgetFor(null, 1_000_000) === 200_000 && contextBudgetFor(null, 128_000) === 128_000
+  )
+  check(
+    'context budget: a chosen limit never exceeds the model window',
+    contextBudgetFor(1_000_000, 128_000) === 128_000 &&
+      contextBudgetFor(400_000, 1_000_000) === 400_000
+  )
+
   if (fails.length) {
     console.error(`\nSHARED FAILED \u2014 ${fails.length} failing: ${fails.join(', ')}`)
     process.exit(1)

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -160,6 +160,95 @@ async function main(): Promise<void> {
   repo.setWebSearchApiKey('   ')
   check('setWebSearchApiKey blanks to null', repo.getSettings().webSearchApiKey === null)
 
+  // ---- per-session inference config ----
+  //
+  // The two behaviours users expect at once: a NEW session starts from what you
+  // last picked, and changing one session never touches another. Exercised
+  // against the real DB because both halves live in SQL (createChat stamps the
+  // seed; setChatConfig writes one row).
+  repo.setActiveProvider('anthropic', 'claude-opus-5')
+  repo.setActiveAgent('plan')
+  repo.setReasoningEffort('max')
+  repo.setContextLimit(1_000_000)
+  check('setActiveAgent persists', repo.getSettings().activeAgentId === 'plan')
+
+  const cfgA = repo.createChat({ title: 'cfg A', kind: 'main', workspacePath: ws })
+  check(
+    'a new session inherits the last-used model',
+    cfgA.providerId === 'anthropic' && cfgA.model === 'claude-opus-5'
+  )
+  check(
+    'a new session inherits the last-used mode/effort/context',
+    cfgA.agentId === 'plan' && cfgA.reasoningEffort === 'max' && cfgA.contextLimit === 1_000_000
+  )
+
+  // Change session A. The GLOBAL template is written separately by the store
+  // (dual-write), so at this layer only A moves.
+  repo.setChatConfig(cfgA.id, { providerId: 'openai', model: 'gpt-5' })
+  repo.setChatConfig(cfgA.id, { reasoningEffort: 'low', contextLimit: 64_000 })
+  check(
+    'setChatConfig pins the session',
+    repo.getChat(cfgA.id)?.model === 'gpt-5' &&
+      repo.getChat(cfgA.id)?.reasoningEffort === 'low' &&
+      repo.getChat(cfgA.id)?.contextLimit === 64_000
+  )
+  check(
+    'setChatConfig does NOT touch the global template',
+    repo.getSettings().activeModel === 'claude-opus-5' &&
+      repo.getSettings().reasoningEffort === 'max'
+  )
+
+  // The isolation guarantee: a second session created from the same template is
+  // unaffected by anything session A did to itself.
+  const cfgB = repo.createChat({ title: 'cfg B', kind: 'main', workspacePath: ws })
+  check(
+    "a sibling session is unaffected by another session's model change",
+    cfgB.model === 'claude-opus-5' && cfgB.reasoningEffort === 'max'
+  )
+  repo.setChatConfig(cfgB.id, { agentId: 'build' })
+  check(
+    "changing one session's mode leaves its sibling alone",
+    repo.getChat(cfgB.id)?.agentId === 'build' && repo.getChat(cfgA.id)?.agentId === 'plan'
+  )
+
+  // A later template change reaches only sessions created AFTER it: the seed is
+  // a snapshot, so tuning a picker never rewrites sessions already in flight.
+  repo.setActiveProvider('google', 'gemini-3')
+  const cfgC = repo.createChat({ title: 'cfg C', kind: 'main', workspacePath: ws })
+  check(
+    'the next new session picks up the newest template',
+    cfgC.providerId === 'google' && cfgC.model === 'gemini-3'
+  )
+  check(
+    'existing sessions are NOT rewritten by a later template change',
+    repo.getChat(cfgA.id)?.model === 'gpt-5' && repo.getChat(cfgB.id)?.model === 'claude-opus-5'
+  )
+
+  // Clearing an override returns that field to the global default (null column).
+  repo.setChatConfig(cfgA.id, { contextLimit: null })
+  check(
+    'setChatConfig clears an override back to inherit',
+    repo.getChat(cfgA.id)?.contextLimit === null
+  )
+
+  // An explicit provider must never be paired with the seeded model id.
+  const cfgD = repo.createChat({
+    title: 'cfg D',
+    kind: 'main',
+    workspacePath: ws,
+    providerId: 'openai'
+  })
+  check(
+    'an explicitly-provided provider does not inherit the template model',
+    cfgD.providerId === 'openai' && cfgD.model === null
+  )
+
+  // Restore the template the rest of the suite expects.
+  repo.setActiveProvider('openai', 'gpt-test')
+  repo.setReasoningEffort('high')
+  repo.setContextLimit(null)
+  for (const id of [cfgA.id, cfgB.id, cfgC.id, cfgD.id]) repo.removeChat(id)
+
   // ---- chats / sessions ----
   const chat = repo.createChat({ title: 'smoke', kind: 'main', workspacePath: ws })
   check('createChat (main + workspace)', chat.kind === 'main' && chat.workspacePath === ws)
@@ -612,7 +701,10 @@ async function main(): Promise<void> {
     const sessA = repo.createChat({ title: 'bg A', kind: 'main', workspacePath: ws })
     const sessB = repo.createChat({ title: 'bg B', kind: 'main', workspacePath: ws })
     const subOfA = repo.createChat({ title: 'sub of A', kind: 'sub', parentId: sessA.id })
-    check('rootSessionId: a main session is its own root', repo.rootSessionId(sessA.id) === sessA.id)
+    check(
+      'rootSessionId: a main session is its own root',
+      repo.rootSessionId(sessA.id) === sessA.id
+    )
     check('rootSessionId: a sub resolves to its parent', repo.rootSessionId(subOfA.id) === sessA.id)
     check('rootSessionId: an unknown id is returned as-is', repo.rootSessionId('nope') === 'nope')
 
@@ -639,7 +731,11 @@ async function main(): Promise<void> {
     check("session B cannot READ session A's process output", !bOut.ok, bOut.output)
 
     const aList = await inSession(sessA.id, 'bash_list', {})
-    check('session A still sees its own process', aList.ok && aList.output.includes(aId), aList.output)
+    check(
+      'session A still sees its own process',
+      aList.ok && aList.output.includes(aId),
+      aList.output
+    )
 
     // A subagent's process is registered under the PARENT, so the parent's
     // bash_list sees it (and deleting the parent will stop it).
@@ -668,7 +764,10 @@ async function main(): Promise<void> {
       aList3.ok && !aList3.output.includes(aId) && !aList3.output.includes(subId),
       aList3.output
     )
-    check('killSessionBackground on an unknown session is a no-op', killSessionBackground('nope') === 0)
+    check(
+      'killSessionBackground on an unknown session is a no-op',
+      killSessionBackground('nope') === 0
+    )
     check('killSessionBackground ignores an empty id', killSessionBackground('') === 0)
 
     repo.removeChat(sessA.id)
@@ -684,7 +783,11 @@ async function main(): Promise<void> {
   {
     /** Open a database the way database.ts does: migrate, then repair. */
     const runLadder = (db: InstanceType<typeof Database>): void => {
-      for (let v = db.pragma('user_version', { simple: true }) as number; v < MIGRATIONS.length; v++) {
+      for (
+        let v = db.pragma('user_version', { simple: true }) as number;
+        v < MIGRATIONS.length;
+        v++
+      ) {
         const step = MIGRATIONS[v]
         if (typeof step === 'string') db.exec(step)
         else step(db)
@@ -697,9 +800,9 @@ async function main(): Promise<void> {
     const colsOf = (db: InstanceType<typeof Database>): string[] =>
       (db.prepare('PRAGMA table_info(chats)').all() as { name: string }[]).map((c) => c.name)
     const tablesOf = (db: InstanceType<typeof Database>): string[] =>
-      (db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[]).map(
-        (t) => t.name
-      )
+      (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[]
+      ).map((t) => t.name)
     /** Apply the first `upTo` migrations, then seed a session. */
     const seeded = async (name: string, upTo: number): Promise<InstanceType<typeof Database>> => {
       const dir = path.join(tmp, name)
@@ -731,8 +834,11 @@ async function main(): Promise<void> {
       } catch (e) {
         reported = e instanceof Error ? e.message : String(e)
       }
-      check('migration repro: reproduces the reported error',
-        /no such column: worktree_path/.test(reported), reported)
+      check(
+        'migration repro: reproduces the reported error',
+        /no such column: worktree_path/.test(reported),
+        reported
+      )
 
       runLadder(db)
       for (const col of ['worktree_path', 'branch', 'dev_port', 'worktree_pending']) {
@@ -743,18 +849,28 @@ async function main(): Promise<void> {
         title: string
         worktree_path: string | null
       }
-      check('migration repair (usage-first): the failing write now succeeds', row.worktree_path === '/wt')
+      check(
+        'migration repair (usage-first): the failing write now succeeds',
+        row.worktree_path === '/wt'
+      )
       check('migration repair (usage-first): existing rows survive', row.title === 'pre-existing')
       check('migration repair (usage-first): usage table intact', tablesOf(db).includes('usage'))
 
       // Idempotent — it runs on every open, including healthy databases.
       repairSchema(db)
       repairSchema(db)
-      check('migration repair: re-running changes nothing',
-        (db.prepare('SELECT worktree_path AS w FROM chats WHERE id = ?').get('mig1') as { w: string }).w ===
-          '/wt')
-      check('migration repair: no duplicate columns',
-        colsOf(db).filter((c) => c === 'worktree_path').length === 1)
+      check(
+        'migration repair: re-running changes nothing',
+        (
+          db.prepare('SELECT worktree_path AS w FROM chats WHERE id = ?').get('mig1') as {
+            w: string
+          }
+        ).w === '/wt'
+      )
+      check(
+        'migration repair: no duplicate columns',
+        colsOf(db).filter((c) => c === 'worktree_path').length === 1
+      )
       db.close()
     }
 
@@ -771,16 +887,23 @@ async function main(): Promise<void> {
       check('migration repro: the usage table is missing', !tablesOf(db).includes('usage'))
 
       runLadder(db)
-      check('migration repair (worktree-first): creates the usage table', tablesOf(db).includes('usage'))
-      check('migration repair (worktree-first): keeps the worktree columns',
-        colsOf(db).includes('worktree_path'))
-      check('migration repair (worktree-first): existing rows survive',
-        (db.prepare('SELECT title FROM chats WHERE id = ?').get('mig1') as { title: string }).title ===
-          'pre-existing')
+      check(
+        'migration repair (worktree-first): creates the usage table',
+        tablesOf(db).includes('usage')
+      )
+      check(
+        'migration repair (worktree-first): keeps the worktree columns',
+        colsOf(db).includes('worktree_path')
+      )
+      check(
+        'migration repair (worktree-first): existing rows survive',
+        (db.prepare('SELECT title FROM chats WHERE id = ?').get('mig1') as { title: string })
+          .title === 'pre-existing'
+      )
       // The usage table must be the REAL one, not a stub.
-      const usageCols = (
-        db.prepare('PRAGMA table_info(usage)').all() as { name: string }[]
-      ).map((c) => c.name)
+      const usageCols = (db.prepare('PRAGMA table_info(usage)').all() as { name: string }[]).map(
+        (c) => c.name
+      )
       for (const col of ['provider_id', 'model', 'cost', 'estimated']) {
         check(`migration repair (worktree-first): usage.${col} exists`, usageCols.includes(col))
       }
@@ -831,7 +954,8 @@ async function main(): Promise<void> {
       check(`self-heal: ${table} is restored`, tablesOf(db).includes(table))
       check(
         `self-heal: data survives the ${table} repair`,
-        (db.prepare('SELECT title AS t FROM chats WHERE id = ?').get('h1') as { t: string }).t === 'seeded'
+        (db.prepare('SELECT title AS t FROM chats WHERE id = ?').get('h1') as { t: string }).t ===
+          'seeded'
       )
       db.close()
     }
@@ -846,7 +970,11 @@ async function main(): Promise<void> {
       } catch (e) {
         before = e instanceof Error ? e.message : String(e)
       }
-      check('self-heal: reproduces "no such table: projects"', /no such table: projects/.test(before), before)
+      check(
+        'self-heal: reproduces "no such table: projects"',
+        /no such table: projects/.test(before),
+        before
+      )
       repairSchema(db)
       let after = ''
       try {
@@ -866,12 +994,19 @@ async function main(): Promise<void> {
     // A hand-ordered project list must never be clobbered by that re-seed.
     {
       const db = healthy()
-      db.prepare('INSERT INTO projects(path, sort_order, created_at) VALUES(?,?,?)').run('/proj', 7, 1)
+      db.prepare('INSERT INTO projects(path, sort_order, created_at) VALUES(?,?,?)').run(
+        '/proj',
+        7,
+        1
+      )
       repairSchema(db)
       check(
         'self-heal: an existing project order is preserved',
-        (db.prepare('SELECT sort_order AS s FROM projects WHERE path = ?').get('/proj') as { s: number })
-          .s === 7
+        (
+          db.prepare('SELECT sort_order AS s FROM projects WHERE path = ?').get('/proj') as {
+            s: number
+          }
+        ).s === 7
       )
       db.close()
     }
@@ -923,9 +1058,7 @@ async function main(): Promise<void> {
     const wired = repo.getChat(plain.id)
     check(
       'setChatWorktree persists path/branch/port',
-      wired?.worktreePath === wtDir &&
-        wired?.branch === 'roxy/a1b2c3d4' &&
-        wired?.devPort === 3101
+      wired?.worktreePath === wtDir && wired?.branch === 'roxy/a1b2c3d4' && wired?.devPort === 3101
     )
     // `ws` has no .git, so findGitRoot finds nothing and we stay put — this is
     // the deliberate "can't trust the mapping" fallback.
@@ -939,7 +1072,11 @@ async function main(): Promise<void> {
     const pkgDir = path.join(repoRoot, 'apps', 'web')
     await fs.mkdir(pkgDir, { recursive: true })
     await fs.mkdir(path.join(repoRoot, '.git'), { recursive: true })
-    const subFolder = repo.createChat({ title: 'cwd subfolder', kind: 'main', workspacePath: pkgDir })
+    const subFolder = repo.createChat({
+      title: 'cwd subfolder',
+      kind: 'main',
+      workspacePath: pkgDir
+    })
     repo.setChatWorktree(subFolder.id, { worktreePath: wtDir, branch: 'roxy/deadbeef' })
     check(
       'sessionCwd: a project inside a repo keeps its subpath in the worktree',
@@ -960,7 +1097,10 @@ async function main(): Promise<void> {
 
     // Clearing the worktree returns the session to the project folder.
     repo.setChatWorktree(subFolder.id, { worktreePath: null })
-    check('sessionCwd: clearing the worktree restores the project folder', sessionCwd(subFolder.id) === pkgDir)
+    check(
+      'sessionCwd: clearing the worktree restores the project folder',
+      sessionCwd(subFolder.id) === pkgDir
+    )
 
     repo.removeChat(plain.id)
     repo.removeChat(noWs.id)
@@ -996,7 +1136,10 @@ async function main(): Promise<void> {
       check('git.repoRoot finds the repo', !!root, String(root))
       check('git.repoRoot is null outside a repo', (await git.repoRoot(tmp)) === null)
       check('git.currentBranch reads the branch', (await git.currentBranch(gitRepo)) === 'main')
-      check('git.defaultBranch falls back to local main', (await git.defaultBranch(gitRepo)) === 'main')
+      check(
+        'git.defaultBranch falls back to local main',
+        (await git.defaultBranch(gitRepo)) === 'main'
+      )
       const branches = await git.listBranches(gitRepo)
       check('git.listBranches includes main', branches.includes('main'), branches.join(','))
 
@@ -1013,10 +1156,17 @@ async function main(): Promise<void> {
 
       // ---- branch naming ----
       const tmpBranch = git.temporaryBranchName()
-      check('temporaryBranchName looks like roxy/<8 hex>', /^roxy\/[0-9a-f]{8}$/.test(tmpBranch), tmpBranch)
+      check(
+        'temporaryBranchName looks like roxy/<8 hex>',
+        /^roxy\/[0-9a-f]{8}$/.test(tmpBranch),
+        tmpBranch
+      )
       check('isTemporaryBranch accepts a generated name', git.isTemporaryBranch(tmpBranch))
       check('isTemporaryBranch rejects a user branch', !git.isTemporaryBranch('fix-auth'))
-      check('isTemporaryBranch rejects a roxy-prefixed real name', !git.isTemporaryBranch('roxy/fix-auth'))
+      check(
+        'isTemporaryBranch rejects a roxy-prefixed real name',
+        !git.isTemporaryBranch('roxy/fix-auth')
+      )
       check('isTemporaryBranch rejects null', !git.isTemporaryBranch(null))
 
       // ---- create ----
@@ -1030,29 +1180,52 @@ async function main(): Promise<void> {
         wtPath
       )
       check('the worktree has the repo content', existsSync(path.join(wtPath, 'README.md')))
-      check('createWorktree records the PR base in git config',
-        (await git.baseBranchFor(gitRepo, tmpBranch)) === 'main')
+      check(
+        'createWorktree records the PR base in git config',
+        (await git.baseBranchFor(gitRepo, tmpBranch)) === 'main'
+      )
       const wt1 = await git.listWorktrees(root!)
       check('listWorktrees now sees two trees', wt1.length === 2, String(wt1.length))
-      check('the new worktree is not flagged main', wt1.some((w) => w.path === wtPath && !w.isMain))
+      check(
+        'the new worktree is not flagged main',
+        wt1.some((w) => w.path === wtPath && !w.isMain)
+      )
 
       // Asking for the same branch again ATTACHES rather than failing — git
       // refuses to check one branch out twice.
       const again = await git.createWorktree({ repoRoot: root!, branch: tmpBranch })
-      check('createWorktree on a checked-out branch attaches instead of failing',
-        again.ok && again.attached === true && again.worktree?.path === wtPath, again.error ?? '')
+      check(
+        'createWorktree on a checked-out branch attaches instead of failing',
+        again.ok && again.attached === true && again.worktree?.path === wtPath,
+        again.error ?? ''
+      )
 
       // ---- sessionCwd resolves into the worktree ----
-      const wtChat = repo.createChat({ title: 'worktree session', kind: 'main', workspacePath: gitRepo })
+      const wtChat = repo.createChat({
+        title: 'worktree session',
+        kind: 'main',
+        workspacePath: gitRepo
+      })
       repo.setChatWorktree(wtChat.id, { worktreePath: wtPath, branch: tmpBranch })
-      check('sessionCwd resolves into the worktree', sessionCwd(wtChat.id) === wtPath, sessionCwd(wtChat.id))
+      check(
+        'sessionCwd resolves into the worktree',
+        sessionCwd(wtChat.id) === wtPath,
+        sessionCwd(wtChat.id)
+      )
 
       // A tool run in that session must actually land in the worktree.
-      const wrote = await runTool('write', { path: 'from-agent.txt', content: 'hi' }, {
-        cwd: sessionCwd(wtChat.id),
-        sessionId: wtChat.id
-      })
-      check('a tool writes inside the worktree', wrote.ok && existsSync(path.join(wtPath, 'from-agent.txt')))
+      const wrote = await runTool(
+        'write',
+        { path: 'from-agent.txt', content: 'hi' },
+        {
+          cwd: sessionCwd(wtChat.id),
+          sessionId: wtChat.id
+        }
+      )
+      check(
+        'a tool writes inside the worktree',
+        wrote.ok && existsSync(path.join(wtPath, 'from-agent.txt'))
+      )
       check('...and NOT in the main checkout', !existsSync(path.join(gitRepo, 'from-agent.txt')))
 
       // ---- lazy materialization ----
@@ -1062,24 +1235,42 @@ async function main(): Promise<void> {
         workspacePath: gitRepo,
         worktree: { mode: 'new' }
       })
-      check('a pending worktree intent is persisted', repo.getChat(lazy.id)?.worktreePending?.mode === 'new')
+      check(
+        'a pending worktree intent is persisted',
+        repo.getChat(lazy.id)?.worktreePending?.mode === 'new'
+      )
       check('...and no worktree exists yet', repo.getChat(lazy.id)?.worktreePath === null)
       const mat = await materializePendingWorktree(lazy.id)
-      check('materialize creates the worktree on first turn', mat.ok && !!mat.worktreePath, mat.error ?? '')
+      check(
+        'materialize creates the worktree on first turn',
+        mat.ok && !!mat.worktreePath,
+        mat.error ?? ''
+      )
       check('the intent is cleared afterwards', repo.getChat(lazy.id)?.worktreePending === null)
-      check('the session now points at its worktree', repo.getChat(lazy.id)?.worktreePath === mat.worktreePath)
+      check(
+        'the session now points at its worktree',
+        repo.getChat(lazy.id)?.worktreePath === mat.worktreePath
+      )
       // Second call: the intent is gone, so it reports "nothing to do" and must
       // leave the existing worktree alone rather than making another.
       const wtCountBefore = (await git.listWorktrees(root!)).length
       const redo = await materializePendingWorktree(lazy.id)
       check('materialize does nothing on a second call', redo.ok === false)
-      check('...and the session keeps its worktree', repo.getChat(lazy.id)?.worktreePath === mat.worktreePath)
-      check('...and no extra worktree was created',
-        (await git.listWorktrees(root!)).length === wtCountBefore)
+      check(
+        '...and the session keeps its worktree',
+        repo.getChat(lazy.id)?.worktreePath === mat.worktreePath
+      )
+      check(
+        '...and no extra worktree was created',
+        (await git.listWorktrees(root!)).length === wtCountBefore
+      )
 
       // Materializing a worktree also reserves a dev port for the session.
-      check('a materialized worktree gets a dev port',
-        typeof repo.getChat(lazy.id)?.devPort === 'number', String(repo.getChat(lazy.id)?.devPort))
+      check(
+        'a materialized worktree gets a dev port',
+        typeof repo.getChat(lazy.id)?.devPort === 'number',
+        String(repo.getChat(lazy.id)?.devPort)
+      )
 
       // The setup script runs in the NEW worktree, through the background path,
       // so it is owned by the session and visible in bash_list.
@@ -1116,9 +1307,15 @@ async function main(): Promise<void> {
         const [gotRoot, gotWt, gotPort] = setupOut.trim().split('|')
         check('ROXY_PROJECT_ROOT points at the project', gotRoot === gitRepo, gotRoot)
         check('ROXY_WORKTREE_PATH points at the worktree', gotWt === sm.worktreePath, gotWt)
-        check('ROXY_PORT is the session port', gotPort === String(repo.getChat(withSetup.id)?.devPort), gotPort)
-        check('the setup script did NOT run in the main checkout',
-          !existsSync(path.join(gitRepo, marker)))
+        check(
+          'ROXY_PORT is the session port',
+          gotPort === String(repo.getChat(withSetup.id)?.devPort),
+          gotPort
+        )
+        check(
+          'the setup script did NOT run in the main checkout',
+          !existsSync(path.join(gitRepo, marker))
+        )
         await fs.rm(path.join(gitRepo, '.roxy'), { recursive: true, force: true })
         await removeWorktreeForChat(withSetup.id, { force: true })
         repo.removeChat(withSetup.id)
@@ -1140,32 +1337,59 @@ async function main(): Promise<void> {
       const orphan = await git.createWorktree({ repoRoot: root!, branch: 'roxy/aaaaaaaa' })
       check('created an orphan worktree for prune', orphan.ok, orphan.error ?? '')
       const dry = await pruneWorktrees(gitRepo, { dryRun: true })
-      check('prune (dry run) finds the orphan',
-        dry.ok && dry.candidates.some((c) => c.path === orphan.worktree!.path), JSON.stringify(dry.candidates))
-      check('prune (dry run) does NOT list a session-owned worktree',
-        !dry.candidates.some((c) => c.path === wtPath))
-      check('prune (dry run) removes nothing', dry.removed.length === 0 && existsSync(orphan.worktree!.path))
+      check(
+        'prune (dry run) finds the orphan',
+        dry.ok && dry.candidates.some((c) => c.path === orphan.worktree!.path),
+        JSON.stringify(dry.candidates)
+      )
+      check(
+        'prune (dry run) does NOT list a session-owned worktree',
+        !dry.candidates.some((c) => c.path === wtPath)
+      )
+      check(
+        'prune (dry run) removes nothing',
+        dry.removed.length === 0 && existsSync(orphan.worktree!.path)
+      )
       const wet = await pruneWorktrees(gitRepo, { dryRun: false, force: true })
-      check('prune removes the orphan', wet.removed.includes(orphan.worktree!.path),
-        JSON.stringify(wet.failed))
+      check(
+        'prune removes the orphan',
+        wet.removed.includes(orphan.worktree!.path),
+        JSON.stringify(wet.failed)
+      )
       check('...and the directory is gone', !existsSync(orphan.worktree!.path))
-      check('prune never touches the main working tree', existsSync(path.join(gitRepo, 'README.md')))
+      check(
+        'prune never touches the main working tree',
+        existsSync(path.join(gitRepo, 'README.md'))
+      )
 
       // ---- remove ----
-      const shared = repo.createChat({ title: 'shares the worktree', kind: 'main', workspacePath: gitRepo })
+      const shared = repo.createChat({
+        title: 'shares the worktree',
+        kind: 'main',
+        workspacePath: gitRepo
+      })
       repo.setChatWorktree(shared.id, { worktreePath: wtPath, branch: tmpBranch })
       const blocked = await removeWorktreeForChat(wtChat.id)
-      check('a worktree shared with another session is NOT removed', blocked.ok && blocked.removed === false)
+      check(
+        'a worktree shared with another session is NOT removed',
+        blocked.ok && blocked.removed === false
+      )
       check('...and it still exists', existsSync(wtPath))
       repo.removeChat(shared.id)
 
       const removed = await removeWorktreeForChat(wtChat.id, { force: true })
-      check('removeWorktreeForChat removes an unshared worktree', removed.ok && removed.removed, removed.error ?? '')
+      check(
+        'removeWorktreeForChat removes an unshared worktree',
+        removed.ok && removed.removed,
+        removed.error ?? ''
+      )
       check('the worktree directory is gone', !existsSync(wtPath))
       const wt2 = await git.listWorktrees(root!)
       check('git no longer lists the removed worktree', !wt2.some((w) => w.path === wtPath))
-      check('removeWorktreeForChat is a no-op without a worktree',
-        (await removeWorktreeForChat(shared.id)).removed === false)
+      check(
+        'removeWorktreeForChat is a no-op without a worktree',
+        (await removeWorktreeForChat(shared.id)).removed === false
+      )
 
       repo.removeChat(wtChat.id)
       repo.removeChat(lazy.id)
@@ -1180,10 +1404,14 @@ async function main(): Promise<void> {
 
     check('listServices is empty for a fresh session', listServices(svcA.id).length === 0)
 
-    const started = await runTool('bash', { command: bgCmd, background: true }, {
-      cwd: ws,
-      sessionId: svcA.id
-    })
+    const started = await runTool(
+      'bash',
+      { command: bgCmd, background: true },
+      {
+        cwd: ws,
+        sessionId: svcA.id
+      }
+    )
     const svcId = started.output.match(/bg_\d+/)?.[0] ?? ''
     check('a background process appears in listServices', listServices(svcA.id).length === 1)
 
@@ -1209,8 +1437,11 @@ async function main(): Promise<void> {
     check('serviceOutput returns the buffered output', logs.includes(bgCmd), logs.slice(0, 80))
     check('serviceOutput is stable when read twice', serviceOutput(svcId, svcA.id) === logs)
     const agentRead = await runTool('bash_output', { id: svcId }, { cwd: ws, sessionId: svcA.id })
-    check("the UI's read did not consume the agent's new output",
-      agentRead.ok && agentRead.output.includes('roxy-bg-ok'), agentRead.output)
+    check(
+      "the UI's read did not consume the agent's new output",
+      agentRead.ok && agentRead.output.includes('roxy-bg-ok'),
+      agentRead.output
+    )
     check('serviceOutput refuses another session', serviceOutput(svcId, svcB.id) === '')
 
     // Restart replaces the row rather than accumulating a dead one per restart.
@@ -1218,15 +1449,22 @@ async function main(): Promise<void> {
     check('restartService succeeds', restarted.ok && !!restarted.id, restarted.error ?? '')
     check('...with a NEW process id', restarted.id !== svcId)
     check('...and does not leave the old row behind', listServices(svcA.id).length === 2)
-    check('the restarted service runs the same command',
-      listServices(svcA.id).some((s) => s.id === restarted.id && s.command === bgCmd))
-    check('restartService refuses another session', (await restartService(restarted.id!, svcB.id)).ok === false)
+    check(
+      'the restarted service runs the same command',
+      listServices(svcA.id).some((s) => s.id === restarted.id && s.command === bgCmd)
+    )
+    check(
+      'restartService refuses another session',
+      (await restartService(restarted.id!, svcB.id)).ok === false
+    )
 
     // Stop is idempotent.
     const stopped = stopService(restarted.id!, svcA.id)
     check('stopService succeeds', stopped.ok)
-    check('...and the service is no longer running',
-      listServices(svcA.id).find((s) => s.id === restarted.id)?.status !== 'running')
+    check(
+      '...and the service is no longer running',
+      listServices(svcA.id).find((s) => s.id === restarted.id)?.status !== 'running'
+    )
     check('stopService twice is fine', stopService(restarted.id!, svcA.id).ok)
     check('stopService refuses an unknown id', stopService('bg_nope', svcA.id).ok === false)
 
@@ -1242,7 +1480,11 @@ async function main(): Promise<void> {
 
     check('a new session starts with no port', repo.getChat(pA.id)?.devPort === null)
     const portA = await ensureDevPort(pA.id)
-    check('ensureDevPort allocates a port', typeof portA === 'number' && portA! >= 3100, String(portA))
+    check(
+      'ensureDevPort allocates a port',
+      typeof portA === 'number' && portA! >= 3100,
+      String(portA)
+    )
     check('...and persists it', repo.getChat(pA.id)?.devPort === portA)
 
     // Stability is the whole point: a bookmarked localhost:<port>, an open tab
@@ -1252,27 +1494,44 @@ async function main(): Promise<void> {
 
     const portB = await ensureDevPort(pB.id)
     check('a second session gets a DIFFERENT port', portB !== portA, `${portA} vs ${portB}`)
-    check('listDevPorts reports both', repo.listDevPorts().includes(portA!) && repo.listDevPorts().includes(portB!))
+    check(
+      'listDevPorts reports both',
+      repo.listDevPorts().includes(portA!) && repo.listDevPorts().includes(portB!)
+    )
 
     // An already-claimed port is skipped even when nothing is listening on it.
     const fresh = await allocateDevPort()
-    check('allocateDevPort skips ports claimed by other sessions',
-      fresh !== portA && fresh !== portB, String(fresh))
+    check(
+      'allocateDevPort skips ports claimed by other sessions',
+      fresh !== portA && fresh !== portB,
+      String(fresh)
+    )
 
     // The port reaches spawned commands as PORT + ROXY_PORT.
     const echoCmd =
-      process.platform === 'win32' ? 'Write-Output "P=$env:PORT R=$env:ROXY_PORT"' : 'echo "P=$PORT R=$ROXY_PORT"'
+      process.platform === 'win32'
+        ? 'Write-Output "P=$env:PORT R=$env:ROXY_PORT"'
+        : 'echo "P=$PORT R=$ROXY_PORT"'
     const envRes = await runTool('bash', { command: echoCmd }, { cwd: ws, sessionId: pA.id })
-    check('PORT is exported to spawned commands',
-      envRes.ok && envRes.output.includes(`P=${portA}`), envRes.output)
-    check('ROXY_PORT is exported too',
-      envRes.ok && envRes.output.includes(`R=${portA}`), envRes.output)
+    check(
+      'PORT is exported to spawned commands',
+      envRes.ok && envRes.output.includes(`P=${portA}`),
+      envRes.output
+    )
+    check(
+      'ROXY_PORT is exported too',
+      envRes.ok && envRes.output.includes(`R=${portA}`),
+      envRes.output
+    )
 
     // A session with no port must NOT get a blank PORT clobbering an inherited one.
     const noPort = repo.createChat({ title: 'no port', kind: 'main', workspacePath: ws })
     const noPortRes = await runTool('bash', { command: echoCmd }, { cwd: ws, sessionId: noPort.id })
-    check('a session without a port does not set PORT',
-      noPortRes.ok && !/P=\d/.test(noPortRes.output), noPortRes.output)
+    check(
+      'a session without a port does not set PORT',
+      noPortRes.ok && !/P=\d/.test(noPortRes.output),
+      noPortRes.output
+    )
 
     // Subagents share the parent's port (they share its tree and its servers).
     const subPort = repo.createChat({ title: 'sub port', kind: 'sub', parentId: pA.id })


### PR DESCRIPTION
## What

Model, mode, thinking effort and context size are now **per-session**, and a new session **inherits whatever you last picked**.

Previously all of this was global: switching the model in one session switched it *everywhere*, including sessions sitting mid-conversation on a different model.

## Why the two rules coexist

Each session pins its own config, stamped from the global settings when it's created. Changing a picker writes **twice** — the open session (scoped, survives restart) and the global "last used" template (seeds the next new session).

That's what makes both expected behaviours fall out together:

- switching to GPT in session A doesn't disturb session B, and
- open a new session after picking Opus 5 → it starts on Opus 5.

The seed is a **snapshot, not a link**. If it were a link, changing the model later would retroactively rewrite sessions you'd already tuned — the exact problem this fixes.

## Notes

**Mode had the inverse bug.** `activeAgentId` was already session-scoped but purely in-memory, and `selectChat` hard-reset it to `build` on every switch — a session left in Plan silently became Build on return. It now persists.

**The resolution logic was duplicated in three places** — renderer send, renderer compaction, and main's phone-driven turn — and had already drifted. All three route through `shared/session-config.ts` now, so they can't disagree about which model a session is on.

**Provider + model resolve as an atomic pair.** A field-by-field fallback could pair `anthropic` with a `gpt-4o` id and 404 the turn. A session either pins both or inherits both. Same guard where a session's pinned provider has since been disconnected.

## Migration (v17)

Revives `chats.provider_id`/`model` — present since v1 but dead columns, written as NULL and never read — and adds `agent_id` / `reasoning_effort` / `context_limit`. Mirrored into `repairSchema`, since this schema self-heals.

`NULL` means "inherit", so **every existing session behaves exactly as before until a picker is touched**.

Rehearsed against a copy of a real 78MB database: v16 → v17, 5 chats / 52 messages intact, all pre-existing sessions resolve to the previous global behaviour.

## Testing

- 514 shared checks pass (18 new, covering the resolver's inheritance/isolation/pairing rules)
- 9 new checks against a real DB (inheritance on create, isolation between siblings, snapshot semantics, clearing an override)
- both typecheck projects clean, prettier clean
- verified live: app boots on the migrated DB, pickers reflect the open session

One smoke test fails — `a session without a port does not set PORT`. It fails identically on clean `origin/main`, so it's pre-existing and unrelated (a sandbox env leak).
