### PR TITLE
Reveal sidebar subagent count on hover

### DIFF
--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -687,10 +687,18 @@ export function Sidebar(): JSX.Element {
                                         liveSubs > 0 ? ` (${liveSubs} working)` : ''
                                       } — tap to ${subsOpen ? 'hide' : 'view'}`}
                                       className={cn(
-                                        'flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums transition-colors',
+                                        'flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums transition-[opacity,color,background-color]',
                                         liveSubs > 0
                                           ? 'bg-accent/10 text-accent'
-                                          : 'bg-surface-2 text-text-subtle hover:text-text'
+                                          : 'bg-surface-2 text-text-subtle hover:text-text',
+                                        // Idle and collapsed, this pill is just noise parked on
+                                        // every row - so reveal it on hover, like the delete button
+                                        // beside it. It stays pinned only when it carries state:
+                                        // a subagent is working, or the list is expanded.
+                                        // Fading opacity (not unmounting) keeps the row stable.
+                                        liveSubs > 0 || subsOpen
+                                          ? 'opacity-100'
+                                          : 'opacity-0 focus-visible:opacity-100 group-hover:opacity-100'
                                       )}
                                     >
                                       {subs.length}


### PR DESCRIPTION
The subagent count pill sat pinned on every session row that had ever spawned a subagent, so an idle session carried a permanent grey badge next to its title for no reason - visually noisy, and it read as a live indicator when nothing was running.

### What changed

`src/renderer/src/components/Sidebar.tsx`

- The pill now **fades in on row hover** (and on keyboard focus), matching the delete button already on that row.
- It **stays pinned only when it carries state**: a subagent is actually running (accent-coloured pill), or the subagent list is expanded.
- Animates `opacity` instead of mounting/unmounting, so the row does not reflow or shift text when you hover across the list.

### Notes

I considered also pinning the pill on the active session row, but dropped it: the delete button on that same row is hover-only regardless of active state, so pinning would have just moved the static noise onto whichever session you happen to be in.

### Verification

- `tsc --noEmit -p tsconfig.web.json` clean
- `prettier --check` clean