### PR TITLE
fix(ui): keep the Switch knob inside its track

### DIFF
--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -117,15 +117,21 @@ export function Switch({
       disabled={disabled}
       onClick={() => onChange?.(!checked)}
       className={cn(
-        'relative h-5 w-9 shrink-0 rounded-full transition-colors duration-150',
-        checked ? 'bg-accent' : 'border border-border bg-surface-2',
+        // Flex + padding centers the knob, rather than absolute offsets. The
+        // knob had no `left`, so `absolute` anchored it to its static position
+        // -- the middle of the button, via the UA's text-align: center -- and
+        // translate-x-4 then pushed it clean off the track. The 1px border also
+        // existed only while unchecked, so the track resized on every toggle;
+        // an inset ring paints the same hairline without affecting layout.
+        'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full p-0.5 outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-accent/40',
+        checked ? 'bg-accent' : 'bg-surface-2 inset-ring-1 inset-ring-border',
         disabled && 'cursor-not-allowed opacity-40'
       )}
     >
       <span
         className={cn(
-          'absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]',
-          checked ? 'translate-x-4' : 'translate-x-0.5'
+          'h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200 ease-drawer',
+          checked ? 'translate-x-4' : 'translate-x-0'
         )}
       />
     </button>


### PR DESCRIPTION
## What

The toggle knob rendered **outside** its track — it sat 14px past the right edge whenever the switch was on.

## Root cause

Not a magic-number tweak — the positioning model was wrong.

The knob was `absolute top-0.5` with **no `left`**. An absolutely-positioned element with no inset resolves to its *static position*, and because buttons inherit the UA's `text-align: center`, that static position was the **middle of the track**, not its left edge. `translate-x-4` therefore measured from 18px instead of 0.

Measured on the component itself (`getBoundingClientRect`, gaps between knob and track edges):

```
before  on:  L=34.00  R=-14.00  T=2.00  B=2.00   ← 14px outside the track
before  off: L=20.00  R=0.00    T=3.00  B=1.00
```

Those vertical numbers exposed a **second bug**: the 1px `border` was applied only in the unchecked state, so the padding box shifted and the knob hopped 1px vertically on every toggle.

## Fix

- Center the knob through layout — `inline-flex` + `items-center` + `p-0.5` — so the inset is derived rather than hardcoded.
- Replace the state-dependent `border` with `inset-ring-1`: identical hairline, painted as a shadow, so it costs no layout and both states stay the same size.
- Swap the inline `ease-[cubic-bezier(0.32,0.72,0,1)]` for `ease-drawer`, the same curve already registered in the theme (`main.css`).
- Add a `focus-visible` ring — this is a keyboard-reachable control that previously had no focus affordance.

```
after   on:  L=18.00  R=2.00   T=2.00  B=2.00
after   off: L=2.00   R=18.00  T=2.00  B=2.00   ← symmetric, tracks identical
```

## Testing

Mounted the real `Switch` under the repo's actual Tailwind config and read `getBoundingClientRect` across all five states (on / off / disabled-on / disabled-off / interactive), plus a live toggle to confirm the transition. Verified `ease-drawer` and `inset-ring-border` compile to real CSS rather than being silently dropped.

`npm run typecheck` passes.

## Scope

`Switch` is shared, so this fixes the same visual bug in all four call sites: `McpServers`, `Integrations`, `Settings`, and the onboarding `IntegrationsStep`.

## Note for the reviewer

`prettier --check src/renderer/src/components/ui.tsx` **already failed on `main`** before this branch — Prettier 3.8.4 wants to rewrap the unrelated `Textarea` generic. I deliberately reverted that reformat to keep this diff focused, so `format:check` stays red for that pre-existing reason. Worth a separate cleanup commit.
