### PR TITLE
Show pull request state on each sidebar row

### DIFF
--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -24,10 +24,14 @@ import {
   Trash2
 } from 'lucide-react'
 import type { Chat, Loop } from '@shared/types'
+import type { LifecycleView } from '@shared/forge'
+import { isPullRequestPhase } from '@shared/forge'
+import { statusKeyForSession } from '@shared/workstream'
 import { formatInterval } from '@shared/format'
 import { useRoxyStore } from '../lib/store'
 import { api } from '../lib/api'
 import { cn } from '../lib/cn'
+import { TONE_BG, TONE_TEXT_STATIC } from '../lib/lifecycle'
 import { HeartbeatDot, NewLoopDialog } from './LoopsSection'
 import { RemoteWorkspaceDialog } from './RemoteWorkspaceDialog'
 import { BrailleSpinner } from './ThinkingIndicator'
@@ -37,6 +41,16 @@ import roxy from '../assets/roxy.png'
 const MIN_WIDTH = 220
 const MAX_WIDTH = 480
 const DEFAULT_WIDTH = 288
+/**
+ * How often to re-read git + PR state for EVERY session.
+ *
+ * Far slower than the strip's 5s, and deliberately so. The strip polls one
+ * session; this sweeps all of them, and each one costs a git spawn. Pull
+ * request state also changes on the order of minutes - the forge answer is
+ * cached for 60s in the main process, so polling faster than this would spawn
+ * git for a number that cannot have moved.
+ */
+const SWEEP_MS = 30_000
 const WIDTH_KEY = 'roxy.sidebar.width'
 const COLLAPSED_KEY = 'roxy.sidebar.collapsed'
 const clampWidth = (n: number): number => Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, n))
@@ -48,12 +62,32 @@ interface Project {
   loops: Loop[]
 }
 
+/**
+ * The row's hover text: title, branch, and whatever the row could not say in
+ * the space it had.
+ *
+ * The badge is ~40px of `merged` or `#42`, so the full sentence the lifecycle
+ * already computed (`#42 merged into main`, `#42 -> main - checks failing`)
+ * has nowhere to live on the row itself. It lives here, on the tooltip that
+ * covers the WHOLE row - which is also why the dirty dot has no `title` of its
+ * own: a 4px target is too small to hover deliberately.
+ */
+function sessionRowTitle(chat: Chat, dirty: boolean, pull: LifecycleView | undefined): string {
+  const bits = [chat.title]
+  if (chat.branch) bits.push(chat.branch)
+  if (pull) bits.push(pull.title)
+  if (dirty) bits.push('uncommitted changes')
+  return bits.join(' - ')
+}
+
 export function Sidebar(): JSX.Element {
   const navigate = useNavigate()
   const chats = useRoxyStore((s) => s.chats)
   const activeChatId = useRoxyStore((s) => s.activeChatId)
   const selectChat = useRoxyStore((s) => s.selectChat)
   const gitStatus = useRoxyStore((s) => s.gitStatus)
+  const forgeStatus = useRoxyStore((s) => s.forgeStatus)
+  const refreshAllGitStatus = useRoxyStore((s) => s.refreshAllGitStatus)
   const runningSubagents = useRoxyStore((s) => s.runningSubagents)
   const newSession = useRoxyStore((s) => s.newSession)
   const newSessionInProject = useRoxyStore((s) => s.newSessionInProject)
@@ -274,6 +308,59 @@ export function Sidebar(): JSX.Element {
     }
     return ids
   }, [chats, gitStatus])
