### PR TITLE
Bump version to 0.0.56

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.55",
+      "version": "0.0.56",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",


### PR DESCRIPTION
Four merged PRs, all interface polish -- no behaviour changes:

  - Anchored menus stay inside the window. Every popover was a fixed-width box pinned to its trigger with no viewport awareness, and the app root is overflow:hidden, so anything past an edge was silently cut. Processes hit it first (widest menu, rightmost trigger) but the bug was structural; long lists also grew off the top. New alignMenu/menuMaxHeight geometry plus a useMenuAnchor hook now fix all six menus, with 14 smoke checks.
  - The Switch knob stays inside its track. It had no `left`, so it resolved to the button's centre and landed 14px past the right edge when checked; the border was drawn only while unchecked, so it also hopped 1px per toggle. Affects every Switch in the app.
  - Composer footer controls drop the pill chrome and adopt the workstream strip's grammar -- background on hover only -- so one row of preferences stops reading as five boxed objects. Carries two knock-on fixes: the context meter's track colour and the attach button's alignment.
  - The sidebar subagent count fades in on hover instead of sitting pinned on every session that ever spawned one; it stays put only while a subagent runs or the list is expanded.