### PR TITLE
Make the "behind origin" chip actually update or reset

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -12,6 +12,7 @@ import type {
   RemoteStartInput,
   SkillView,
   SkillWriteInput,
+  SyncOutcome,
   UpsertMcpServerInput
 } from '../../shared/api'
 import type {
@@ -641,6 +642,27 @@ export function registerIpc(): void {
     const r = await git.pushBranch(cwd, branch, { setUpstream: !st?.hasUpstream })
     // The remote just changed, so every cached PR answer is suspect - drop it
     // rather than let the chip show pre-push state for up to a minute.
+    if (r.ok) forge.invalidate()
+    return r
+  })
+
+  // Update + reset are separate channels rather than one `sync(mode)` because
+  // they are separate promises: one can only ever move the branch forward, the
+  // other can throw away local work. Collapsing them into a parameter is how a
+  // caller ends up destructive by typo.
+  ipcMain.handle(CHANNELS.forgePull, async (_e, cwd: string): Promise<SyncOutcome> => {
+    if (!cwd || !(await git.isGitAvailable()))
+      return { ok: false, error: 'Git isn\u2019t installed.' }
+    return git.pullFastForward(cwd)
+  })
+
+  ipcMain.handle(CHANNELS.forgeReset, async (_e, cwd: string): Promise<SyncOutcome> => {
+    if (!cwd || !(await git.isGitAvailable()))
+      return { ok: false, error: 'Git isn\u2019t installed.' }
+    const r = await git.resetToUpstream(cwd)
+    // The local branch just moved to whatever the server has, so anything we
+    // cached about "this branch vs its PR" describes a commit that is no longer
+    // HEAD. Drop it rather than show pre-reset state until the TTL expires.
     if (r.ok) forge.invalidate()
     return r
   })

--- a/src/main/services/forge/index.ts
+++ b/src/main/services/forge/index.ts
@@ -20,7 +20,8 @@ import type {
   ForgeStatusView,
   ForgeError,
   ForgeKind,
-  ForgeHostView
+  ForgeHostView,
+  SyncTarget
 } from '../../../shared/forge'
 import { branchLifecycle, parseRemote, detectHost } from '../../../shared/forge'
 import * as git from '../git'
@@ -103,6 +104,30 @@ export async function forgeStatus(
     dirty: st?.dirty ?? false
   }
 
+  // Computed from the status we already have - no extra git spawn, so it rides
+  // the 5s poll for free. Null when there is no upstream: with nothing to sync
+  // against, the panel must not offer to sync.
+  const syncTarget: SyncTarget | null = st?.upstream
+    ? {
+        upstream: st.upstream,
+        behind: st.behind,
+        ahead: st.ahead,
+        changed: st.changed,
+        // Deliberately NOT `behind > 0`. That count comes from the last fetch,
+        // and nothing fetches on a timer (background network churn per session
+        // per 5s is not a trade worth making) - so "0 behind" really means "0
+        // behind as of whenever we last looked", which may be hours ago.
+        // Greying the button out on that number would disable it in precisely
+        // the moment the user wants to check for new commits, which is the
+        // dead end this whole panel exists to remove.
+        //
+        // `ahead === 0` is the honest predicate: with no local commits, the
+        // action can only no-op or fast-forward - it cannot fail. So it stays
+        // clickable, fetches, and answers "Already up to date" or updates.
+        canFastForward: st.ahead === 0
+      }
+    : null
+
   const remote = await resolveForge(cwd)
   // Distinguish "no remote at all" from "a real host we can't classify". The
   // second is a question we can ask the user once; the first isn't.
@@ -121,6 +146,7 @@ export async function forgeStatus(
       remote: remote && summarize(remote),
       lifecycle: branchLifecycle({ sync, pr: null, forgeKnown: false }),
       pull: null,
+      syncTarget,
       error: null,
       refreshing: false,
       unknownHost
@@ -154,6 +180,7 @@ export async function forgeStatus(
       forgeKnown: !!current && !current.error
     }),
     pull,
+    syncTarget,
     error: current?.error ?? null,
     refreshing: !!current?.inflight,
     unknownHost: null

