### PR TITLE
Keep anchored popovers inside the window

### DIFF
--- a/src/renderer/src/components/InferenceControls.tsx
+++ b/src/renderer/src/components/InferenceControls.tsx
@@ -10,16 +10,28 @@ import {
   resolveSessionConfig,
   type SessionConfig
 } from '@shared/session-config'
+import { useMenuAnchor } from '../lib/useMenuAnchor'
 import { cn } from '../lib/cn'
 
-/** Close-on-outside-click / Escape for a small popover. */
-function usePopover(): {
+/**
+ * Close-on-outside-click / Escape for a small popover, plus the geometry that
+ * keeps it inside the window.
+ *
+ * These popovers open upward from the composer footer, which is a left-aligned
+ * row inside a centered column — so the further right a control sits, the more
+ * of its fixed-width menu hangs off the edge. The app root is `overflow:
+ * hidden`, so "hangs off" means "is silently cut". `width` is the menu's width
+ * in px and must match the class it renders with.
+ */
+function usePopover(width: number): {
   open: boolean
   setOpen: (v: boolean) => void
   ref: React.RefObject<HTMLDivElement>
+  anchor: React.CSSProperties
 } {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const anchor = useMenuAnchor(ref, open, width, { gap: 8 })
   useEffect(() => {
     if (!open) return
     const onClick = (e: MouseEvent): void => {
@@ -35,7 +47,7 @@ function usePopover(): {
       document.removeEventListener('keydown', onKey)
     }
   }, [open])
-  return { open, setOpen, ref }
+  return { open, setOpen, ref, anchor }
 }
 
 /**
@@ -77,8 +89,17 @@ function useActiveModelInfo(): ModelInfo | undefined {
 
 const triggerClass =
   'press-scale flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1 text-xs text-text-muted hover:border-border-strong hover:text-text'
+/**
+ * Width and horizontal offset are supplied by `usePopover`'s anchor, not by
+ * classes — a fixed `left-0` is exactly what pushes these off the window edge.
+ * `flex-col` + `overflow-y-auto` let the `maxHeight` the anchor computes turn a
+ * tall list into a scrolling one instead of one that runs off the top.
+ */
 const popoverClass =
-  'animate-pop-in absolute bottom-full left-0 z-50 mb-2 w-72 origin-bottom-left overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl'
+  'animate-pop-in absolute bottom-full z-50 mb-2 flex flex-col overflow-y-auto rounded-xl border border-border bg-elevated shadow-2xl origin-bottom-left'
+/** Menu widths in px, matching what each picker renders. */
+const POPOVER_W = 288
+const AGENT_POPOVER_W = 256
 
 // ---- Thinking effort ---------------------------------------------------------
 
@@ -94,7 +115,7 @@ export function ThinkingPicker(): JSX.Element | null {
   const info = useActiveModelInfo()
   const config = useSessionConfig()
   const setReasoningEffort = useRoxyStore((s) => s.setReasoningEffort)
-  const { open, setOpen, ref } = usePopover()
+  const { open, setOpen, ref, anchor } = usePopover(POPOVER_W)
 
   if (!info?.reasoning) return null
   const current = config.reasoningEffort
@@ -112,8 +133,8 @@ export function ThinkingPicker(): JSX.Element | null {
         <span>{currentLabel}</span>
       </button>
       {open && (
-        <div className={popoverClass}>
-          <div className="border-b border-border px-3 py-2 text-[11px] font-medium text-text-subtle">
+        <div className={popoverClass} style={anchor}>
+          <div className="shrink-0 border-b border-border px-3 py-2 text-[11px] font-medium text-text-subtle">
             Thinking Effort
           </div>
           <div className="py-1">
@@ -143,7 +164,7 @@ export function ThinkingPicker(): JSX.Element | null {
               )
             })}
           </div>
-          <div className="border-t border-border px-3 py-1.5 text-[11px] text-text-subtle">
+          <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-text-subtle">
             Higher levels of thinking may increase cost.
           </div>
         </div>
@@ -168,7 +189,7 @@ const AGENT_TAGLINE: Record<string, string> = {
 export function AgentPicker(): JSX.Element {
   const activeAgentId = useRoxyStore((s) => s.activeAgentId)
   const setActiveAgent = useRoxyStore((s) => s.setActiveAgent)
-  const { open, setOpen, ref } = usePopover()
+  const { open, setOpen, ref, anchor } = usePopover(AGENT_POPOVER_W)
 
   const active = getAgent(activeAgentId) ?? getAgent(DEFAULT_AGENT_ID)!
 
@@ -184,7 +205,7 @@ export function AgentPicker(): JSX.Element {
         <span>{active.name}</span>
       </button>
       {open && (
-        <div className={cn(popoverClass, 'w-64')}>
+        <div className={popoverClass} style={anchor}>
           <div className="p-1">
             {PRIMARY_AGENTS.map((a) => {
               const selected = a.id === active.id
@@ -242,7 +263,7 @@ export function ContextPicker(): JSX.Element | null {
   const info = useActiveModelInfo()
   const config = useSessionConfig()
   const setContextLimit = useRoxyStore((s) => s.setContextLimit)
-  const { open, setOpen, ref } = usePopover()
+  const { open, setOpen, ref, anchor } = usePopover(POPOVER_W)
 
   const max = info ? effectiveContextMax(info) : 0
   if (!max) return null
@@ -261,8 +282,8 @@ export function ContextPicker(): JSX.Element | null {
         <span>{formatTokens(current)}</span>
       </button>
       {open && (
-        <div className={popoverClass}>
-          <div className="border-b border-border px-3 py-2 text-[11px] font-medium text-text-subtle">
+        <div className={popoverClass} style={anchor}>
+          <div className="shrink-0 border-b border-border px-3 py-2 text-[11px] font-medium text-text-subtle">
             Context Size
           </div>
           <div className="py-1">
@@ -296,7 +317,7 @@ export function ContextPicker(): JSX.Element | null {
               )
             })}
           </div>
-          <div className="border-t border-border px-3 py-1.5 text-[11px] text-text-subtle">
+          <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-text-subtle">
             Larger context may increase cost.
           </div>
         </div>
@@ -332,6 +353,9 @@ export function ContextMeter(): JSX.Element {
   const compactConversation = useRoxyStore((s) => s.compactConversation)
   const compacting = useRoxyStore((s) => (activeChatId ? !!s.compactingChats[activeChatId] : false))
   const [open, setOpen] = useState(false)
+  // The rightmost control in the footer, so the most exposed to the window edge.
+  const ref = useRef<HTMLDivElement>(null)
+  const anchor = useMenuAnchor(ref, open, POPOVER_W)
 
   const chat = chats.find((c) => c.id === activeChatId)
   // Load the workspace's instruction files so systemTokens counts them; the
@@ -397,13 +421,14 @@ export function ContextMeter(): JSX.Element {
 
   return (
     <div
+      ref={ref}
       className="relative"
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
     >
       {open && (
-        <div className="absolute bottom-full left-0 z-50 w-72 pb-1.5">
-          <div className="animate-pop-in origin-bottom-left overflow-hidden rounded-xl border border-border bg-elevated p-3 shadow-2xl">
+        <div className="absolute bottom-full z-50 flex flex-col pb-1.5" style={anchor}>
+          <div className="animate-pop-in min-h-0 origin-bottom-left overflow-y-auto rounded-xl border border-border bg-elevated p-3 shadow-2xl">
             <div className="mb-1.5 text-xs font-medium text-text">Context Window</div>
             <div className="mb-1 flex items-baseline justify-between text-[11px] text-text-subtle">
               <span className="tabular-nums">

--- a/src/renderer/src/components/ModelPicker.tsx
+++ b/src/renderer/src/components/ModelPicker.tsx
@@ -3,6 +3,7 @@ import { Brain, Check, ChevronsUpDown, Search, Wrench } from 'lucide-react'
 import { useRoxyStore } from '../lib/store'
 import { resolveSessionConfig } from '@shared/session-config'
 import { ProviderLogo } from '../lib/providerLogos'
+import { useMenuAnchor } from '../lib/useMenuAnchor'
 import { cn } from '../lib/cn'
 
 /**
@@ -10,6 +11,8 @@ import { cn } from '../lib/cn'
  * trigger, and a popover grouped by every connected provider (with its icon)
  * listing the real models models.dev knows about, with reasoning/tools badges.
  */
+const MENU_W = 320
+
 export function ModelPicker(): JSX.Element {
   const providers = useRoxyStore((s) => s.providers)
   const settings = useRoxyStore((s) => s.settings)
@@ -22,6 +25,9 @@ export function ModelPicker(): JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const rootRef = useRef<HTMLDivElement>(null)
+  // Leftmost control, so it only clips in a narrow window — but it clips the
+  // same way, and one rule for all of them beats a special case.
+  const anchor = useMenuAnchor(rootRef, open, MENU_W, { gap: 8 })
 
   // The model shown is the OPEN SESSION's, not a global one: two sessions can
   // sit on different models at once, and each remembers its own across
@@ -93,8 +99,11 @@ export function ModelPicker(): JSX.Element {
       </button>
 
       {open && (
-        <div className="animate-pop-in absolute bottom-full left-0 z-50 mb-2 w-80 origin-bottom-left overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl">
-          <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <div
+          className="animate-pop-in absolute bottom-full z-50 mb-2 flex flex-col overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl origin-bottom-left"
+          style={anchor}
+        >
+          <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
             <Search className="h-3.5 w-3.5 shrink-0 text-text-subtle" />
             <input
               autoFocus
@@ -104,7 +113,7 @@ export function ModelPicker(): JSX.Element {
               className="w-full bg-transparent text-xs text-text outline-none placeholder:text-text-subtle"
             />
           </div>
-          <div className="max-h-80 overflow-y-auto py-1">
+          <div className="min-h-0 flex-1 overflow-y-auto py-1">
             {loading && <div className="px-3 py-3 text-xs text-text-subtle">Loading models…</div>}
             {!loading &&
               providers.map((p) => {

--- a/src/renderer/src/components/ServicesSegment.tsx
+++ b/src/renderer/src/components/ServicesSegment.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react'
+import { useMenuAnchor } from '../lib/useMenuAnchor'
 import { ExternalLink, Play, RotateCw, ScrollText, Square, Terminal } from 'lucide-react'
 import type { ServiceView } from '@shared/api'
 import { isServiceFailure, serviceStatusLabel, servicesSummary } from '@shared/services'
@@ -40,6 +41,12 @@ const POLL_MS = 2_000
 const IDLE_POLL_MS = 10_000
 /** Log refresh while a log pane is open — faster, since it's the focus. */
 const LOG_POLL_MS = 1_000
+/**
+ * Menu width, in px rather than a Tailwind class because the anchoring math
+ * needs the number. Wider than the workstream menu: these rows carry a full
+ * shell command plus a port, a status and four actions.
+ */
+const MENU_W = 416
 
 /**
  * Keeps the store's service list warm and reports whether there is anything to
@@ -78,6 +85,9 @@ export function ServicesSegment({
   const [open, setOpen] = useState(false)
   const [logsFor, setLogsFor] = useState<string | null>(null)
   const ref = useRef<HTMLDivElement>(null)
+  // The widest menu in the strip, on the segment that sits furthest right — so
+  // it is the first one to run off the window edge if left unclamped.
+  const anchor = useMenuAnchor(ref, open, MENU_W)
 
   // While the popover is open, poll fast regardless of state: the user is
   // watching, and an install that finishes should say so immediately.
@@ -119,6 +129,7 @@ export function ServicesSegment({
           services={services}
           sessionId={sessionId}
           logsFor={logsFor}
+          style={anchor}
           onToggleLogs={(id) => setLogsFor((cur) => (cur === id ? null : id))}
         />
       )}
@@ -154,27 +165,37 @@ function ServicesMenu({
   services,
   sessionId,
   logsFor,
-  onToggleLogs
+  onToggleLogs,
+  style
 }: {
   services: ServiceView[]
   sessionId: string
   logsFor: string | null
   onToggleLogs: (id: string) => void
+  /** Width + edge-clamped offset + height cap, from useMenuAnchor. */
+  style: CSSProperties
 }): JSX.Element {
   return (
-    // Wider than the workstream menu: these rows carry a full shell command.
-    <div className="absolute bottom-full left-0 z-50 w-[26rem] pb-1.5">
-      <div className="overflow-hidden rounded-xl border border-border bg-elevated py-1 shadow-2xl">
-        <div className="px-3 py-1 text-[11px] font-medium text-text-muted">Processes</div>
-        {services.map((svc) => (
-          <ServiceRow
-            key={svc.id}
-            service={svc}
-            sessionId={sessionId}
-            logsOpen={logsFor === svc.id}
-            onToggleLogs={() => onToggleLogs(svc.id)}
-          />
-        ))}
+    // `left` and `maxHeight` come from the anchor rather than from classes: a
+    // fixed `left-0` on a trigger this far right sends the menu off the window,
+    // and there is no scroll container to rescue it.
+    <div className="absolute bottom-full z-50 flex flex-col pb-1.5" style={style}>
+      <div className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-elevated py-1 shadow-2xl">
+        <div className="shrink-0 px-3 py-1 text-[11px] font-medium text-text-muted">Processes</div>
+        {/* Scrolls instead of growing past the top of the window: a worktree
+            setup can leave several processes behind, and the header has to stay
+            on screen or the list loses its label. */}
+        <div className="min-h-0 overflow-y-auto">
+          {services.map((svc) => (
+            <ServiceRow
+              key={svc.id}
+              service={svc}
+              sessionId={sessionId}
+              logsOpen={logsFor === svc.id}
+              onToggleLogs={() => onToggleLogs(svc.id)}
+            />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import type { LifecycleAction, LifecycleTone, ForgeKind } from '@shared/forge'
 import { FORGE_NAMES, relativeAge } from '@shared/forge'
 import { api } from '../lib/api'
@@ -8,6 +8,7 @@ import { useRoxyStore } from '../lib/store'
 import { workstreamStripView, statusKeyForSession } from '@shared/workstream'
 import { branchNameError } from '@shared/branch'
 import { ServicesSegment, useServices } from './ServicesSegment'
+import { useMenuAnchor } from '../lib/useMenuAnchor'
 import { cn } from '../lib/cn'
 
 /**
@@ -27,6 +28,16 @@ import { cn } from '../lib/cn'
 
 /** How often to re-poll git status while a session is on screen. */
 const POLL_MS = 5_000
+
+/**
+ * Menu widths in px, not Tailwind classes, because `useMenuAnchor` needs the
+ * number to keep each menu inside the window. The strip is a centered row whose
+ * segments can sit anywhere across it, so every menu here is one narrow window
+ * away from hanging off an edge — the numbers must match the rendered widths.
+ */
+const WORKSTREAM_MENU_W = 288
+const FORGE_PANEL_W = 320
+const HOST_MENU_W = 224
 
 export function WorkstreamStrip(): JSX.Element | null {
   const chats = useRoxyStore((s) => s.chats)
@@ -165,6 +176,7 @@ function LifecycleChip({
   const forgeStatus = useRoxyStore((s) => s.forgeStatus)
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const anchor = useMenuAnchor(ref, open, FORGE_PANEL_W, { align: 'end' })
 
   useEffect(() => {
     if (!open) return
@@ -197,7 +209,12 @@ function LifecycleChip({
   return (
     <div className="relative" ref={ref}>
       {open && (
-        <ForgePanel ownerId={ownerId} statusKey={statusKey} onClose={() => setOpen(false)} />
+        <ForgePanel
+          ownerId={ownerId}
+          statusKey={statusKey}
+          style={anchor}
+          onClose={() => setOpen(false)}
+        />
       )}
       <button
         type="button"
@@ -222,6 +239,8 @@ function LifecycleChip({
  */
 function UnknownHostChip({ host }: { host: string }): JSX.Element {
   const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const anchor = useMenuAnchor(ref, open, HOST_MENU_W, { align: 'end' })
   const refreshGitStatus = useRoxyStore((s) => s.refreshGitStatus)
   const activeChatId = useRoxyStore((s) => s.activeChatId)
 
@@ -232,10 +251,10 @@ function UnknownHostChip({ host }: { host: string }): JSX.Element {
   }
 
   return (
-    <div className="relative">
+    <div className="relative" ref={ref}>
       {open && (
-        <div className="absolute bottom-full right-0 z-50 w-56 pb-1.5">
-          <div className="overflow-hidden rounded-xl border border-border bg-elevated py-1 shadow-2xl">
+        <div className="absolute bottom-full z-50 flex flex-col pb-1.5" style={anchor}>
+          <div className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-border bg-elevated py-1 shadow-2xl">
             <div className="px-3 py-1.5 text-[11px] text-text-subtle">
               What does <span className="text-text-muted">{host}</span> run?
             </div>
@@ -312,10 +331,13 @@ function StateDot({ tone, filled }: { tone: LifecycleTone; filled: boolean }): J
 function ForgePanel({
   ownerId,
   statusKey,
+  style,
   onClose
 }: {
   ownerId: string
   statusKey: string | null
+  /** Width + edge-clamped offset + height cap, from useMenuAnchor. */
+  style: CSSProperties
   onClose: () => void
 }): JSX.Element {
   const forgeStatus = useRoxyStore((s) => s.forgeStatus)
@@ -363,9 +385,9 @@ function ForgePanel({
   }
 
   return (
-    <div className="absolute bottom-full right-0 z-50 w-80 pb-1.5">
-      <div className="overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl">
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+    <div className="absolute bottom-full z-50 flex flex-col pb-1.5" style={style}>
+      <div className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl">
+        <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
           <span className="min-w-0 flex-1 truncate text-xs text-text-muted">
             {view?.remote ? view.remote.slug : 'No remote'}
           </span>
@@ -606,6 +628,7 @@ function WorkstreamSegment({
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const anchor = useMenuAnchor(ref, open, WORKSTREAM_MENU_W)
 
   // Click-outside + Escape, so the menu behaves like the rest of the app's
   // popovers even though this one is click-opened (ContextMeter is hover-opened,
@@ -640,7 +663,7 @@ function WorkstreamSegment({
 
   return (
     <div className="relative" ref={ref}>
-      {open && <WorkstreamMenu chat={chat} onClose={() => setOpen(false)} />}
+      {open && <WorkstreamMenu chat={chat} style={anchor} onClose={() => setOpen(false)} />}
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
@@ -670,7 +693,16 @@ function WorkstreamSegment({
 }
 
 /** The dropdown: this project's workstreams, plus ways to start a new one. */
-function WorkstreamMenu({ chat, onClose }: { chat: Chat; onClose: () => void }): JSX.Element {
+function WorkstreamMenu({
+  chat,
+  style,
+  onClose
+}: {
+  chat: Chat
+  /** Width + edge-clamped offset + height cap, from useMenuAnchor. */
+  style: CSSProperties
+  onClose: () => void
+}): JSX.Element {
   const chats = useRoxyStore((s) => s.chats)
   const worktrees = useRoxyStore((s) => s.worktrees)
   const branches = useRoxyStore((s) => s.gitBranches)
@@ -718,8 +750,11 @@ function WorkstreamMenu({ chat, onClose }: { chat: Chat; onClose: () => void }):
   }
 
   return (
-    <div className="absolute bottom-full left-0 z-50 w-72 pb-1.5">
-      <div className="overflow-hidden rounded-xl border border-border bg-elevated py-1 shadow-2xl">
+    <div className="absolute bottom-full z-50 flex flex-col pb-1.5" style={style}>
+      {/* The whole menu scrolls, not just the branch list: a project with a
+          dozen sessions makes the workstream list itself taller than the window,
+          and `maxHeight` without `overflow` would only clip it differently. */}
+      <div className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-border bg-elevated py-1 shadow-2xl">
         <MenuLabel>Workstreams</MenuLabel>
 
         {/* The default workstream is the project folder itself — always present,

--- a/src/renderer/src/lib/anchor.ts
+++ b/src/renderer/src/lib/anchor.ts
@@ -54,6 +54,73 @@ export interface Placement {
 
 const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(v, hi))
 
+/* ---- anchored menus --------------------------------------------------------
+ *
+ * Popovers in the workstream strip and the composer footer are fixed-width
+ * boxes pinned to one edge of their trigger (`left-0` / `right-0`) with no idea
+ * where the window ends. That is fine until a trigger sits near an edge — then
+ * the box simply runs off screen and is cut, because the app root is
+ * `overflow: hidden` and there is nothing to scroll.
+ *
+ * The Processes popover hit this first (widest box, and its trigger is the LAST
+ * segment of a centered row, so it starts furthest right), but the bug is
+ * structural: every one of these menus has it. These two functions are the whole
+ * fix — clamp the box into the viewport, and cap its height to the room actually
+ * available on the side it opens toward.
+ *
+ * Kept here, pure and DOM-free, for the same reason `place` is: the interesting
+ * part is the arithmetic at the edges, and that deserves tests. See
+ * lib/useMenuAnchor.ts for the wiring.
+ */
+
+/** Which trigger edge the menu lines up with when there's room for its choice. */
+export type MenuAlign = 'start' | 'end'
+/** Which way the menu opens away from its trigger. */
+export type MenuSide = 'top' | 'bottom'
+/**
+ * A menu never gets squeezed below this. Past it the honest answer is a scroll
+ * bar, not a 30px sliver that can't show a single row.
+ */
+export const MIN_MENU_H = 120
+
+/**
+ * The menu's left edge, expressed RELATIVE TO ITS TRIGGER — i.e. exactly what an
+ * `absolute` child of the trigger wants for `left`. Returning an offset rather
+ * than a viewport coordinate keeps the menu a normal positioned child, so it
+ * still moves with its trigger between measurements instead of detaching.
+ */
+export function alignMenu(
+  triggerLeft: number,
+  triggerWidth: number,
+  menuWidth: number,
+  viewportWidth: number,
+  align: MenuAlign = 'start'
+): number {
+  const ideal = align === 'end' ? triggerLeft + triggerWidth - menuWidth : triggerLeft
+  // When the menu is wider than the viewport allows, the left margin wins. Text
+  // starts on the left, so a box that MUST be cut should lose its tail rather
+  // than its first character.
+  const left = Math.max(MARGIN, Math.min(ideal, viewportWidth - MARGIN - menuWidth))
+  return Math.round(left - triggerLeft)
+}
+
+/**
+ * How tall the menu may be before it has to scroll, given the room between the
+ * trigger and the viewport edge it opens toward. `gap` is the space the menu
+ * already reserves between itself and the trigger.
+ */
+export function menuMaxHeight(
+  triggerTop: number,
+  triggerBottom: number,
+  viewportHeight: number,
+  side: MenuSide = 'top',
+  gap = 6
+): number {
+  const room =
+    side === 'top' ? triggerTop - gap - MARGIN : viewportHeight - triggerBottom - gap - MARGIN
+  return Math.max(MIN_MENU_H, Math.floor(room))
+}
+
 /** Largest the image can be drawn inside `availW`×`availH`, or null if it can't. */
 function fit(
   natW: number,

--- a/src/renderer/src/lib/useMenuAnchor.ts
+++ b/src/renderer/src/lib/useMenuAnchor.ts
@@ -1,0 +1,70 @@
+/**
+ * Keeps an anchored popover inside the window.
+ *
+ * The menus in the workstream strip and the composer footer are absolutely
+ * positioned children of their triggers, pinned to one edge (`left-0` /
+ * `right-0`) at a fixed width. Nothing in that arrangement knows where the
+ * window ends, so a trigger near an edge pushes its menu off screen — and since
+ * the app root is `overflow: hidden`, it is silently cut rather than scrolled
+ * into reach.
+ *
+ * This measures the trigger against the viewport and hands back a style that
+ * nudges the menu back inside, plus a `maxHeight` so a long list can't run off
+ * the top either. The menu stays a positioned CHILD (the returned `left` is an
+ * offset from the trigger, not a viewport coordinate), which means it keeps
+ * tracking its trigger between measurements instead of detaching from it the
+ * way a portal would.
+ *
+ * The geometry itself lives in lib/anchor.ts, pure and tested.
+ */
+import { useCallback, useEffect, useState, type CSSProperties, type RefObject } from 'react'
+import { alignMenu, menuMaxHeight, type MenuAlign, type MenuSide } from './anchor'
+
+interface Options {
+  /** Which trigger edge to line up with when there's room. */
+  align?: MenuAlign
+  /** Which way the menu opens. */
+  side?: MenuSide
+  /** Space reserved between menu and trigger — must match the menu's own padding. */
+  gap?: number
+}
+
+/**
+ * `ref` is the POSITIONED wrapper (the `relative` element that contains both
+ * trigger and menu), `open` gates the work, and `width` is the menu's fixed
+ * width in px. Returns styles to spread onto the menu.
+ */
+export function useMenuAnchor(
+  ref: RefObject<HTMLElement>,
+  open: boolean,
+  width: number,
+  { align = 'start', side = 'top', gap = 6 }: Options = {}
+): CSSProperties {
+  // Start with the un-nudged position so the FIRST paint is already anchored:
+  // measuring in an effect means one frame exists before we know better, and a
+  // menu that visibly jumps sideways on open is worse than one slightly off.
+  const [style, setStyle] = useState<CSSProperties>({ width })
+
+  const measure = useCallback((): void => {
+    const el = ref.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    setStyle({
+      width,
+      left: alignMenu(r.left, r.width, width, window.innerWidth, align),
+      maxHeight: menuMaxHeight(r.top, r.bottom, window.innerHeight, side, gap)
+    })
+  }, [ref, width, align, side, gap])
+
+  useEffect(() => {
+    if (!open) return
+    measure()
+    // Resizing the window and dragging the sidebar's edge both move the trigger
+    // without remounting the menu, so re-measure rather than close: the user is
+    // mid-interaction and closing their menu for them would be rude.
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [open, measure])
+
+  return style
+}

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -186,11 +186,14 @@ import {
 } from '../src/shared/forge'
 import {
   place,
+  alignMenu,
+  menuMaxHeight,
   GAP,
   MARGIN,
   MAX_W,
   MAX_H,
   CHROME_H,
+  MIN_MENU_H,
   type Rect
 } from '../src/renderer/src/lib/anchor'
 
@@ -3550,6 +3553,96 @@ async function main(): Promise<void> {
     gapped !== null && Math.round(700 - boxOf(gapped).bottom) === GAP,
     gapped ? String(700 - boxOf(gapped).bottom) : 'null'
   )
+
+  // ---- anchored menu geometry (renderer/lib/anchor) --------------------------
+  // The regression this exists for: the Processes popover is 416px wide and its
+  // trigger is the LAST segment of a centered max-w-3xl row, so a left-pinned
+  // menu ran past the right edge of the window and was cut (the app root is
+  // overflow:hidden, so there is nothing to scroll it back into view).
+  const MENU_W = 416
+  // Worst realistic case: minimum window width (main/index.ts pins minWidth 760)
+  // with a trigger near the right edge of the composer column.
+  const trigger = { left: 600, width: 90 }
+  const off = alignMenu(trigger.left, trigger.width, MENU_W, 760)
+  check(
+    'menu: clamps a wide menu back inside a narrow window',
+    trigger.left + off + MENU_W <= 760 - MARGIN,
+    String(trigger.left + off + MENU_W)
+  )
+  check('menu: only ever pulls a clipped menu leftward', off <= 0, String(off))
+
+  // With room to spare the menu must NOT drift — it should sit exactly on the
+  // trigger edge it is aligned to, or the fix would move every menu in the app.
+  check(
+    'menu: start-aligns flush with the trigger when there is room',
+    alignMenu(100, 90, 288, 1400, 'start') === 0
+  )
+  check(
+    'menu: end-aligns flush with the trigger when there is room',
+    alignMenu(400, 90, 288, 1400, 'end') === 400 + 90 - 288 - 400
+  )
+
+  // Both edges, both alignments, across window sizes and trigger positions.
+  let outside = 0
+  let drifted = 0
+  for (const vw of [760, 900, 1100, 1440, 1920]) {
+    for (const w of [224, 256, 288, 320, 416]) {
+      for (let x = 0; x <= vw - 40; x += 17) {
+        for (const align of ['start', 'end']) {
+          const tw = 90
+          const left = x + alignMenu(x, tw, w, vw, align)
+          // Never past a margin, unless the menu simply cannot fit — in which
+          // case it pins to the left margin and loses its tail, not its head.
+          const fits = w <= vw - MARGIN * 2
+          if (left < MARGIN - 0.5) outside++
+          else if (fits && left + w > vw - MARGIN + 0.5) outside++
+          // Untouched when it already fits where it wanted to go.
+          const ideal = align === 'end' ? x + tw - w : x
+          if (ideal >= MARGIN && ideal + w <= vw - MARGIN && Math.abs(left - ideal) > 0.5) drifted++
+        }
+      }
+    }
+  }
+  check('menu: never lands outside the viewport margins', outside === 0, String(outside))
+  check(
+    'menu: leaves menus that already fit exactly where they were',
+    drifted === 0,
+    String(drifted)
+  )
+
+  // A menu wider than the window keeps its left edge readable rather than
+  // centering the overflow and cutting both sides.
+  check(
+    'menu: a too-wide menu pins to the left margin',
+    alignMenu(300, 90, 900, 500) === MARGIN - 300
+  )
+
+  // Height: a menu opening upward gets the room above its trigger, never more.
+  const strip = { top: 700, bottom: 724 }
+  const capUp = menuMaxHeight(strip.top, strip.bottom, 780, 'top', 6)
+  check('menu: height cap fits above the trigger', capUp <= strip.top - 6 - MARGIN, String(capUp))
+  const capDown = menuMaxHeight(strip.top, strip.bottom, 780, 'bottom', 6)
+  check(
+    'menu: height cap fits below the trigger',
+    capDown <= 780 - strip.bottom - 6 - MARGIN || capDown === MIN_MENU_H,
+    String(capDown)
+  )
+  // Even pinned against an edge it stays usable — scrolling beats a sliver.
+  check(
+    'menu: never caps below a usable height',
+    menuMaxHeight(4, 28, 780, 'top') === MIN_MENU_H &&
+      menuMaxHeight(750, 774, 780, 'bottom') === MIN_MENU_H
+  )
+  let badCap = 0
+  for (const vh of [480, 600, 780, 1080]) {
+    for (let y = 0; y < vh - 24; y += 13) {
+      for (const side of ['top', 'bottom']) {
+        const cap = menuMaxHeight(y, y + 24, vh, side)
+        if (!Number.isFinite(cap) || cap < MIN_MENU_H) badCap++
+      }
+    }
+  }
+  check('menu: height cap is always finite and usable', badCap === 0, String(badCap))
   if (fails.length) {
     console.error(`\nSHARED FAILED \u2014 ${fails.length} failing: ${fails.join(', ')}`)
     process.exit(1)


### PR DESCRIPTION
Every anchored menu was a fixed-width box pinned to a trigger edge with no viewport awareness (`absolute bottom-full left-0 w-[26rem]`). The app root is `overflow: hidden`, so a menu that ran past an edge was silently cut rather than scrolled back into reach.

Processes showed it first because it is the widest menu (416px) and its trigger is the last segment of a centered column the sidebar already pushes right, but the bug was structural: ContextMeter, ModelPicker, the workstream/forge/host menus and the composer pickers all shared it.

Height had the same problem, less visibly: a long process list or a project with many workstreams grew off the TOP of the window.

- add pure `alignMenu`/`menuMaxHeight` geometry to lib/anchor.ts, beside `place`
- add `useMenuAnchor`, which measures the trigger and returns left/maxHeight; the menu stays a positioned CHILD (offset is relative to the trigger), so it keeps tracking its trigger instead of detaching the way a portal would
- apply to all six menus; long lists now scroll under a cap with the header pinned, instead of running off the top
- 14 new smoke checks covering both edges, both alignments and the height cap

Verified with a throwaway iframe harness rendering the real hook at real widths, including a control case using the pre-fix markup: the control reproduced the reported clipping (off-right 257px) while all 9 real configurations, down to 760x480 with a 480px sidebar, measured clean.