+
+  // The PR badge on a row, when that row's branch HAS a pull request. Anything
+  // earlier in the lifecycle (`local`, `up-3`, `pushed`) is filtered out by
+  // `isPullRequestPhase`: those are true of most rows most of the time, and a
+  // column of them would bury the one row that says `merged`.
+  //
+  // Keyed by WORKTREE path only, matching `dirtyById` above, and for the same
+  // reason: sessions without a worktree share the project checkout with each
+  // other and with the user's editor, so a PR found there belongs to the branch
+  // rather than to any one of those sessions. The strip still shows it for
+  // whichever session is open, where there is exactly one and no ambiguity.
+  const pullById = useMemo(() => {
+    const map = new Map<string, LifecycleView>()
+    for (const c of chats) {
+      const key = c.worktreePath
+      if (!key) continue
+      const lifecycle = forgeStatus[key]?.lifecycle
+      if (lifecycle && isPullRequestPhase(lifecycle.phase)) map.set(c.id, lifecycle)
+    }
+    return map
+  }, [chats, forgeStatus])
+
+  // Keep every row's status current, not just the open session's - the whole
+  // point is answering "what happened to my PR?" without clicking into each one.
+  //
+  // Depends on the COUNT of pollable sessions rather than on `chats`, which is
+  // replaced on every streamed message: with the array in the deps this timer
+  // would restart continuously and, at a 30s period, effectively never fire.
+  // The count moves only when a session is created, deleted, or gains a
+  // worktree - exactly when a fresh sweep is actually warranted.
+  const pollableCount = useMemo(
+    () => chats.reduce((n, c) => (statusKeyForSession(c) ? n + 1 : n), 0),
+    [chats]
+  )
+  useEffect(() => {
+    if (!pollableCount) return
+    void refreshAllGitStatus()
+    const timer = setInterval(() => {
+      // A backgrounded window has nobody reading the sidebar, and this sweep
+      // spawns git once per workstream. Skipping it while hidden is the
+      // difference between a status indicator and a battery drain.
+      if (document.hidden) return
+      void refreshAllGitStatus()
+    }, SWEEP_MS)
+    // Regaining focus is the highest-value moment to refresh: the user has most
+    // likely just come back from merging the PR in a browser.
+    const onFocus = (): void => void refreshAllGitStatus()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      clearInterval(timer)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [pollableCount, refreshAllGitStatus])
 
   // Subagent sessions grouped by the main chat that spawned them.
   const subsByParent = useMemo(() => {
@@ -579,6 +666,8 @@ export function Sidebar(): JSX.Element {
                             // right now — so a COLLAPSED parent still shows that
                             // something is happening underneath it.
                             const liveSubs = subs.filter((x) => runningSubagents[x.id]).length
+                            // Undefined until this branch has a PR on the host.
+                            const pull = pullById.get(chat.id)
                             return (
                               <li
                                 key={chat.id}
@@ -653,13 +742,7 @@ export function Sidebar(): JSX.Element {
                                     <button
                                       onClick={() => selectChat(chat.id)}
                                       onDoubleClick={() => beginRename(chat)}
-                                      title={
-                                        chat.branch
-                                          ? dirtyById.has(chat.id)
-                                            ? `${chat.title} - ${chat.branch} (uncommitted changes)`
-                                            : `${chat.title} - ${chat.branch}`
-                                          : chat.title
-                                      }
+                                      title={sessionRowTitle(chat, dirtyById.has(chat.id), pull)}
                                       className="min-w-0 flex-1 text-left"
                                     >
                                       <span className="block truncate">{chat.title}</span>
@@ -675,6 +758,40 @@ export function Sidebar(): JSX.Element {
                                               never be seen. */}
                                           {dirtyById.has(chat.id) && (
                                             <span className="h-1 w-1 shrink-0 rounded-full bg-warning" />
+                                          )}
+                                          {/* Where the branch ended up on the host: `#42`,
+                                              `#42 draft`, `merged`, `closed`. Same dot-plus-label
+                                              grammar and the same colours as the strip's chip, from
+                                              the one shared tone map.
+
+                                              `ml-auto` parks it in a column down the right edge so
+                                              the states are scannable vertically, instead of landing
+                                              at a different x on every row. `shrink-0` is the
+                                              load-bearing part: a status that gets truncated away
+                                              behind a long branch name is one you can't rely on, and
+                                              an unreliable status is worse than none. The branch
+                                              name yields instead - it's the thing you can still
+                                              recover from the tooltip.
+
+                                              Deliberately NOT a link. It sits inside the row's
+                                              button, so a nested button would be invalid HTML and
+                                              would swallow the click that opens the session; the
+                                              strip's chip is where "view on the web" lives. */}
+                                          {pull && (
+                                            <span
+                                              className={cn(
+                                                'ml-auto flex shrink-0 items-center gap-1',
+                                                TONE_TEXT_STATIC[pull.tone]
+                                              )}
+                                            >
+                                              <span
+                                                className={cn(
+                                                  'h-1.5 w-1.5 rounded-full',
+                                                  TONE_BG[pull.tone]
+                                                )}
+                                              />
+                                              <span className="tabular-nums">{pull.label}</span>
+                                            </span>
                                           )}
                                         </span>
                                       )}

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -9,6 +9,10 @@ import { workstreamStripView, statusKeyForSession } from '@shared/workstream'
 import { branchNameError } from '@shared/branch'
 import { ServicesSegment, useServices } from './ServicesSegment'
 import { cn } from '../lib/cn'
+// The tone -> class mapping is shared with the sidebar's row badge. Two copies
+// would drift, and a `merged` PR that is green in one place and grey in the
+// other teaches the user that the colour means nothing.
+import { TONE_BG, TONE_TEXT } from '../lib/lifecycle'
 
 /**
  * The workstream strip — one quiet row under the composer answering "where does
@@ -266,27 +270,6 @@ function UnknownHostChip({ host }: { host: string }): JSX.Element {
 }
 
 const FORGE_KINDS: ForgeKind[] = ['github', 'azure-devops', 'gitlab', 'bitbucket']
-/**
- * Colour is the fastest channel the chip has, so it carries the one thing worth
- * interrupting for: whether something needs the user. Merged is the only green
- * - "done" is the state worth celebrating, and if everything were coloured
- * nothing would stand out.
- */
-const TONE_TEXT: Record<LifecycleTone, string> = {
-  neutral: 'text-text-subtle hover:text-text-muted',
-  info: 'text-text-muted hover:text-text',
-  success: 'text-success',
-  warning: 'text-warning',
-  danger: 'text-danger'
-}
-
-const TONE_BG: Record<LifecycleTone, string> = {
-  neutral: 'bg-text-subtle/70',
-  info: 'bg-text-muted',
-  success: 'bg-success',
-  warning: 'bg-warning',
-  danger: 'bg-danger'
-}
 
 /**
  * Hollow while the work is local, filled once it exists on the server. It's the

--- a/src/renderer/src/lib/lifecycle.ts
+++ b/src/renderer/src/lib/lifecycle.ts
@@ -1,0 +1,48 @@
+/**
+ * The shared visual vocabulary for a branch's lifecycle state.
+ *
+ * Two places render it now - the workstream strip under the composer, and the
+ * sidebar's session rows - and they must never disagree. A `merged` PR that is
+ * green in one and grey in the other is worse than showing it in only one
+ * place: the user learns the colour means nothing.
+ *
+ * So the mapping lives here rather than in either component. `LifecycleTone` is
+ * the semantic layer (defined in `shared/forge` alongside the state machine
+ * that produces it); this is the only file allowed to turn a tone into a class.
+ */
+import type { LifecycleTone } from '@shared/forge'
+
+/**
+ * Colour is the fastest channel a status indicator has, so it carries the one
+ * thing worth interrupting for: whether something needs the user. Merged is the
+ * only green - "done" is the state worth celebrating, and if everything were
+ * coloured nothing would stand out.
+ */
+export const TONE_TEXT: Record<LifecycleTone, string> = {
+  neutral: 'text-text-subtle hover:text-text-muted',
+  info: 'text-text-muted hover:text-text',
+  success: 'text-success',
+  warning: 'text-warning',
+  danger: 'text-danger'
+}
+
+/**
+ * The same tones without the hover pair, for places that aren't a button.
+ * Splitting them matters: `hover:` on a non-interactive span is a lie the
+ * cursor tells, promising a click that does nothing.
+ */
+export const TONE_TEXT_STATIC: Record<LifecycleTone, string> = {
+  neutral: 'text-text-subtle',
+  info: 'text-text-muted',
+  success: 'text-success',
+  warning: 'text-warning',
+  danger: 'text-danger'
+}
+
+export const TONE_BG: Record<LifecycleTone, string> = {
+  neutral: 'bg-text-subtle/70',
+  info: 'bg-text-muted',
+  success: 'bg-success',
+  warning: 'bg-warning',
+  danger: 'bg-danger'
+}

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -34,7 +34,7 @@ import {
   type SessionConfigPatch
 } from '@shared/session-config'
 import { uniqueSlug } from '@shared/slugs'
-import { shouldAutoWorkstream } from '@shared/workstream'
+import { shouldAutoWorkstream, statusKeyForSession } from '@shared/workstream'
 import { api } from './api'
 import type { ComposerImage } from './images'
 import type { GitStatusView, ServiceView, WorktreeView } from '@shared/api'
@@ -178,6 +178,17 @@ interface RoxyStore {
    * worktrees watchers multiply, and fs.watch is unreliable on Windows.
    */
   refreshGitStatus: (chatId: string) => Promise<void>
+  /**
+   * Refresh git + PR status for EVERY session, so the sidebar can show where
+   * each workstream stands without the user opening it.
+   *
+   * Deduped by cwd, because that is the unit of work: ten sessions in one
+   * worktree are one git spawn, not ten. The forge side is deduped again in
+   * the main process (60s TTL, shared in-flight promise), so a sweep over a
+   * dozen sessions costs a dozen local `git status` calls and, at most, one
+   * network request per distinct branch per minute.
+   */
+  refreshAllGitStatus: () => Promise<void>
   /** Push this session's branch to origin, then refresh its status. */
   pushBranch: (chatId: string) => Promise<{ ok: boolean; error?: string }>
   /** Load the worktrees + branches for a project (menu open). */
@@ -226,6 +237,18 @@ const remoteTurns = new Map<string, PartsFold>()
  * whole transcript so far instead of resuming from whatever arrives next.
  */
 const subagentTurns = new Map<string, PartsFold>()
+
+/**
+ * The in-flight sidebar sweep, shared by every caller until it settles.
+ *
+ * The sweep walks worktrees one at a time, so it can easily still be running
+ * when the next trigger arrives - the 30s timer, a window focus, and an
+ * alt-tab burst all call it. Without this, focusing the window three times in
+ * a second starts three overlapping walks over the same repos, each spawning
+ * its own git processes and racing the others' `set()` calls. Sharing the
+ * promise makes every extra trigger free.
+ */
+let gitSweep: Promise<void> | null = null
 
 /**
  * Record a config change as the new GLOBAL default - the template every new
@@ -701,6 +724,56 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       }))
     } catch {
       // Best-effort: a transient git failure leaves the last known state.
+    }
+  },
+
+  refreshAllGitStatus: async () => {
+    // Coalesce: a re-entrant call rides the walk already in progress instead of
+    // starting a second one over the same repos.
+    if (gitSweep) return gitSweep
+    gitSweep = (async () => {
+      // Probe once, exactly as refreshGitStatus does - on a cold start this runs
+      // before anything has touched git, and `null` must not be read as `false`.
+      if (get().gitAvailable === null) {
+        try {
+          set({ gitAvailable: await api.git.available() })
+        } catch {
+          set({ gitAvailable: false })
+        }
+      }
+      if (!get().gitAvailable) return
+
+      // One entry per distinct cwd. `statusKeyForSession` returns null for
+      // sub-sessions (they inherit their parent's workstream) and for sessions
+      // with no folder at all, and Set collapses the rest.
+      const keys = new Set<string>()
+      for (const c of get().chats) {
+        const key = statusKeyForSession(c)
+        if (key) keys.add(key)
+      }
+      if (!keys.size) return
+
+      // Sequential, not Promise.all: git serializes per repo in the main process
+      // anyway, and firing N spawns at once on a machine with a dozen sessions is
+      // a visible stall on the very interaction (opening the app) this is meant
+      // to be invisible during.
+      for (const key of keys) {
+        try {
+          const [status, forge] = await Promise.all([api.git.status(key), api.forge.status(key)])
+          set((s) => ({
+            gitStatus: { ...s.gitStatus, [key]: status },
+            forgeStatus: forge ? { ...s.forgeStatus, [key]: forge } : s.forgeStatus
+          }))
+        } catch {
+          // Best-effort per session: a deleted worktree must not stop the sweep
+          // and leave every row below it blank.
+        }
+      }
+    })()
+    try {
+      await gitSweep
+    } finally {
+      gitSweep = null
     }
   },
 

--- a/src/shared/forge.ts
+++ b/src/shared/forge.ts
@@ -537,6 +537,43 @@ function openTitle(pr: PullRequestView): string {
 }
 
 // ---------------------------------------------------------------------------
+// The sidebar’s narrower question
+// ---------------------------------------------------------------------------
+
+/**
+ * Does this phase mean a pull request actually exists on the server?
+ *
+ * This is the line the SIDEBAR draws. The strip describes one session and can
+ * afford to be complete; the sidebar prints a badge on every row at once, so it
+ * can only afford the states worth interrupting for - and those are exactly the
+ * ones that answer "what happened to my PR?".
+ *
+ * The pre-PR phases are deliberately left out. `local`, `up-3` and `pushed` are
+ * true of nearly every row nearly all of the time, so rendering them N times
+ * down the list would bury the one row that says `merged` under a column of
+ * noise - the opposite of what a status column is for. Uncommitted work already
+ * has its own dot there, and the strip still shows the full ladder for the
+ * session you actually have open.
+ *
+ * Written as an exhaustive switch on purpose: a new `LifecyclePhase` fails to
+ * compile here until someone decides which side of the line it belongs on.
+ */
+export function isPullRequestPhase(phase: LifecyclePhase): boolean {
+  switch (phase) {
+    case 'draft':
+    case 'open':
+    case 'merged':
+    case 'closed':
+      return true
+    case 'unpublished':
+    case 'ahead':
+    case 'behind':
+    case 'synced':
+      return false
+  }
+}
+
+// ---------------------------------------------------------------------------
 // The wire shape
 // ---------------------------------------------------------------------------
 

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -180,6 +180,8 @@ import {
   forgeKindForHost,
   detectHost,
   branchLifecycle,
+  isPullRequestPhase,
+  type LifecyclePhase,
   relativeAge,
   FORGE_NAMES,
   type PullRequestView
@@ -3195,6 +3197,44 @@ async function main(): Promise<void> {
       })
       return v.phase === 'closed'
     })()
+  )
+
+  // ---- forge: which phases the sidebar badges -----------------------------
+  // The sidebar renders one badge per row, so it only shows phases that mean a
+  // PR actually exists. The pre-PR states are true of nearly every row nearly
+  // all the time and would bury the row that says `merged`.
+  check(
+    'sidebar: PR phases are badged',
+    (['draft', 'open', 'merged', 'closed'] as LifecyclePhase[]).every(isPullRequestPhase)
+  )
+  check(
+    'sidebar: pre-PR phases are not badged',
+    (['unpublished', 'ahead', 'behind', 'synced'] as LifecyclePhase[]).every(
+      (p) => !isPullRequestPhase(p)
+    )
+  )
+  // The two functions have to agree: every phase branchLifecycle can produce
+  // WITH a pr must badge, and every phase it produces WITHOUT one must not.
+  // Asserting that here is what stops the sidebar and the strip from drifting.
+  check(
+    'sidebar: badged phases are exactly the ones with a PR',
+    (['open', 'draft', 'merged', 'closed'] as const).every((state) =>
+      isPullRequestPhase(
+        branchLifecycle({
+          sync: { ...noSync, hasUpstream: true },
+          pr: mkPr({ state }),
+          forgeKnown: true
+        }).phase
+      )
+    ) &&
+      [
+        { ...noSync },
+        { ...noSync, hasUpstream: true, ahead: 2 },
+        { ...noSync, hasUpstream: true, behind: 3 },
+        { ...noSync, hasUpstream: true }
+      ].every(
+        (sync) => !isPullRequestPhase(branchLifecycle({ sync, pr: null, forgeKnown: true }).phase)
+      )
   )
 
   // ---- forge: unknown hosts + user override -------------------------------


### PR DESCRIPTION
Answering "what happened to my PR?" meant opening each session in turn to read the workstream strip. The sidebar already lists every workstream; it just had nothing to say about where each one ended up.

## What this adds

Each sidebar row now carries a badge next to its branch — `merged`, `#42`, `#42 draft`, `closed` — using the same dot-plus-label grammar and the same colours as the workstream strip's chip, so the two read as one vocabulary rather than two dialects.

## Notes on the design

**The tone map moved to `lib/lifecycle.ts`.** Two components render lifecycle state now, and two copies of the colour mapping would drift. A PR that is green in the strip and grey in the sidebar is worse than showing it in only one place: the user learns the colour means nothing.

**Only phases where a PR actually exists are shown.** `isPullRequestPhase` draws that line as an exhaustive switch, so a newly added phase fails to compile until someone decides which side it belongs on. The pre-PR states (`unpublished`, `ahead`, `behind`, `synced`) are deliberately excluded — they are true of nearly every row nearly all of the time, and a column full of them would bury the one row that says `merged`.

**Polling.** Feeding this needs status for sessions the user has not opened, so `refreshAllGitStatus` sweeps every session, deduped by cwd — ten sessions sharing one worktree are one git spawn, not ten. It runs every 30s rather than the strip's 5s, skips entirely while the window is hidden, and refreshes on focus, which is the highest-value moment: the user has most likely just come back from merging in a browser. Concurrent calls share a single walk, so an alt-tab burst cannot start three overlapping sweeps over the same repos.

## Known limitation

The badge is keyed by `worktreePath`, so sessions running directly in a project checkout (no worktree) get no badge. A PR found there belongs to the *branch*, not to any one of the several sessions that may share that directory, and picking one arbitrarily would be a lie. This matches the existing `dirtyById` behaviour, and the strip still shows it for whichever session is open, where there is exactly one and no ambiguity.

## Testing

- 3 new cases in `test/shared.ts` covering `isPullRequestPhase` — the PR phases included, and every pre-PR sync state excluded. 639 shared checks pass.
- `npm run typecheck` clean; prettier clean on all touched files.
- Rendered every lifecycle state through the real `branchLifecycle` in a scratch harness at both the default sidebar width (288px) and `MIN_WIDTH` (220px): all six badge states fit, right-align into a scannable column, and never overlap the truncated branch name. The no-PR row is correctly blank.