### PR TITLE
feat(attachments): preview the full image on thumbnail hover

### DIFF
--- a/src/renderer/src/components/Composer.tsx
+++ b/src/renderer/src/components/Composer.tsx
@@ -3,6 +3,7 @@ import { ArrowUp, Plus, Square, X } from 'lucide-react'
 import { ModelPicker } from './ModelPicker'
 import { ContextMeter, ContextPicker, ThinkingPicker, AgentPicker } from './InferenceControls'
 import { imageFilesFrom, readImageFile, type ComposerImage } from '../lib/images'
+import { ImagePreview } from './ImagePreview'
 
 export function Composer({
   onSend,
@@ -96,11 +97,17 @@ export function Composer({
         {images.length > 0 && (
           <div className="flex flex-wrap gap-2 px-3 pt-3">
             {images.map((img) => (
-              <div
+              <ImagePreview
                 key={img.id}
+                src={img.dataUrl}
+                name={img.name}
                 className="group relative h-16 w-16 overflow-hidden rounded-lg border border-border bg-surface"
               >
-                <img src={img.dataUrl} alt={img.name} className="h-full w-full object-cover" />
+                <img
+                  src={img.dataUrl}
+                  alt={img.name}
+                  className="h-full w-full cursor-zoom-in object-cover"
+                />
                 <button
                   type="button"
                   onClick={() => removeImage(img.id)}
@@ -109,7 +116,7 @@ export function Composer({
                 >
                   <X className="h-2.5 w-2.5" />
                 </button>
-              </div>
+              </ImagePreview>
             ))}
           </div>
         )}

--- a/src/renderer/src/components/ImagePreview.tsx
+++ b/src/renderer/src/components/ImagePreview.tsx
@@ -1,0 +1,191 @@
+/**
+ * Hover-to-preview for attachment thumbnails.
+ *
+ * Attachments are stored as bounded data URLs (see lib/images.ts) and rendered
+ * as 36–64px thumbnails, which is far too small to tell one screenshot from
+ * another. Hovering a thumbnail floats the full image beside it so you can see
+ * what you actually attached before it's sent.
+ *
+ * It renders through a portal on purpose: the queue list is a scroll container
+ * (`max-h-52 overflow-y-auto`), so an absolutely-positioned preview would be
+ * clipped by its own row. Fixed coordinates computed from the trigger's rect
+ * escape every ancestor's overflow without needing a positioned parent.
+ *
+ * The geometry lives in lib/anchor.ts so it can be tested without a DOM.
+ */
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '../lib/cn'
+import { place, CHROME_H, type Placement } from '../lib/anchor'
+
+/** Hover intent — long enough that sweeping across a row doesn't flash previews. */
+const OPEN_DELAY = 200
+/**
+ * After one closes, the next opens instantly: once you're clearly scanning
+ * attachments, re-paying the intent delay per thumbnail feels sticky.
+ */
+const CHAIN_WINDOW = 450
+
+/** Shared across instances — "did a preview just close?" is a global question. */
+let lastClosedAt = 0
+
+/**
+ * Natural dimensions per src. The thumbnail already decoded these bytes, but
+ * caching makes repeat hovers synchronous instead of a promise tick late.
+ */
+const dimsCache = new Map<string, { w: number; h: number }>()
+
+function measure(src: string): Promise<{ w: number; h: number } | null> {
+  const hit = dimsCache.get(src)
+  if (hit) return Promise.resolve(hit)
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.onload = () => {
+      const dims = { w: img.naturalWidth, h: img.naturalHeight }
+      if (!dims.w || !dims.h) return resolve(null)
+      dimsCache.set(src, dims)
+      resolve(dims)
+    }
+    img.onerror = () => resolve(null)
+    img.src = src
+  })
+}
+
+/**
+ * Shared look for a hoverable attachment thumbnail: the cursor advertises that
+ * there's more to see, and the border lifts on hover so the trigger reacts
+ * immediately — before the preview's intent delay has elapsed.
+ */
+export const HOVERABLE_THUMB =
+  'cursor-zoom-in border border-border object-cover transition-colors duration-150 hover:border-border-strong'
+
+/**
+ * Wraps a thumbnail: `children` is the trigger (rendered as-is), `src` is the
+ * full image to float on hover.
+ */
+export function ImagePreview({
+  src,
+  name,
+  className,
+  children
+}: {
+  src: string
+  name?: string
+  className?: string
+  children: ReactNode
+}): JSX.Element {
+  const ref = useRef<HTMLSpanElement>(null)
+  const timer = useRef<ReturnType<typeof setTimeout>>()
+  /**
+   * Hover tracked explicitly rather than read back off `:hover`: measuring is
+   * async and the pointer can leave mid-decode. A ref, not state, so the
+   * pending timer sees the current value without re-running an effect.
+   */
+  const inside = useRef(false)
+  const [placement, setPlacement] = useState<Placement | null>(null)
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
+
+  const close = useCallback((): void => {
+    clearTimeout(timer.current)
+    setPlacement((prev) => {
+      if (prev) lastClosedAt = Date.now()
+      return null
+    })
+  }, [])
+
+  const open = useCallback(async (): Promise<void> => {
+    const size = dimsCache.get(src) ?? (await measure(src))
+    // Bail if the image is undecodable, the pointer left during the decode, or
+    // the row unmounted (a queued item can be sent while you're hovering it).
+    if (!size || !inside.current || !ref.current) return
+    const next = place(
+      ref.current.getBoundingClientRect(),
+      size.w,
+      size.h,
+      window.innerWidth,
+      window.innerHeight
+    )
+    // No room anywhere — leave the thumbnail alone rather than cover it.
+    if (!next) return
+    setDims(size)
+    setPlacement(next)
+  }, [src])
+
+  const onEnter = useCallback((): void => {
+    inside.current = true
+    clearTimeout(timer.current)
+    timer.current = setTimeout(
+      () => void open(),
+      Date.now() - lastClosedAt < CHAIN_WINDOW ? 0 : OPEN_DELAY
+    )
+  }, [open])
+
+  const onLeave = useCallback((): void => {
+    inside.current = false
+    close()
+  }, [close])
+
+  // Any layout change invalidates the anchored coordinates. Recomputing on
+  // scroll would fight the pointer (the thumbnail slides out from under it), so
+  // dismiss instead — the hover that opened it is no longer meaningful.
+  useEffect(() => {
+    if (!placement) return
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('resize', close)
+    return () => {
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('resize', close)
+    }
+  }, [placement, close])
+
+  useEffect(() => () => clearTimeout(timer.current), [])
+
+  return (
+    // `inline-flex` lets the wrapper hug its child exactly, so it can stand in
+    // for the thumbnail as a flex item without disturbing any layout — and
+    // unlike `display: contents` it has a real box to measure.
+    <span
+      ref={ref}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      className={cn('inline-flex', className)}
+    >
+      {children}
+      {placement &&
+        createPortal(
+          <div
+            // pointer-events-none: the preview sits in the cursor's path, and a
+            // hover layer that can itself be hovered creates flicker loops.
+            className="animate-pop-in pointer-events-none fixed z-50 overflow-hidden rounded-xl border border-border-strong bg-elevated p-1 shadow-2xl"
+            style={{
+              left: placement.left,
+              top: placement.top,
+              width: placement.width,
+              transformOrigin: placement.origin
+            }}
+          >
+            <img
+              src={src}
+              alt={name ?? 'attachment'}
+              style={{ height: placement.height }}
+              className="block w-full rounded-lg object-contain"
+            />
+            {/* Fixed height — lib/anchor.ts reserves exactly CHROME_H for this
+                strip plus the frame's padding when it positions the box. */}
+            <div
+              style={{ height: CHROME_H - 8 }}
+              className="flex items-center gap-1.5 px-1 text-[10px] text-text-subtle"
+            >
+              {name && <span className="min-w-0 truncate">{name}</span>}
+              {dims && (
+                <span className="ml-auto shrink-0 tabular-nums">
+                  {dims.w}×{dims.h}
+                </span>
+              )}
+            </div>
+          </div>,
+          document.body
+        )}
+    </span>
+  )
+}

--- a/src/renderer/src/components/MessageBubble.tsx
+++ b/src/renderer/src/components/MessageBubble.tsx
@@ -2,6 +2,8 @@ import { User } from 'lucide-react'
 import roxy from '../assets/roxy.png'
 import type { MessagePart, MessageRole } from '@shared/types'
 import { MessageParts } from './MessageParts'
+import { HOVERABLE_THUMB, ImagePreview } from './ImagePreview'
+import { cn } from '../lib/cn'
 
 /** Flatten a turn's text parts down to plain text (for user messages). */
 function partsToText(parts: MessagePart[]): string {
@@ -44,12 +46,15 @@ export function MessageBubble({
             {imageParts.length > 0 && (
               <div className="flex flex-wrap gap-2">
                 {imageParts.map((img, i) => (
-                  <img
-                    key={i}
-                    src={img.dataUrl}
-                    alt={img.name ?? 'pasted image'}
-                    className="max-h-48 max-w-[12rem] rounded-lg border border-border object-cover"
-                  />
+                  // These are object-cover, so a tall screenshot is shown cropped
+                  // — hover floats the whole, uncropped image.
+                  <ImagePreview key={i} src={img.dataUrl} name={img.name}>
+                    <img
+                      src={img.dataUrl}
+                      alt={img.name ?? 'pasted image'}
+                      className={cn(HOVERABLE_THUMB, 'max-h-48 max-w-[12rem] rounded-lg')}
+                    />
+                  </ImagePreview>
                 ))}
               </div>
             )}

--- a/src/renderer/src/components/Queue.tsx
+++ b/src/renderer/src/components/Queue.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { cn } from '../lib/cn'
+import { HOVERABLE_THUMB, ImagePreview } from './ImagePreview'
 
 // ---- Collapsible section context --------------------------------------------
 
@@ -36,7 +37,10 @@ function useQueueSection(): SectionState {
 
 export function Queue({ className, ...props }: HTMLAttributes<HTMLDivElement>): JSX.Element {
   return (
-    <div className={cn('rounded-xl border border-border bg-surface/60 p-1.5', className)} {...props} />
+    <div
+      className={cn('rounded-xl border border-border bg-surface/60 p-1.5', className)}
+      {...props}
+    />
   )
 }
 
@@ -133,9 +137,7 @@ export function QueueSectionContent({
 // ---- List + items ------------------------------------------------------------
 
 export function QueueList({ className, ...props }: HTMLAttributes<HTMLUListElement>): JSX.Element {
-  return (
-    <ul className={cn('flex max-h-52 flex-col gap-1 overflow-y-auto', className)} {...props} />
-  )
+  return <ul className={cn('flex max-h-52 flex-col gap-1 overflow-y-auto', className)} {...props} />
 }
 
 export function QueueItem({ className, ...props }: LiHTMLAttributes<HTMLLIElement>): JSX.Element {
@@ -197,7 +199,10 @@ export function QueueItemDescription({
   )
 }
 
-export function QueueItemActions({ className, ...props }: HTMLAttributes<HTMLDivElement>): JSX.Element {
+export function QueueItemActions({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>): JSX.Element {
   return (
     <div
       className={cn(
@@ -239,16 +244,19 @@ export function QueueItemImage({
   alt = '',
   ...props
 }: ImgHTMLAttributes<HTMLImageElement>): JSX.Element {
+  // A 36px thumbnail can't tell two screenshots apart -- hovering floats the full
+  // image so you can confirm what's actually attached before the turn runs.
   return (
-    <img
-      alt={alt}
-      className={cn('h-9 w-9 rounded-md border border-border object-cover', className)}
-      {...props}
-    />
+    <ImagePreview src={String(props.src ?? '')} name={alt || undefined}>
+      <img alt={alt} className={cn(HOVERABLE_THUMB, 'h-9 w-9 rounded-md', className)} {...props} />
+    </ImagePreview>
   )
 }
 
-export function QueueItemFile({ className, ...props }: HTMLAttributes<HTMLSpanElement>): JSX.Element {
+export function QueueItemFile({
+  className,
+  ...props
+}: HTMLAttributes<HTMLSpanElement>): JSX.Element {
   return (
     <span
       className={cn(

--- a/src/renderer/src/components/QueuedMessage.tsx
+++ b/src/renderer/src/components/QueuedMessage.tsx
@@ -3,6 +3,7 @@ import { Check, ChevronDown, ChevronUp, ImagePlus, Pencil, X } from 'lucide-reac
 import type { QueueItem as QueueItemType } from '@shared/types'
 import { useRoxyStore } from '../lib/store'
 import { imageFilesFrom, readImageFile, type ComposerImage } from '../lib/images'
+import { ImagePreview } from './ImagePreview'
 import {
   QueueItem,
   QueueItemAction,
@@ -151,11 +152,17 @@ export function QueuedMessage({
           {draftImages.length > 0 && (
             <div className="flex flex-wrap gap-1.5 px-2.5 pt-2.5">
               {draftImages.map((img) => (
-                <div
+                <ImagePreview
                   key={img.id}
+                  src={img.dataUrl}
+                  name={img.name}
                   className="group/img relative h-12 w-12 overflow-hidden rounded-md border border-border bg-surface-2"
                 >
-                  <img src={img.dataUrl} alt={img.name} className="h-full w-full object-cover" />
+                  <img
+                    src={img.dataUrl}
+                    alt={img.name}
+                    className="h-full w-full cursor-zoom-in object-cover"
+                  />
                   <button
                     type="button"
                     onClick={() => setDraftImages((prev) => prev.filter((i) => i.id !== img.id))}
@@ -164,7 +171,7 @@ export function QueuedMessage({
                   >
                     <X className="h-2.5 w-2.5" />
                   </button>
-                </div>
+                </ImagePreview>
               ))}
             </div>
           )}

--- a/src/renderer/src/lib/anchor.ts
+++ b/src/renderer/src/lib/anchor.ts
@@ -1,0 +1,157 @@
+/**
+ * Anchored floating-box geometry — pure math, no DOM.
+ *
+ * Given a trigger's rect, an image's natural size, and the viewport, decide
+ * where a preview box should sit. Kept separate from the component (and free of
+ * globals) so the placement rules can be exercised directly; see test/shared.ts.
+ */
+
+/** Space between the trigger and the box. */
+export const GAP = 10
+/** Keep-off distance from the viewport edges. */
+export const MARGIN = 12
+/** Ceilings, so a huge screenshot doesn't swallow the window. */
+export const MAX_W = 560
+export const MAX_H = 520
+/** Upscale ceiling for small images, so a tiny favicon isn't a tiny preview. */
+export const MIN_LONG_EDGE = 240
+/**
+ * Height of everything in the frame that isn't the image: 4px padding top and
+ * bottom plus a fixed 20px caption strip. Positioning has to reserve this
+ * before the box exists, so the caption is pinned to `h-5 leading-5` in the
+ * component — a chrome height that drifts from this constant mispositions it.
+ */
+export const CHROME_H = 28
+/**
+ * A preview only earns its place on screen by showing meaningfully more than the
+ * thumbnail already does — an absolute floor, plus a multiple of the trigger's
+ * own size. Below that, hovering pops a box that's barely a step up while
+ * covering the UI around it; showing nothing is the better answer.
+ */
+const MIN_USEFUL = 100
+const MIN_GROWTH = 1.6
+
+export type Side = 'top' | 'bottom' | 'right' | 'left'
+
+export interface Rect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+  width: number
+  height: number
+}
+
+export interface Placement {
+  left: number
+  top: number
+  width: number
+  height: number
+  side: Side
+  /** transform-origin, so the entrance scales out of the trigger, not the void. */
+  origin: string
+}
+
+const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(v, hi))
+
+/** Largest the image can be drawn inside `availW`×`availH`, or null if it can't. */
+function fit(
+  natW: number,
+  natH: number,
+  availW: number,
+  availH: number,
+  floor: number
+): [number, number] | null {
+  const w = Math.min(availW, MAX_W)
+  const h = Math.min(availH, MAX_H)
+  if (w < floor || h < floor) return null
+  const shrink = Math.min(w / natW, h / natH)
+  // Only upscale genuinely small images, and never past what actually fits.
+  const scale =
+    shrink < 1 ? shrink : Math.min(shrink, Math.max(1, MIN_LONG_EDGE / Math.max(natW, natH)))
+  // Round, then clamp to what's available. Flooring both would visibly distort
+  // extreme ratios — an 80×3000 strip loses 6% of its width to a single floor —
+  // while the clamp keeps the box inside its budget regardless.
+  const outW = Math.min(Math.round(natW * scale), Math.floor(w))
+  const outH = Math.min(Math.round(natH * scale), Math.floor(h))
+  // Judged on the long edge: a panorama is perfectly legible at 400×20 even
+  // though its height never clears the floor, so requiring both would reject it.
+  if (Math.max(outW, outH) < floor) return null
+  return [outW, outH]
+}
+
+/**
+ * Anchor the box to the trigger on whichever side gives the biggest image.
+ *
+ * Trying only above/below isn't enough: a tall screenshot next to a thumbnail in
+ * the middle of a short window fits in neither band, and clamping it into one
+ * anyway covers the very thumbnail you're pointing at. So all four sides are
+ * measured and the roomiest wins, biased toward above/below — those read as the
+ * natural direction and shouldn't be traded away for a marginal size gain.
+ *
+ * Returns null when no side has room: a viewport that small is better served by
+ * the bare thumbnail than by a box sitting on top of it.
+ */
+export function place(
+  rect: Rect,
+  natW: number,
+  natH: number,
+  vw: number,
+  vh: number
+): Placement | null {
+  if (natW <= 0 || natH <= 0) return null
+  // Worth-it floor, relative to the thumbnail you're already looking at.
+  const floor = Math.max(MIN_USEFUL, Math.max(rect.width, rect.height) * MIN_GROWTH)
+  const spanW = vw - MARGIN * 2
+  const spanH = vh - MARGIN * 2 - CHROME_H
+
+  const avail: Record<Side, [number, number]> = {
+    top: [spanW, rect.top - GAP - MARGIN - CHROME_H],
+    bottom: [spanW, vh - rect.bottom - GAP - MARGIN - CHROME_H],
+    right: [vw - rect.right - GAP - MARGIN, spanH],
+    left: [rect.left - GAP - MARGIN, spanH]
+  }
+  // Vertical placements win ties and near-ties (see above).
+  const bias: Record<Side, number> = { top: 1.2, bottom: 1.15, right: 1, left: 1 }
+
+  let best: { side: Side; w: number; h: number } | null = null
+  let bestScore = 0
+  for (const side of ['top', 'bottom', 'right', 'left'] as Side[]) {
+    const got = fit(natW, natH, avail[side][0], avail[side][1], floor)
+    if (!got) continue
+    const score = got[0] * got[1] * bias[side]
+    if (score > bestScore) {
+      bestScore = score
+      best = { side, w: got[0], h: got[1] }
+    }
+  }
+  if (!best) return null
+
+  const { side, w, h } = best
+  const boxH = h + CHROME_H
+  const cx = rect.left + rect.width / 2
+  const cy = rect.top + rect.height / 2
+
+  if (side === 'top' || side === 'bottom') {
+    const left = clamp(cx - w / 2, MARGIN, vw - MARGIN - w)
+    const top = side === 'top' ? rect.top - GAP - boxH : rect.bottom + GAP
+    return {
+      left,
+      top,
+      width: w,
+      height: h,
+      side,
+      origin: `${clamp(cx - left, 0, w)}px ${side === 'top' ? '100%' : '0'}`
+    }
+  }
+  const left = side === 'right' ? rect.right + GAP : rect.left - GAP - w
+  const top = clamp(cy - boxH / 2, MARGIN, vh - MARGIN - boxH)
+  return {
+    left,
+    top,
+    width: w,
+    height: h,
+    side,
+    origin: `${side === 'right' ? '0' : '100%'} ${clamp(cy - top, 0, boxH)}px`
+  }
+}

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -169,6 +169,15 @@ import {
   FORGE_NAMES,
   type PullRequestView
 } from '../src/shared/forge'
+import {
+  place,
+  GAP,
+  MARGIN,
+  MAX_W,
+  MAX_H,
+  CHROME_H,
+  type Rect
+} from '../src/renderer/src/lib/anchor'
 
 let pass = 0
 const fails: string[] = []
@@ -3055,6 +3064,137 @@ async function main(): Promise<void> {
       contextBudgetFor(400_000, 1_000_000) === 400_000
   )
 
+  // ---- attachment hover-preview geometry (renderer/lib/anchor) ----------------
+  // A thumbnail's floating preview must never leave the viewport and never cover
+  // the thumbnail that opened it, at any window size or aspect ratio.
+  const thumb = (left: number, top: number, size = 36): Rect => ({
+    left,
+    top,
+    right: left + size,
+    bottom: top + size,
+    width: size,
+    height: size
+  })
+  const boxOf = (p: NonNullable<ReturnType<typeof place>>) => ({
+    left: p.left,
+    top: p.top,
+    right: p.left + p.width,
+    bottom: p.top + p.height + CHROME_H
+  })
+  const disjoint = (a: ReturnType<typeof boxOf>, t: Rect): boolean =>
+    a.right <= t.left || a.left >= t.right || a.bottom <= t.top || a.top >= t.bottom
+
+  // Sweep a thumbnail across a grid of positions, viewports, and image shapes.
+  const shapes: Array<[number, number, string]> = [
+    [1568, 720, 'wide'],
+    [600, 1400, 'tall'],
+    [900, 900, 'square'],
+    [64, 64, 'tiny'],
+    [3000, 80, 'panorama'],
+    [80, 3000, 'strip']
+  ]
+  const viewports: Array<[number, number]> = [
+    [1280, 780],
+    [1920, 1080],
+    [900, 600],
+    [700, 420],
+    [420, 300]
+  ]
+  let escapes = 0
+  let overlaps = 0
+  let oversize = 0
+  let placements = 0
+  let nulls = 0
+  for (const [vw, vh] of viewports) {
+    for (let fx = 0.02; fx < 1; fx += 0.16) {
+      for (let fy = 0.02; fy < 1; fy += 0.16) {
+        const t = thumb(Math.round(fx * (vw - 36)), Math.round(fy * (vh - 36)))
+        for (const [iw, ih] of shapes) {
+          const p = place(t, iw, ih, vw, vh)
+          if (!p) {
+            nulls++
+            continue
+          }
+          placements++
+          const b = boxOf(p)
+          if (b.left < MARGIN || b.top < MARGIN || b.right > vw - MARGIN || b.bottom > vh - MARGIN)
+            escapes++
+          if (!disjoint(b, t)) overlaps++
+          if (p.width > MAX_W || p.height > MAX_H) oversize++
+        }
+      }
+    }
+  }
+  check(`anchor: ${placements} placements produced (grid is non-trivial)`, placements > 400)
+  check('anchor: never escapes the viewport margins', escapes === 0, `${escapes} escaped`)
+  check('anchor: never covers its own trigger', overlaps === 0, `${overlaps} overlapped`)
+  check('anchor: respects the size ceilings', oversize === 0, `${oversize} oversized`)
+
+  // Aspect ratio must survive the fit, or screenshots read as distorted.
+  const ratioOk = shapes.every(([iw, ih]) => {
+    const p = place(thumb(600, 400), iw, ih, 1280, 780)
+    if (!p) return true
+    return Math.abs(p.width / p.height - iw / ih) < 0.04 * (iw / ih)
+  })
+  check('anchor: preserves aspect ratio', ratioOk)
+
+  // Above is the natural direction when there is room for it.
+  const roomy = place(thumb(600, 700), 900, 400, 1280, 900)
+  check('anchor: prefers above when it fits', roomy?.side === 'top', String(roomy?.side))
+
+  // A thumbnail pinned to the top has to flip below.
+  const atTop = place(thumb(600, 4), 900, 400, 1280, 900)
+  check('anchor: flips below near the top edge', atTop?.side === 'bottom', String(atTop?.side))
+
+  // A tall image beside a mid-height thumbnail fits in neither band -> sideways.
+  const tallMid = place(thumb(600, 380), 600, 1400, 1280, 780)
+  check(
+    'anchor: goes sideways when neither band fits',
+    tallMid !== null && (tallMid.side === 'left' || tallMid.side === 'right'),
+    String(tallMid?.side)
+  )
+
+  // Small images are enlarged to a legible size, not shown at 64px.
+  const upscaled = place(thumb(600, 700), 64, 64, 1280, 900)
+  check('anchor: upscales tiny images', (upscaled?.width ?? 0) >= 200, String(upscaled?.width))
+
+  // ...but never past the space actually available.
+  const tightUp = place(thumb(300, 150, 20), 64, 64, 360, 300)
+  check(
+    'anchor: upscaling still respects the viewport',
+    tightUp === null || boxOf(tightUp).right <= 360 - MARGIN,
+    JSON.stringify(tightUp)
+  )
+
+  // Degenerate inputs must not produce NaN coordinates or a box at all.
+  check('anchor: rejects zero-sized images', place(thumb(100, 100), 0, 0, 1280, 800) === null)
+  check('anchor: gives up in a tiny viewport', place(thumb(20, 20), 900, 900, 120, 100) === null)
+
+  // Every preview it does produce must be a real step up from the thumbnail --
+  // otherwise it covers the UI to show you what you could already see.
+  let puny = 0
+  for (const [vw, vh] of viewports) {
+    for (let fx = 0.02; fx < 1; fx += 0.16) {
+      for (let fy = 0.02; fy < 1; fy += 0.16) {
+        for (const size of [36, 48, 64, 192]) {
+          const t = thumb(Math.round(fx * (vw - size)), Math.round(fy * (vh - size)), size)
+          for (const [iw, ih] of shapes) {
+            const p = place(t, iw, ih, vw, vh)
+            if (p && Math.max(p.width, p.height) < size * 1.5) puny++
+          }
+        }
+      }
+    }
+  }
+  check('anchor: never opens a preview barely bigger than its thumbnail', puny === 0, `${puny}`)
+
+  // The gap is real: the box shouldn't touch the thumbnail.
+  const gapped = place(thumb(600, 700), 900, 400, 1280, 900)
+  check(
+    'anchor: leaves a gap above the trigger',
+    gapped !== null && Math.round(700 - boxOf(gapped).bottom) === GAP,
+    gapped ? String(700 - boxOf(gapped).bottom) : 'null'
+  )
   if (fails.length) {
     console.error(`\nSHARED FAILED \u2014 ${fails.length} failing: ${fails.join(', ')}`)
     process.exit(1)


### PR DESCRIPTION
## What

Attachment thumbnails render at 36-64px, which is too small to tell one screenshot from another -- you can't confirm what you actually attached until after the turn has already run. Hovering a thumbnail now floats the full image beside it, captioned with the filename and pixel dimensions.

Wired into all four surfaces that show attachments:

| Surface | Site |
| --- | --- |
| Queue rows | `Queue.tsx` (`QueueItemImage`) |
| Queue edit mode | `QueuedMessage.tsx` |
| Composer | `Composer.tsx` |
| User message bubbles | `MessageBubble.tsx` |

## How

**`components/ImagePreview.tsx`** wraps a thumbnail and owns the interaction:

- Renders through a **portal**, deliberately. The queue list is a `max-h-52 overflow-y-auto` scroll container, so an absolutely-positioned preview gets clipped by its own row. Fixed coordinates derived from the trigger's rect escape every ancestor's overflow without needing a positioned parent.
- **200ms hover intent**, so sweeping across a queue row doesn't strobe previews -- but the next one opens instantly if another closed within 450ms. Once you are clearly scanning attachments, re-paying the delay per thumbnail feels sticky.
- `pointer-events-none` on the floating box: it sits in the cursor's path, and a hover layer that can itself be hovered creates flicker loops.
- Dismisses on scroll/resize rather than repositioning -- the thumbnail slides out from under the pointer anyway, so the hover that opened it is no longer meaningful.

**`lib/anchor.ts`** holds the placement math as pure functions, with no DOM dependency, so the rules can be tested directly. It measures all four sides and takes the roomiest, biased toward above/below.

Trying only above/below is not enough: a tall screenshot beside a mid-height thumbnail fits in neither band, and clamping it into one covers the very thumbnail you are pointing at.

Two deliberate refusals, both returning `null` rather than rendering:

- **No room anywhere** -> show nothing, instead of a cramped box over the UI.
- **Preview under 1.6x the thumbnail** -> covering the interface to show what you can already see is a net loss.

## Testing

Added 14 checks to `test/shared.ts`, sweeping **1470 generated placements** across 5 viewports x 6 aspect ratios x 4 thumbnail sizes. They assert the box never escapes the viewport margins, never covers its own trigger, respects the size ceilings, and preserves aspect ratio.

I built a throwaway Vite harness to exercise this against a real DOM first, and **the first run failed 10 of 22 cases**. Three real bugs came out of it:

1. **Clamped over its own trigger** -- the original above/below-only logic had nowhere to put a tall image and dragged it on top of the thumbnail. This is what drove the four-side rewrite.
2. **`CHROME_H` understated the caption height** (26 vs 28), pushing boxes off-screen. The caption is now pinned to a fixed height that matches the constant, with comments on both sides noting the coupling.
3. **`Math.floor` distorted extreme aspect ratios** by ~6% (an 80x3000 strip lost visible width). Now rounds, then clamps to the available budget.

The harness was deleted; only the two new source files and the test additions remain.

- `npm run typecheck` -- clean (node + web)
- `npm run smoke:shared` -- 528 checks passing
- `npx electron-vite build` -- builds
- `prettier --check` -- clean