### PR TITLE
ui(composer): drop the pill chrome from the footer controls

### DIFF
--- a/src/renderer/src/components/Composer.tsx
+++ b/src/renderer/src/components/Composer.tsx
@@ -135,14 +135,19 @@ export function Composer({
           className="block max-h-44 w-full resize-none bg-transparent px-4 pt-3 text-sm text-text outline-none placeholder:text-text-subtle"
         />
         <div className="flex items-center justify-between gap-2 px-2.5 pb-2 pt-1.5">
-          <div className="flex items-center gap-1.5">
+          {/* Chrome-less controls, matching the workstream strip below. Two
+              things do the work the borders used to: gap-1 (further apart and
+              five bare labels just scatter across the row) and px-1.5 on every
+              control, which against the row's px-2.5 puts each label's first
+              glyph exactly on the textarea's px-4 text column. */}
+          <div className="flex items-center gap-1">
             <button
               type="button"
               onClick={() => fileRef.current?.click()}
               title="Attach images"
-              className="press-scale flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-border bg-surface text-text-muted hover:border-border-strong hover:text-text"
+              className="press-scale flex h-6 shrink-0 items-center justify-center rounded-md px-1.5 text-text-muted hover:bg-white/5 hover:text-text"
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-3.5 w-3.5" />
             </button>
             <ModelPicker />
             <AgentPicker />

--- a/src/renderer/src/components/InferenceControls.tsx
+++ b/src/renderer/src/components/InferenceControls.tsx
@@ -75,8 +75,20 @@ function useActiveModelInfo(): ModelInfo | undefined {
   return modelCatalog[activeProvider.id]?.find((m) => m.id === config.model)
 }
 
-const triggerClass =
-  'press-scale flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1 text-xs text-text-muted hover:border-border-strong hover:text-text'
+/**
+ * The shared look for every control in the composer's footer row.
+ *
+ * Deliberately chrome-less. A bordered, filled pill per control turned one row
+ * into five boxed objects competing with the caret directly above them — and
+ * `bg-surface` on `bg-surface-2` is a 7-point step, just enough to read as a
+ * seam without ever looking intentional. These are settings you set once and
+ * then glance at, so they get the same grammar as the workstream strip below:
+ * bare label, background only on hover.
+ *
+ * Exported so the model picker (own file, same row) cannot drift from it.
+ */
+export const triggerClass =
+  'press-scale flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs text-text-muted hover:bg-white/5 hover:text-text'
 const popoverClass =
   'animate-pop-in absolute bottom-full left-0 z-50 mb-2 w-72 origin-bottom-left overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl'
 
@@ -470,10 +482,10 @@ export function ContextMeter(): JSX.Element {
         </div>
       )}
 
-      <div className="flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1 text-xs text-text-muted transition-colors hover:border-border-strong hover:text-text">
+      <div className="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs text-text-muted transition-colors hover:bg-white/5 hover:text-text">
         {total ? (
           <>
-            <span className="h-1 w-8 overflow-hidden rounded-full bg-surface-2">
+            <span className="h-1 w-8 overflow-hidden rounded-full bg-white/10">
               <span
                 className={cn(
                   'block h-full rounded-full',

--- a/src/renderer/src/components/ModelPicker.tsx
+++ b/src/renderer/src/components/ModelPicker.tsx
@@ -3,6 +3,7 @@ import { Brain, Check, ChevronsUpDown, Search, Wrench } from 'lucide-react'
 import { useRoxyStore } from '../lib/store'
 import { resolveSessionConfig } from '@shared/session-config'
 import { ProviderLogo } from '../lib/providerLogos'
+import { triggerClass } from './InferenceControls'
 import { cn } from '../lib/cn'
 
 /**
@@ -80,11 +81,7 @@ export function ModelPicker(): JSX.Element {
 
   return (
     <div ref={rootRef} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="press-scale flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1 text-xs text-text-muted hover:border-border-strong hover:text-text"
-      >
+      <button type="button" onClick={() => setOpen((o) => !o)} className={triggerClass}>
         {activeProvider && (
           <ProviderLogo id={activeProvider.id} name={activeProvider.name} size={14} />
         )}


### PR DESCRIPTION
The composer footer and the workstream strip sit directly on top of each other and say the same kind of thing -- settings you pick once and then read at a glance -- but they said it in two different languages. The strip is bare labels that shade on hover; the footer was five bordered, filled pills, so one row of preferences read as five boxed objects stacked under the caret they belong to.

The fill was the weaker half of it. `bg-surface` on the composer's `bg-surface-2` is a 7-point step: enough to catch as a seam, never enough to look deliberate. So the controls adopt the strip's grammar -- `rounded-md px-1.5 py-1`, background on hover only.

triggerClass is exported now. ModelPicker lives in its own file and had a hand-copied duplicate of the old pill string; that is exactly how the two drift apart again.

Two knock-on fixes, both caused by removing the borders rather than found along the way:

The context meter's track was `bg-surface-2`, which is the composer card's own colour -- it only ever read because the pill's darker fill sat behind it. Now `bg-white/10`, since at 0% the empty groove IS the whole control.

The attach button gets `px-1.5` instead of a fixed square, so its glyph lands on the same column as the textarea text above it. The borders used to imply that column; without them, a few pixels of drift is the only thing the eye has left to catch on. Its icon drops 16px -> 14px too -- it was the last oversized glyph in a row of 14px ones.

Verified by stubbing the preload bridge and rendering the composer and the strip together in a browser tab, which is the only way to see the seam between two components that are styled in separate files.