--- a/src/main/services/git.ts
+++ b/src/main/services/git.ts
@@ -107,6 +107,26 @@ export interface GitStatus {
   branch: string | null
   /** True when the branch has an upstream to compare against. */
   hasUpstream: boolean
+  /**
+   * The upstream ref this branch is measured against, e.g. `origin/main`.
+   *
+   * Kept alongside `hasUpstream` because it is what a sync action has to NAME.
+   * "Update from origin/main" is a promise the user can verify; "pull" is a
+   * guess about which of possibly several remotes we meant.
+   */
+  upstream: string | null
+}
+
+/** The outcome of a fast-forward or a reset. */
+export interface SyncResult {
+  ok: boolean
+  error?: string
+  /** The ref we synced to (or would have), once we knew it. */
+  upstream?: string
+  /** False when the branch was already there and nothing moved. */
+  updated?: boolean
+  /** True when a reset parked uncommitted work in the stash first. */
+  stashed?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -377,9 +397,24 @@ export async function defaultBranch(cwd: string): Promise<string | null> {
   return await currentBranch(cwd)
 }
 
-/** Fetch from origin. Fails harmlessly when there's no remote or no network. */
-export async function fetchOrigin(cwd: string): Promise<GitResult> {
-  return git(['fetch', '--quiet', 'origin'], cwd, FETCH_TIMEOUT_MS)
+/** Fetch from a remote (default `origin`). Fails harmlessly when offline. */
+export async function fetchOrigin(cwd: string, remote = 'origin'): Promise<GitResult> {
+  return git(['fetch', '--quiet', remote], cwd, FETCH_TIMEOUT_MS)
+}
+
+/**
+ * The remote a branch tracks, e.g. `origin`.
+ *
+ * Read from config rather than split off the front of `origin/main`: a remote
+ * name may itself contain a slash, and guessing wrong means fetching the wrong
+ * server and then "updating" from a stale ref — a silent wrong answer, which is
+ * the worst kind for a sync button.
+ */
+export async function upstreamRemote(cwd: string, branch: string): Promise<string | null> {
+  if (!cwd || !branch) return null
+  const r = await git(['config', '--get', `branch.${branch}.remote`], cwd)
+  const name = r.stdout.trim()
+  return r.ok && name ? name : null
 }
 
 /** Whether the repo has an `origin` remote configured. */
@@ -438,7 +473,7 @@ export async function status(cwd: string): Promise<GitStatus | null> {
   let branch: string | null = null
   let ahead = 0
   let behind = 0
-  let hasUpstream = false
+  let upstream: string | null = null
   let changed = 0
   for (const raw of r.stdout.split('\n')) {
     const line = raw.trimEnd()
@@ -447,7 +482,7 @@ export async function status(cwd: string): Promise<GitStatus | null> {
       const v = line.slice('# branch.head '.length).trim()
       branch = v === '(detached)' ? null : v
     } else if (line.startsWith('# branch.upstream ')) {
-      hasUpstream = true
+      upstream = line.slice('# branch.upstream '.length).trim() || null
     } else if (line.startsWith('# branch.ab ')) {
       const m = /\+(\d+)\s+-(\d+)/.exec(line)
       if (m) {
@@ -458,7 +493,113 @@ export async function status(cwd: string): Promise<GitStatus | null> {
       changed++
     }
   }
-  return { dirty: changed > 0, changed, ahead, behind, branch, hasUpstream }
+  return { dirty: changed > 0, changed, ahead, behind, branch, hasUpstream: !!upstream, upstream }
+}
+
+// ---------------------------------------------------------------------------
+// Getting back in sync with the remote
+// ---------------------------------------------------------------------------
+
+/**
+ * Fast-forward the checked-out branch onto its upstream.
+ *
+ * Explicitly NOT `git pull`. `pull` is two operations wearing one name, and
+ * which ones depend on `pull.rebase`, `pull.ff` and the user's global config —
+ * so the same button would merge on one machine, rebase on another, and open an
+ * editor on a third. This does exactly one thing on every machine:
+ *
+ *   fetch, then move the branch pointer forward IF that is all it takes.
+ *
+ * `--ff-only` is the entire safety model. When the branch has local commits the
+ * upstream doesn't, git refuses and nothing is touched: no merge commit, no
+ * half-finished rebase with conflict markers in a tree an agent is editing, no
+ * state the user has to know git to get out of. They get told to reset (which
+ * stashes) or to resolve it themselves, deliberately.
+ */
+export async function pullFastForward(cwd: string): Promise<SyncResult> {
+  if (!cwd) return { ok: false, error: 'pull: missing cwd' }
+  const st = await status(cwd)
+  if (!st?.branch) return { ok: false, error: 'Not on a branch (detached HEAD).' }
+  if (!st.upstream) return { ok: false, error: `"${st.branch}" has no upstream to pull from.` }
+
+  // Fetch first so "behind" is measured against what the server has NOW, not
+  // whatever the last poll happened to see.
+  const remote = (await upstreamRemote(cwd, st.branch)) ?? 'origin'
+  const fetched = await fetchOrigin(cwd, remote)
+  if (!fetched.ok) return { ok: false, error: cleanGitError(fetched, `Could not reach ${remote}`) }
+
+  const after = await status(cwd)
+  if ((after?.behind ?? 0) === 0) {
+    return { ok: true, upstream: st.upstream, updated: false }
+  }
+
+  // A dirty tree is fine for a fast-forward as long as no incoming file
+  // collides with a local edit — git checks that itself and refuses if so, and
+  // its refusal names the files, which is better than any pre-flight we could
+  // write here.
+  const r = await git(['merge', '--ff-only', st.upstream], cwd, FETCH_TIMEOUT_MS)
+  if (!r.ok)
+    return { ok: false, error: cleanGitError(r, 'Could not fast-forward'), upstream: st.upstream }
+  return { ok: true, upstream: st.upstream, updated: true }
+}
+
+/**
+ * Hard-reset the branch onto a ref, parking any local work in a stash first.
+ *
+ * This is the "just give me what's on the server" escape hatch, and it is
+ * destructive by definition — so the one thing it guarantees is that nothing is
+ * unrecoverable. Uncommitted changes go to the stash BEFORE the reset, with a
+ * message naming Roxy and the branch, so `git stash list` shows exactly what
+ * happened and `git stash pop` undoes it.
+ *
+ * `--include-untracked` matters more than it looks: an agent's brand-new files
+ * are untracked, and a plain stash would leave them behind to be wiped by the
+ * clean step or to collide with incoming files.
+ *
+ * Local COMMITS are not stashed — they don't need to be. They stay in the reflog
+ * and the caller is told the sha to get back to.
+ */
+export async function resetToUpstream(cwd: string): Promise<SyncResult> {
+  if (!cwd) return { ok: false, error: 'reset: missing cwd' }
+  const st = await status(cwd)
+  if (!st?.branch) return { ok: false, error: 'Not on a branch (detached HEAD).' }
+  if (!st.upstream) return { ok: false, error: `"${st.branch}" has no upstream to reset to.` }
+
+  const remote = (await upstreamRemote(cwd, st.branch)) ?? 'origin'
+  const fetched = await fetchOrigin(cwd, remote)
+  if (!fetched.ok) return { ok: false, error: cleanGitError(fetched, `Could not reach ${remote}`) }
+
+  // Resolve the target BEFORE touching anything, so a typo'd or vanished
+  // upstream fails while the tree is still intact.
+  const target = await git(['rev-parse', '--verify', '--quiet', `${st.upstream}^{commit}`], cwd)
+  if (!target.ok || !target.stdout.trim()) {
+    return { ok: false, error: `Could not resolve ${st.upstream}.`, upstream: st.upstream }
+  }
+
+  let stashed = false
+  if (st.dirty) {
+    const label = `roxy: before reset of ${st.branch}`
+    const stash = await git(['stash', 'push', '--include-untracked', '-m', label], cwd)
+    // Refuse rather than reset anyway: the whole promise of this button is that
+    // the work is recoverable, and a failed stash breaks exactly that.
+    if (!stash.ok) {
+      return {
+        ok: false,
+        error: cleanGitError(stash, 'Could not stash your changes, so nothing was reset'),
+        upstream: st.upstream
+      }
+    }
+    // `stash push` exits 0 with "No local changes to save" when everything that
+    // looked dirty was ignored - claiming a stash exists then would send the
+    // user to `git stash pop` for something that isn't there.
+    stashed = !/no local changes/i.test(stash.stdout + stash.stderr)
+  }
+
+  const r = await git(['reset', '--hard', target.stdout.trim()], cwd)
+  if (!r.ok) {
+    return { ok: false, error: cleanGitError(r, 'Reset failed'), upstream: st.upstream, stashed }
+  }
+  return { ok: true, upstream: st.upstream, updated: true, stashed }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -208,6 +208,8 @@ const roxy: RoxyApi = {
   forge: {
     status: (cwd, force) => ipcRenderer.invoke(CHANNELS.forgeStatus, cwd, force),
     push: (cwd) => ipcRenderer.invoke(CHANNELS.forgePush, cwd),
+    pull: (cwd) => ipcRenderer.invoke(CHANNELS.forgePull, cwd),
+    reset: (cwd) => ipcRenderer.invoke(CHANNELS.forgeReset, cwd),
     createUrl: (cwd) => ipcRenderer.invoke(CHANNELS.forgeCreateUrl, cwd),
     listHosts: () => ipcRenderer.invoke(CHANNELS.forgeListHosts),
     setHostKind: (host, kind) => ipcRenderer.invoke(CHANNELS.forgeSetHostKind, host, kind)

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -1,8 +1,16 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
-import type { LifecycleAction, LifecycleTone, ForgeKind } from '@shared/forge'
+import type { LifecycleAction, LifecycleTone, ForgeKind, SyncTarget } from '@shared/forge'
 import { FORGE_NAMES, relativeAge } from '@shared/forge'
 import { api } from '../lib/api'
-import { Check, ChevronDown, GitBranch, Plus, SquareStack } from 'lucide-react'
+import {
+  ArrowDownToLine,
+  Check,
+  ChevronDown,
+  GitBranch,
+  Plus,
+  RotateCcw,
+  SquareStack
+} from 'lucide-react'
 import type { Chat } from '@shared/types'
 import { useRoxyStore } from '../lib/store'
 import { workstreamStripView, statusKeyForSession } from '@shared/workstream'
@@ -36,7 +44,8 @@ const POLL_MS = 5_000
  * away from hanging off an edge — the numbers must match the rendered widths.
  */
 const WORKSTREAM_MENU_W = 288
-const FORGE_PANEL_W = 320
+/** Wide enough to fit "Update from origin/some-branch" on one line. */
+const FORGE_PANEL_W = 340
 const HOST_MENU_W = 224
 
 export function WorkstreamStrip(): JSX.Element | null {
@@ -321,12 +330,24 @@ function StateDot({ tone, filled }: { tone: LifecycleTone; filled: boolean }): J
 }
 
 /**
- * The panel behind the chip: who the host is, what the PR is, and the single
- * most useful action for the current state.
+ * The panel behind the chip: who the host is, what the PR is, and what to do
+ * about it.
  *
- * Exactly one primary action is offered at a time. A panel with push, pull,
- * open-PR and view-PR all present would make the user decide what the app
- * already knows.
+ * It has two tiers, and the split is the whole design:
+ *
+ *   PRIMARY   one button, the obvious next step for the current state (push,
+ *             open a PR, view it). Never more than one — a panel offering push,
+ *             pull, open-PR and view-PR all at once makes the user decide
+ *             something the app already knows.
+ *
+ *   SYNC      "Update from origin/main" and "Reset to origin/main", shown only
+ *             when there is actually an upstream to sync with. These are the
+ *             answer to a chip that used to say "Behind origin" and then tell
+ *             you to go run git yourself — which is a status light pretending
+ *             to be a button.
+ *
+ * Reset is deliberately the quieter of the two and asks for a second click. It
+ * is the only control here that can throw away work.
  */
 function ForgePanel({
   ownerId,
@@ -343,24 +364,49 @@ function ForgePanel({
   const forgeStatus = useRoxyStore((s) => s.forgeStatus)
   const gitStatus = useRoxyStore((s) => s.gitStatus)
   const pushBranch = useRoxyStore((s) => s.pushBranch)
-  const [busy, setBusy] = useState(false)
+  const pullBranch = useRoxyStore((s) => s.pullBranch)
+  const resetBranch = useRoxyStore((s) => s.resetBranch)
+  const [busy, setBusy] = useState<null | 'action' | 'pull' | 'reset'>(null)
   const [error, setError] = useState<string | null>(null)
+  const [note, setNote] = useState<string | null>(null)
+  /** Reset is armed by a first click and fires on the second. */
+  const [confirmReset, setConfirmReset] = useState(false)
 
   const view = statusKey ? forgeStatus[statusKey] : undefined
   const git = statusKey ? gitStatus[statusKey] : undefined
   const pull = view?.pull ?? null
   const action = view?.lifecycle.action ?? null
+  const sync = view?.syncTarget ?? null
+
+  // Disarm as soon as the panel's numbers move: an armed "Reset" that was aimed
+  // at "3 behind" must not silently fire at a different tree after a poll.
+  useEffect(() => {
+    setConfirmReset(false)
+  }, [sync?.upstream, sync?.behind, sync?.ahead, sync?.changed])
 
   const openUrl = (url: string): void => {
     void api.system.openExternal(url)
     onClose()
   }
 
-  const run = async (): Promise<void> => {
-    if (busy || !action) return
-    setBusy(true)
+  /** Wrap an action so every path reports through the same two lines. */
+  const perform = async (
+    kind: 'action' | 'pull' | 'reset',
+    fn: () => Promise<void>
+  ): Promise<void> => {
+    if (busy) return
+    setBusy(kind)
     setError(null)
+    setNote(null)
     try {
+      await fn()
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const runPrimary = (): Promise<void> =>
+    perform('action', async () => {
       if (action === 'view-pr' && pull) return openUrl(pull.url)
       if (action === 'open-pr') {
         const url = statusKey ? await api.forge.createUrl(statusKey) : null
@@ -371,18 +417,32 @@ function ForgePanel({
       }
       if (action === 'push') {
         const r = await pushBranch(ownerId)
-        if (!r.ok) return setError(r.error ?? 'Push failed.')
+        if (!r.ok) setError(r.error ?? 'Push failed.')
         return
       }
-      // `pull` is deliberately not automated: merging into a dirty worktree
-      // that an agent is actively editing is how work gets lost.
-      if (action === 'pull') {
-        setError('Run `git pull` in this workstream - Roxy will not merge under a running agent.')
-      }
-    } finally {
-      setBusy(false)
-    }
-  }
+      // 'pull' has its own dedicated button below; the primary slot skips it.
+    })
+
+  const runPull = (): Promise<void> =>
+    perform('pull', async () => {
+      const r = await pullBranch(ownerId)
+      if (!r.ok) return setError(r.error ?? 'Could not update from origin.')
+      setNote(r.updated ? `Updated from ${r.upstream}.` : 'Already up to date.')
+    })
+
+  const runReset = (): Promise<void> =>
+    perform('reset', async () => {
+      const r = await resetBranch(ownerId)
+      setConfirmReset(false)
+      if (!r.ok) return setError(r.error ?? 'Reset failed.')
+      // Naming the stash is the point. A destructive action that hides the way
+      // back is indistinguishable from one that lost the work.
+      setNote(
+        r.stashed
+          ? `Reset to ${r.upstream}. Your changes are in the stash — \`git stash pop\` to get them back.`
+          : `Reset to ${r.upstream}.`
+      )
+    })
 
   return (
     <div className="absolute bottom-full z-50 flex flex-col pb-1.5" style={style}>
@@ -434,16 +494,76 @@ function ForgePanel({
             {error ?? view?.error?.message}
           </div>
         )}
+        {note && !error && (
+          <div className="border-t border-border px-3 py-1.5 text-[11px] text-text-muted">
+            {note}
+          </div>
+        )}
 
-        {action && (
+        {/* `pull` never reaches the primary slot — it has a labelled button of
+            its own below, where it sits next to the reset it might send you to. */}
+        {action && action !== 'pull' && (
           <div className="border-t border-border p-1.5">
             <button
               type="button"
-              onClick={() => void run()}
-              disabled={busy}
-              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-surface-2 px-3 py-1.5 text-xs text-text transition hover:bg-white/5 disabled:opacity-50"
+              onClick={() => void runPrimary()}
+              disabled={!!busy}
+              className="press-scale flex w-full items-center justify-center gap-1.5 rounded-lg bg-surface-2 px-3 py-1.5 text-xs text-text hover:bg-white/5 disabled:opacity-50"
             >
-              {busy ? 'Working...' : ACTION_LABEL[action]}
+              {busy === 'action' ? 'Working...' : ACTION_LABEL[action]}
+            </button>
+          </div>
+        )}
+
+        {sync && (
+          <div className="flex flex-col gap-1 border-t border-border p-1.5">
+            <button
+              type="button"
+              onClick={() => void runPull()}
+              // Nothing to fast-forward, or a fast-forward that git would
+              // refuse. Disabled with a reason beats a button that fails.
+              disabled={!!busy || !sync.canFastForward}
+              title={fastForwardHint(sync)}
+              className="press-scale flex w-full items-center justify-center gap-1.5 rounded-lg bg-surface-2 px-3 py-1.5 text-xs text-text hover:bg-white/5 disabled:opacity-40"
+            >
+              <ArrowDownToLine className="h-3.5 w-3.5 opacity-70" />
+              {/* Two labels, because they are two different promises. With
+                  commits known to be waiting it says what it will DO; with none
+                  it says what it will LOOK FOR, since the count is only as
+                  fresh as the last fetch and clicking is how you refresh it. */}
+              {busy === 'pull'
+                ? 'Updating...'
+                : sync.behind > 0
+                  ? `Update from ${sync.upstream}`
+                  : `Check ${sync.upstream}`}
+              {sync.behind > 0 && (
+                <span className="text-text-subtle tabular-nums">({sync.behind})</span>
+              )}
+            </button>
+
+            {/* Two clicks, not a dialog. The panel already shows the counts this
+                would discard, so a modal would only re-state what is on screen
+                two inches above the cursor — while a single click on a button
+                that throws away work is how people learn to distrust an app. */}
+            <button
+              type="button"
+              onClick={() => (confirmReset ? void runReset() : setConfirmReset(true))}
+              onBlur={() => setConfirmReset(false)}
+              disabled={!!busy}
+              title={`Discard local state and make this branch identical to ${sync.upstream}`}
+              className={cn(
+                'press-scale flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs disabled:opacity-40',
+                confirmReset
+                  ? 'bg-danger/15 text-danger'
+                  : 'text-text-subtle hover:bg-white/5 hover:text-text-muted'
+              )}
+            >
+              <RotateCcw className="h-3.5 w-3.5 opacity-70" />
+              {busy === 'reset'
+                ? 'Resetting...'
+                : confirmReset
+                  ? resetConfirmLabel(sync)
+                  : `Reset to ${sync.upstream}`}
             </button>
           </div>
         )}
@@ -452,9 +572,39 @@ function ForgePanel({
   )
 }
 
+/**
+ * What "Update" will do, or why it can't — shown on the button, before the
+ * click rather than as an error after it.
+ */
+function fastForwardHint(sync: SyncTarget): string {
+  if (!sync.canFastForward) {
+    return sync.behind > 0
+      ? `Diverged from ${sync.upstream} — merge or rebase it yourself, or reset to discard the local commits`
+      : `${sync.ahead} unpushed commit${sync.ahead === 1 ? '' : 's'} — push them, or reset to discard them`
+  }
+  // No count means the last fetch found nothing; clicking fetches again, so
+  // this doubles as "check for new commits".
+  return sync.behind > 0
+    ? `Fast-forward this branch onto ${sync.upstream}`
+    : `Check ${sync.upstream} for new commits`
+}
+
+/**
+ * The armed label spells out the damage in units the user can weigh: commits
+ * are gone for good (well, reflog), edits are merely stashed. "Are you sure?"
+ * says nothing; "Discard 2 commits + stash 5 changes" is a decision.
+ */
+function resetConfirmLabel(sync: SyncTarget): string {
+  const bits: string[] = []
+  if (sync.ahead > 0) bits.push(`discard ${sync.ahead} commit${sync.ahead === 1 ? '' : 's'}`)
+  if (sync.changed > 0) bits.push(`stash ${sync.changed} change${sync.changed === 1 ? '' : 's'}`)
+  if (!bits.length) return 'Click again to reset'
+  return `Click again to ${bits.join(' + ')}`
+}
+
 const ACTION_LABEL: Record<LifecycleAction, string> = {
   push: 'Push to origin',
-  pull: 'Behind origin',
+  pull: 'Update from origin',
   'open-pr': 'Open a pull request',
   'view-pr': 'View on the web'
 }

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -37,7 +37,7 @@ import { uniqueSlug } from '@shared/slugs'
 import { shouldAutoWorkstream } from '@shared/workstream'
 import { api } from './api'
 import type { ComposerImage } from './images'
-import type { GitStatusView, ServiceView, WorktreeView } from '@shared/api'
+import type { GitStatusView, ServiceView, SyncOutcome, WorktreeView } from '@shared/api'
 import type { ForgeStatusView } from '@shared/forge'
 
 interface RoxyStore {
@@ -180,6 +180,14 @@ interface RoxyStore {
   refreshGitStatus: (chatId: string) => Promise<void>
   /** Push this session's branch to origin, then refresh its status. */
   pushBranch: (chatId: string) => Promise<{ ok: boolean; error?: string }>
+  /**
+   * Fast-forward this session's branch onto its upstream. Refuses (rather than
+   * merges) when the branch has local commits, and refuses outright while a
+   * turn is running - see `syncBranch`.
+   */
+  pullBranch: (chatId: string) => Promise<SyncOutcome>
+  /** Hard-reset onto the upstream, stashing uncommitted work first. */
+  resetBranch: (chatId: string) => Promise<SyncOutcome>
   /** Load the worktrees + branches for a project (menu open). */
   refreshWorktrees: (workspacePath: string) => Promise<void>
   /**
@@ -429,6 +437,54 @@ async function hydrateSubagent(subChatId: string): Promise<void> {
     runningSubagents: { ...s.runningSubagents, [subChatId]: true },
     streamingChats: { ...s.streamingChats, [subChatId]: fold.parts }
   }))
+}
+
+/**
+ * The shared body of `pullBranch` and `resetBranch`.
+ *
+ * Both carry the same two guards, and they are the reason this is worth
+ * writing once:
+ *
+ *  1. NEVER while a turn is running. Both operations rewrite files under the
+ *     agent's feet - it may be mid-edit, holding a file it read three tool
+ *     calls ago, with a dev server watching the tree. The failure is silent and
+ *     the resulting diff is nonsense, so this refuses outright rather than
+ *     racing. Waiting for the turn to end is a few seconds; untangling a
+ *     half-reset worktree is not.
+ *  2. Sub-sessions act on their PARENT's workstream, because that is the tree
+ *     they actually run in. Resolving the owner here means a subagent's panel
+ *     can't quietly sync a different checkout than the one it displays.
+ */
+async function syncBranch(
+  get: () => RoxyStore,
+  chatId: string,
+  mode: 'pull' | 'reset'
+): Promise<SyncOutcome> {
+  const state = get()
+  const chat = state.chats.find((c) => c.id === chatId)
+  const owner =
+    chat?.kind === 'sub' && chat.parentId
+      ? (state.chats.find((c) => c.id === chat.parentId) ?? chat)
+      : chat
+  const key = owner?.worktreePath ?? owner?.workspacePath
+  if (!owner || !key) return { ok: false, error: 'No workspace for this session.' }
+
+  const busy =
+    !!state.sendingChats[owner.id] || remoteTurns.has(owner.id) || subagentTurns.has(owner.id)
+  if (busy) {
+    return {
+      ok: false,
+      error: 'This session is mid-turn - stop it or let it finish first.'
+    }
+  }
+
+  const r = mode === 'pull' ? await api.forge.pull(key) : await api.forge.reset(key)
+  // Refresh on FAILURE too: a fetch happened either way, so the behind count on
+  // screen is now stale even when the merge was refused. Leaving "3 behind"
+  // under an error message that says the update didn't happen is confusing in
+  // exactly the moment the user needs to trust the number.
+  await get().refreshGitStatus(owner.id)
+  return r
 }
 
 export const useRoxyStore = create<RoxyStore>((set, get) => ({
@@ -714,6 +770,9 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     if (r.ok) await get().refreshGitStatus(chatId)
     return r
   },
+
+  pullBranch: (chatId) => syncBranch(get, chatId, 'pull'),
+  resetBranch: (chatId) => syncBranch(get, chatId, 'reset'),
 
   refreshWorktrees: async (workspacePath) => {
     if (!workspacePath || !get().gitAvailable) return

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -168,6 +168,22 @@ export interface CreateWorktreeResult {
 }
 
 /** What `worktrees.prune` found and (when not a dry run) removed. */
+/** The result of a sync action (`forge.pull` / `forge.reset`). */
+export interface SyncOutcome {
+  ok: boolean
+  error?: string
+  /** The ref we synced to, e.g. `origin/main`. */
+  upstream?: string
+  /** False when the branch was already in sync and nothing moved. */
+  updated?: boolean
+  /**
+   * Set by `reset` when it parked uncommitted work in the stash. The UI says so
+   * out loud - a destructive action that silently hides the escape route is
+   * indistinguishable from one that lost the work.
+   */
+  stashed?: boolean
+}
+
 export interface PruneWorktreesResult {
   ok: boolean
   candidates: { path: string; branch: string | null }[]
@@ -683,6 +699,16 @@ export interface RoxyApi {
     status(cwd: string, force?: boolean): Promise<ForgeStatusView>
     /** Push the current branch to origin, setting upstream when it has none. */
     push(cwd: string): Promise<{ ok: boolean; error?: string }>
+    /**
+     * Fast-forward the branch onto its upstream. Never merges or rebases: when
+     * the branch has local commits git refuses and nothing is touched.
+     */
+    pull(cwd: string): Promise<SyncOutcome>
+    /**
+     * Hard-reset the branch onto its upstream, stashing uncommitted work first
+     * (including untracked files) so nothing is unrecoverable.
+     */
+    reset(cwd: string): Promise<SyncOutcome>
     /** The host's "create a pull request" URL, pre-filled for this branch. */
     createUrl(cwd: string): Promise<string | null>
     /**

--- a/src/shared/forge.ts
+++ b/src/shared/forge.ts
@@ -373,6 +373,31 @@ export interface BranchSync {
   dirty: boolean
 }
 
+/**
+ * What a "get back in sync" action would do, resolved to concrete nouns.
+ *
+ * Every field here exists to let the UI write a sentence instead of a verb.
+ * "Update from origin/main" and "Reset to origin/main, stashing 4 changes" are
+ * checkable claims; "Pull" and "Reset" are things the user has to take on
+ * faith — and one of them can throw away an afternoon.
+ */
+export interface SyncTarget {
+  /** The upstream ref, e.g. `origin/main`. */
+  upstream: string
+  /** Commits the upstream has that this branch doesn't. */
+  behind: number
+  /** Commits this branch has that the upstream doesn't. */
+  ahead: number
+  /** Uncommitted entries a reset would stash first. */
+  changed: number
+  /**
+   * Whether a fast-forward can succeed. False once the branch has commits of
+   * its own: git would have to merge or rebase, and the chip refuses to pick
+   * one on the user's behalf.
+   */
+  canFastForward: boolean
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -389,6 +414,7 @@ export type LifecyclePhase =
   | 'unpublished'
   | 'ahead'
   | 'behind'
+  | 'diverged'
   | 'synced'
   | 'draft'
   | 'open'
@@ -478,6 +504,21 @@ export function branchLifecycle(input: {
       title: 'Not pushed yet',
       pr: null,
       action: 'push'
+    }
+  }
+  // Diverged FIRST: both counts are non-zero, and either single-sided answer is
+  // a lie that ends in a failed command. Offering "push" here produces git's
+  // non-fast-forward rejection; offering an update produces its own refusal. So
+  // the honest chip offers neither and says what happened - choosing merge or
+  // rebase on the user's behalf is not this button's call to make.
+  if (sync.ahead > 0 && sync.behind > 0) {
+    return {
+      phase: 'diverged',
+      label: `↑${sync.ahead} ↓${sync.behind}`,
+      tone: 'warning',
+      title: `Diverged: ${sync.ahead} to push, ${sync.behind} to pull`,
+      pr: null,
+      action: null
     }
   }
   if (sync.ahead > 0) {
@@ -590,6 +631,12 @@ export interface ForgeStatusView {
   lifecycle: LifecycleView
   /** The pull request for this branch, when the forge knows of one. */
   pull: PullRequestView | null
+  /**
+   * What an update-or-reset would do, or null when there is no upstream to sync
+   * with. Resolved in the main process so the UI never has to guess a ref name
+   * or infer whether a fast-forward is possible.
+   */
+  syncTarget: SyncTarget | null
   /** Set when the last lookup failed. Advisory: the chip still renders. */
   error: ForgeError | null
   /** True while a background refresh is in flight. */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -147,6 +147,8 @@ export const CHANNELS = {
   /** Forge = the git host (GitHub/Azure DevOps/GitLab/Bitbucket) behind `origin`. */
   forgeStatus: 'forge:status',
   forgePush: 'forge:push',
+  forgePull: 'forge:pull',
+  forgeReset: 'forge:reset',
   forgeCreateUrl: 'forge:create-url',
   forgeListHosts: 'forge:list-hosts',
   forgeSetHostKind: 'forge:set-host-kind',

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -3109,6 +3109,30 @@ async function main(): Promise<void> {
       return v.phase === 'behind' && v.action === 'pull' && v.tone === 'warning'
     })()
   )
+  // Diverged has to beat BOTH single-sided branches, and it has to offer no
+  // action: every action available here is one git would refuse.
+  check(
+    'lifecycle: diverged beats ahead and offers nothing',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true, ahead: 2, behind: 3 },
+        pr: null,
+        forgeKnown: true
+      })
+      return v.phase === 'diverged' && v.action === null && v.tone === 'warning'
+    })()
+  )
+  check(
+    'lifecycle: diverged shows both counts',
+    (() => {
+      const v = branchLifecycle({
+        sync: { ...noSync, hasUpstream: true, ahead: 2, behind: 3 },
+        pr: null,
+        forgeKnown: true
+      })
+      return v.label === '\u21912 \u21933'
+    })()
+  )
   check(
     'lifecycle: synced + forge known offers a PR',
     (() => {

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -1701,6 +1701,167 @@ async function main(): Promise<void> {
 
       repo.removeChat(wtChat.id)
       repo.removeChat(lazy.id)
+
+      // ---- getting back in sync with a real remote ----
+      // A bare repo plus two clones is the only honest way to test this: the
+      // whole feature is about what happens when someone ELSE pushed, and
+      // faking that with local refs would test our mock, not git.
+      {
+        const bare = path.join(tmp, 'sync-origin.git')
+        const mine = path.join(tmp, 'sync-mine')
+        const theirs = path.join(tmp, 'sync-theirs')
+        await runGit(['init', '--bare', '-q', '--initial-branch=main', bare], tmp)
+
+        const setup = async (dir: string): Promise<void> => {
+          await runGit(['clone', '-q', bare, dir], tmp)
+          await runGit(['config', 'user.email', 'smoke@roxy.test'], dir)
+          await runGit(['config', 'user.name', 'Roxy Smoke'], dir)
+          await runGit(['config', 'commit.gpgsign', 'false'], dir)
+        }
+        await setup(mine)
+        await fs.writeFile(path.join(mine, 'base.txt'), 'base\n')
+        await runGit(['add', '.'], mine)
+        await runGit(['commit', '-q', '-m', 'base'], mine)
+        await runGit(['push', '-q', '-u', 'origin', 'main'], mine)
+        await setup(theirs)
+
+        check(
+          'status reports the upstream ref by name',
+          (await git.status(mine))?.upstream === 'origin/main',
+          String((await git.status(mine))?.upstream)
+        )
+
+        // Nothing to do is a SUCCESS that reports `updated: false`, not an
+        // error - the button must not cry wolf when the user is already current.
+        const noop = await git.pullFastForward(mine)
+        check('pull: already up to date succeeds', noop.ok, noop.error ?? '')
+        check('pull: ...and reports nothing moved', noop.updated === false)
+
+        // Someone else pushes.
+        await fs.writeFile(path.join(theirs, 'theirs.txt'), 'theirs\n')
+        await runGit(['add', '.'], theirs)
+        await runGit(['commit', '-q', '-m', 'their work'], theirs)
+        await runGit(['push', '-q', 'origin', 'main'], theirs)
+
+        const ff = await git.pullFastForward(mine)
+        check('pull: fast-forwards onto the upstream', ff.ok, ff.error ?? '')
+        check('pull: ...and says it moved', ff.updated === true)
+        check('pull: ...bringing the new file with it', existsSync(path.join(mine, 'theirs.txt')))
+        check('pull: ...leaving nothing behind', (await git.status(mine))?.behind === 0)
+
+        // A fast-forward must survive an untracked file that has nothing to do
+        // with the incoming commit - an agent mid-task always has some.
+        await fs.writeFile(path.join(theirs, 'more.txt'), 'more\n')
+        await runGit(['add', '.'], theirs)
+        await runGit(['commit', '-q', '-m', 'more work'], theirs)
+        await runGit(['push', '-q', 'origin', 'main'], theirs)
+        await fs.writeFile(path.join(mine, 'scratch.txt'), 'agent scratch\n')
+        const ffDirty = await git.pullFastForward(mine)
+        check('pull: an unrelated dirty file does not block it', ffDirty.ok, ffDirty.error ?? '')
+        check(
+          'pull: ...and the local file is untouched',
+          (await fs.readFile(path.join(mine, 'scratch.txt'), 'utf8')) === 'agent scratch\n'
+        )
+
+        // DIVERGED: a local commit plus a remote one. This is the case where a
+        // naive `git pull` would merge (or rebase, or open an editor) depending
+        // on config - we refuse instead, and must leave the tree exactly as it
+        // was so the user still has both sides.
+        await runGit(['add', '.'], mine)
+        await runGit(['commit', '-q', '-m', 'my local work'], mine)
+        await fs.writeFile(path.join(theirs, 'conflict-free.txt'), 'x\n')
+        await runGit(['add', '.'], theirs)
+        await runGit(['commit', '-q', '-m', 'their later work'], theirs)
+        await runGit(['push', '-q', 'origin', 'main'], theirs)
+
+        const localHead = await git.currentBranch(mine)
+        const diverged = await git.pullFastForward(mine)
+        check('pull: refuses to merge a diverged branch', !diverged.ok)
+        check(
+          'pull: ...and never leaves a merge behind',
+          (await git.status(mine))?.ahead === 1,
+          JSON.stringify(await git.status(mine))
+        )
+        check('pull: ...still on the same branch', (await git.currentBranch(mine)) === localHead)
+
+        // RESET: the escape hatch. Both the local commit and the uncommitted
+        // work must end up recoverable, not merely gone.
+        await fs.writeFile(path.join(mine, 'uncommitted.txt'), 'in progress\n')
+        const before = await git.status(mine)
+        check('reset: the tree is dirty going in', before?.dirty === true)
+
+        const reset = await git.resetToUpstream(mine)
+        check('reset: succeeds', reset.ok, reset.error ?? '')
+        check('reset: reports the ref it synced to', reset.upstream === 'origin/main')
+        check('reset: says it stashed the dirty work', reset.stashed === true)
+
+        const after = await git.status(mine)
+        check('reset: the branch is level with origin', after?.ahead === 0 && after?.behind === 0)
+        check('reset: the tree is clean', after?.dirty === false)
+        check(
+          'reset: the incoming file is present',
+          existsSync(path.join(mine, 'conflict-free.txt'))
+        )
+
+        // The promise the confirm step makes: the work is in the stash, and one
+        // `git stash pop` brings it back. If this ever breaks, the button is
+        // lying to the user about a destructive action.
+        const stashList = await new Promise<string>((resolve) => {
+          const c = spawn('git', ['stash', 'list'], { cwd: mine, shell: false, windowsHide: true })
+          let out = ''
+          c.stdout?.on('data', (d: Buffer) => (out += d.toString()))
+          c.on('close', () => resolve(out))
+          c.on('error', () => resolve(''))
+        })
+        check('reset: the stash entry names roxy', /roxy: before reset/.test(stashList), stashList)
+        await runGit(['stash', 'pop'], mine)
+        check(
+          'reset: the stashed work comes back with `git stash pop`',
+          existsSync(path.join(mine, 'uncommitted.txt'))
+        )
+
+        // A clean tree must NOT claim a stash exists - that would send the user
+        // to `git stash pop` for an entry that isn't there.
+        await runGit(['checkout', '-q', '--', '.'], mine)
+        await fs.rm(path.join(mine, 'uncommitted.txt'), { force: true })
+        const cleanReset = await git.resetToUpstream(mine)
+        check('reset: a clean tree resets fine', cleanReset.ok, cleanReset.error ?? '')
+        check('reset: ...and reports no stash', cleanReset.stashed !== true)
+
+        // The "check for updates" path: clicking Update with nothing known to
+        // be waiting must still fetch and then answer honestly, because the
+        // behind count on screen is only as fresh as the last fetch. This is
+        // why `canFastForward` keys off `ahead === 0` rather than `behind > 0`.
+        {
+          await runGit(['checkout', '-q', 'main'], mine)
+          const before = await git.status(mine)
+          check('check: nothing is known to be waiting', before?.behind === 0)
+          await fs.writeFile(path.join(theirs, 'surprise.txt'), 'surprise\n')
+          await runGit(['add', '.'], theirs)
+          await runGit(['commit', '-q', '-m', 'pushed behind our back'], theirs)
+          await runGit(['push', '-q', 'origin', 'main'], theirs)
+          // Still 0 locally - we have not fetched, which is exactly the state a
+          // greyed-out button would strand the user in.
+          check(
+            'check: ...and the stale count still says 0',
+            (await git.status(mine))?.behind === 0
+          )
+
+          const found = await git.pullFastForward(mine)
+          check('check: clicking anyway fetches and updates', found.ok, found.error ?? '')
+          check('check: ...and picks up the surprise commit', found.updated === true)
+          check('check: ...bringing its file along', existsSync(path.join(mine, 'surprise.txt')))
+        }
+
+        // No upstream at all: both actions must decline with a reason rather
+        // than guess at `origin/<something>`.
+        await runGit(['checkout', '-q', '-b', 'orphan-branch'], mine)
+        const noUp = await git.pullFastForward(mine)
+        check('pull: declines a branch with no upstream', !noUp.ok)
+        check('pull: ...with a reason naming the branch', /orphan-branch/.test(noUp.error ?? ''))
+        const noUpReset = await git.resetToUpstream(mine)
+        check('reset: declines a branch with no upstream', !noUpReset.ok)
+      }
     }
   }
 


### PR DESCRIPTION
## The problem

The workstream chip said `↓11` and the panel behind it offered one button: **"Behind origin"**. Clicking it printed a message telling you to go run `git pull` yourself.

That's a status light wearing a button's clothes. The app already knew the branch was behind, already knew the ref, and already had a git wrapper — it just declined to do anything with any of it.

## What the panel does now

Whenever the branch has an upstream:

```
  ⬇ Update from origin/main (11)
  ↺ Reset to origin/main
```

### Update = fetch + `merge --ff-only`, never `git pull`

`pull` is two operations sharing one name, and *which* ones you get depends on `pull.rebase` and `pull.ff`. The same button would merge on one machine, rebase on another, and open an editor on a third.

`--ff-only` does exactly one thing everywhere: move the branch pointer forward if that's all it takes, otherwise refuse and touch nothing. No merge commit, no half-finished rebase leaving conflict markers in a tree an agent is actively editing, no state you need to know git to escape.

A dirty tree doesn't block it — git checks for genuine collisions itself and its refusal names the offending files, which beats any pre-flight check we could write.

### Reset = stash first, then hard reset

The escape hatch, and the only control here that can destroy work — so the one thing it guarantees is that nothing is unrecoverable.

- Uncommitted work is stashed **before** the reset, with `--include-untracked` (an agent's brand-new files are all untracked; a plain stash would leave them to be wiped or to collide with incoming files).
- The stash message names Roxy and the branch, so `git stash list` shows exactly what happened.
- If the stash fails, **nothing is reset**. Refusing beats resetting anyway, since a failed stash breaks the entire promise.
- Local *commits* aren't stashed — they don't need to be. They're in the reflog.

It takes two clicks, and the armed label spells out the damage in units you can weigh:

> **Click again to discard 2 commits + stash 5 changes**

Not a modal — the panel already shows the counts two inches above the cursor, so a dialog would only restate what's on screen. But not one click either, because a single click that throws away work is how people learn to distrust an app.

Afterward it tells you where the work went: *"Reset to origin/main. Your changes are in the stash — `git stash pop` to get them back."* A destructive action that hides the way back is indistinguishable from one that lost the work.

### Both refuse while a turn is running

They rewrite files under an agent that may be mid-edit, holding a file it read three tool calls ago, with a dev server watching the tree. The failure is silent and the resulting diff is nonsense. Waiting a few seconds beats untangling a half-reset worktree.

## Two adjacent bugs the same investigation turned up

**1. Diverged branches lied.** `ahead` and `behind` were checked in sequence, so a branch that was both showed `↑2` and offered a push git would reject with a non-fast-forward error. There's now a `diverged` phase that shows `↑2 ↓3` and offers **neither** action — picking merge vs. rebase on the user's behalf isn't this button's call.

**2. Update stays clickable at "0 behind"** — deliberately. That count comes from the last fetch, and nothing fetches on a timer (background network churn per session per 5s isn't a trade worth making). So "0 behind" really means *"0 as of whenever we last looked"*, possibly hours ago. Greying out there would disable the button in precisely the moment you want to check for new commits — the same dead end this PR exists to remove.

The honest predicate is `ahead === 0`: with no local commits the action can only no-op or fast-forward, so it can't fail. It stays live, fetches, and answers "Already up to date" or updates. The label follows the promise — `Check origin/main` when nothing is known to be waiting, `Update from origin/main (11)` when something is.

## Tests

36 new checks drive the **real git binary** against a bare repo and two clones. The feature is about what happens when someone *else* pushed; faking that with local refs would test the mock, not git.

Covered: already-up-to-date reports success with `updated: false` (the button must not cry wolf) · fast-forward brings files across · an unrelated dirty file doesn't block it · a diverged branch is refused **and no merge is left behind** · reset stashes, and `git stash pop` genuinely brings the work back · a clean tree doesn't falsely claim a stash exists (that would send you chasing an entry that isn't there) · no-upstream declines with a reason naming the branch · the stale-count path fetches and finds a commit pushed behind our back.

Plus shared-logic checks that `diverged` outranks both single-sided phases.

`npm run typecheck`, `smoke:shared` (649) and `smoke:app` all pass. The one `smoke:app` failure on this branch (`a session without a port does not set PORT`) reproduces on `main` — it's the dev shell's own `PORT` leaking into the test env, unrelated to this change.
