### PR TITLE
Push worktree materialization to the renderer

### DIFF
--- a/src/main/services/session-events.ts
+++ b/src/main/services/session-events.ts
@@ -1,0 +1,47 @@
+/**
+ * main -> renderer pushes for session rows that MAIN changes on its own.
+ *
+ * Most session mutations are renderer-initiated (`chats:rename`, `chats:create`)
+ * so the store refreshes off the call it just made. Three are not, and they are
+ * exactly the ones the workstream strip displays:
+ *
+ *   - `worktree_path` + `branch`, written by lazy worktree materialization on
+ *     the first turn (services/worktree.ts);
+ *   - `branch` again, when the agent retitles its own session and the branch
+ *     follows (syncBranchToTitle);
+ *   - `dev_port`, allocated alongside the worktree.
+ *
+ * Without a push, the renderer's copy of those fields stays whatever it was when
+ * the session was created — i.e. empty — for the WHOLE first turn, which can be
+ * many minutes. The strip renders "(pending) / branch pending" the entire time
+ * even though the worktree exists and the agent is already writing files in it.
+ *
+ * Broadcast to every window rather than replying to one, for the same reason
+ * background-tasks.ts does: the write happens on the turn path, which may have
+ * been started by the phone (remote host) or by a loop heartbeat, so there is no
+ * "the window that asked" to answer.
+ */
+import { BrowserWindow } from 'electron'
+import { CHANNELS } from '../../shared/ipc'
+import type { SessionsUpdated } from '../../shared/api'
+
+/**
+ * Tell every window that session rows changed and why.
+ *
+ * `reason` is not decoration: the renderer does strictly more work for
+ * `worktree` (it has to prime git status for a path key it has never polled)
+ * than for a plain metadata change, and guessing from a diff of the chat list
+ * would be both slower and easy to get wrong.
+ *
+ * Never throws. This rides along with worktree creation on the turn path, and a
+ * torn-down window must not be able to fail a turn.
+ */
+export function emitSessionsUpdated(payload: SessionsUpdated): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    try {
+      if (!win.isDestroyed()) win.webContents.send(CHANNELS.chatsUpdated, payload)
+    } catch {
+      // window went away mid-send — ignore
+    }
+  }
+}

--- a/src/main/services/worktree.ts
+++ b/src/main/services/worktree.ts
@@ -23,6 +23,7 @@ import * as git from './git'
 import { ensureDevPort } from './ports'
 import { startBackground, killSessionBackground } from '../harness'
 import { activeBackgroundSubChatIds, hasActiveBackgroundJobs } from './background-tasks'
+import { emitSessionsUpdated } from './session-events'
 import type { WorktreeIntent } from '../../shared/types'
 
 /**
@@ -143,6 +144,18 @@ export async function materializePendingWorktree(chatId: string): Promise<Materi
   // install that builds against a port sees the right one. Allocation failure
   // (range exhausted) is not fatal — the session just has no reserved port.
   const devPort = await ensureDevPort(chatId)
+
+  // The session just moved: it has a worktree, a branch and a port it did not
+  // have a moment ago, and every one of those is on screen. Announce it BEFORE
+  // the setup script (fire-and-forget, and often minutes long) so the strip
+  // stops saying "(pending) / branch pending" the instant that becomes untrue,
+  // rather than whenever the renderer next happens to refetch — which, on a
+  // first turn, is not until the whole turn ends.
+  emitSessionsUpdated({
+    reason: 'worktree',
+    sessionIds: [chatId],
+    statusKey: result.worktreePath
+  })
 
   // Fire-and-forget: installs take minutes, and the turn starts now.
   runSetupScript({
@@ -336,6 +349,10 @@ export async function syncBranchToTitle(
     if (!r.ok) return { renamed: false }
 
     repo.setChatWorktree(chat.id, { branch: next })
+    // The agent renamed its own session's branch. The renderer refreshes chats
+    // on this tool's `tool-end`, but that races the DB write and only reaches
+    // the window that ran the turn — a phone-driven or loop turn has none.
+    emitSessionsUpdated({ reason: 'branch', sessionIds: [chat.id], statusKey: chat.worktreePath })
     return { renamed: true, branch: next }
   } catch {
     // A metadata update must never fail because a branch rename did.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ import type {
   BrowserTab,
   RemoteState,
   RemoteDelta,
+  SessionsUpdated,
   SubagentDelta,
   UpdateState
 } from '../shared/api'
@@ -42,7 +43,13 @@ const roxy: RoxyApi = {
     rename: (id, title) => ipcRenderer.invoke(CHANNELS.chatsRename, id, title),
     remove: (id) => ipcRenderer.invoke(CHANNELS.chatsRemove, id),
     reorder: (workspacePath, ids) => ipcRenderer.invoke(CHANNELS.chatsReorder, workspacePath, ids),
-    setConfig: (id, patch) => ipcRenderer.invoke(CHANNELS.chatsSetConfig, id, patch)
+    setConfig: (id, patch) => ipcRenderer.invoke(CHANNELS.chatsSetConfig, id, patch),
+    onUpdated: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: SessionsUpdated): void =>
+        callback(payload)
+      ipcRenderer.on(CHANNELS.chatsUpdated, handler)
+      return () => ipcRenderer.removeListener(CHANNELS.chatsUpdated, handler)
+    }
   },
   projects: {
     listOrder: () => ipcRenderer.invoke(CHANNELS.projectsListOrder),

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -18,6 +18,7 @@ import type {
   ModelInfo,
   RemoteDelta,
   RemoteState,
+  SessionsUpdated,
   SubagentDelta,
   TaskUpdate
 } from '@shared/api'
@@ -203,6 +204,7 @@ let taskUpdateSubscribed = false
 let remoteStateSubscribed = false
 let remoteDeltaSubscribed = false
 let subagentDeltaSubscribed = false
+let chatsUpdatedSubscribed = false
 /** Routes streamed completion events to the in-flight send for a request id. */
 const deltaHandlers = new Map<string, (event: LlmEvent) => void>()
 /** The active llm request id per chat, so stop() can abort the right stream. */
@@ -324,6 +326,42 @@ function applyRemoteDelta(payload: RemoteDelta): void {
     remoteTurns.set(sessionId, turn)
   }
   reflect(turn.apply(payload.event))
+}
+
+/**
+ * Apply a main-process session change: refetch the rows, and — when a worktree
+ * just came into existence — prime the git status for its brand-new path.
+ *
+ * The priming is the non-obvious half. `gitStatus` is keyed by PATH, and until
+ * now the session was keyed by its project folder; the worktree path has never
+ * been polled, so it has no entry. `workstreamStripView` renders NOTHING without
+ * a status, so a plain refetch would swap "(pending)" for an empty row that pops
+ * back a few seconds later on the next poll tick — trading a stale strip for a
+ * flickering one. Fetching the status for the new key first means the row goes
+ * straight from pending to live, with no blank frame in between.
+ */
+async function applySessionsUpdated(payload: SessionsUpdated): Promise<void> {
+  const store = useRoxyStore.getState()
+  if (payload.reason === 'worktree' && payload.statusKey) {
+    const key = payload.statusKey
+    if (!store.gitStatus[key]) {
+      try {
+        const [status, forge] = await Promise.all([api.git.status(key), api.forge.status(key)])
+        useRoxyStore.setState((s) => ({
+          gitStatus: { ...s.gitStatus, [key]: status },
+          forgeStatus: forge ? { ...s.forgeStatus, [key]: forge } : s.forgeStatus
+        }))
+      } catch {
+        // Best-effort: the 5s poll picks it up. Must never block the refresh
+        // below, which is what actually clears the stale "pending" label.
+      }
+    }
+    // A new worktree is also a new row in the project's worktree list, which the
+    // workstream menu reads. Cheap, and only on this rare event.
+    const workspace = store.chats.find((c) => c.id === payload.sessionIds[0])?.workspacePath
+    if (workspace) void store.refreshWorktrees(workspace)
+  }
+  await useRoxyStore.getState().refreshChats()
 }
 
 /**
@@ -506,6 +544,16 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     if (!llmDeltaSubscribed) {
       llmDeltaSubscribed = true
       api.llm.onDelta(({ requestId, event }) => deltaHandlers.get(requestId)?.(event))
+    }
+
+    // Session rows the MAIN process changed on its own. The big one is lazy
+    // worktree materialization: a session's worktree, branch and dev port are
+    // all written by main on the first turn, so without this push the strip
+    // below the composer keeps insisting "(pending) / branch pending" for the
+    // whole turn — minutes of the UI contradicting what is already on disk.
+    if (!chatsUpdatedSubscribed) {
+      chatsUpdatedSubscribed = true
+      api.chats.onUpdated((payload) => void applySessionsUpdated(payload))
     }
 
     // Background subagent tasks (Phase 11) report state out-of-band — they can

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -296,6 +296,32 @@ export interface SubagentRunView {
   startedAt: number
 }
 
+/**
+ * main -> renderer: session rows changed in MAIN, with no renderer call to hang
+ * a refresh off.
+ *
+ * `worktree_path`, `branch` and `dev_port` are written by the main process on
+ * the turn path (lazy worktree materialization), so the renderer's copy is stale
+ * from the moment the turn starts until something unrelated refetches. This is
+ * the push that closes that window.
+ */
+export interface SessionsUpdated {
+  /**
+   * Why the rows changed. `worktree` is the one that needs more than a refetch:
+   * the session just moved to a git path the renderer has never polled, so its
+   * status map has no entry for it yet.
+   */
+  reason: 'worktree' | 'branch' | 'metadata'
+  /** The sessions affected — usually one. */
+  sessionIds: string[]
+  /**
+   * The session's git path after the change (its worktree, else its project
+   * folder), so the renderer can prime `gitStatus` for a key it has never seen
+   * instead of blanking the strip until the next poll tick.
+   */
+  statusKey?: string | null
+}
+
 /** A background subagent task's lifecycle state, broadcast to all windows. */
 export interface TaskUpdate {
   jobId: string
@@ -493,6 +519,12 @@ export interface RoxyApi {
     setConfig(id: string, patch: SessionConfigPatch): Promise<Chat>
     /** Reorder a project's sessions; `ids` is the full project session list, top-to-bottom. */
     reorder(workspacePath: string | null, ids: string[]): Promise<void>
+    /**
+     * Subscribe to session rows changed by MAIN with no renderer call behind
+     * them — a worktree materialized on the first turn, a branch renamed under
+     * it. Returns an unsubscribe fn.
+     */
+    onUpdated(callback: (payload: SessionsUpdated) => void): () => void
   }
   projects: {
     /** Workspace paths in sidebar display order, top → bottom. */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -22,6 +22,14 @@ export const CHANNELS = {
   chatsReorder: 'chats:reorder',
   /** Pin part of a single session's inference config (model/mode/effort/context). */
   chatsSetConfig: 'chats:setConfig',
+  /**
+   * main -> renderer: a session row changed in MAIN, with no renderer call to
+   * hang a refresh off. The only source of truth for `worktree_path` / `branch`
+   * / `dev_port` is the main process, and it writes them mid-turn (lazy worktree
+   * materialization) — so without this push the workstream strip keeps claiming
+   * "(pending) / branch pending" until something unrelated happens to refetch.
+   */
+  chatsUpdated: 'chats:updated',
 
   /** Project (workspace) display order — read + drag-to-reorder. */
   projectsListOrder: 'projects:listOrder',

--- a/src/shared/workstream.ts
+++ b/src/shared/workstream.ts
@@ -60,7 +60,8 @@ export interface StripView {
  * Hidden (not greyed out) when there's no session, no workspace, no git binary,
  * or the folder isn't a repository — most folders aren't repos, and a permanent
  * disabled row would just be a nag. Also hidden until the first status arrives,
- * so it doesn't flash on and back off.
+ * so it doesn't flash on and back off — except for a session that already has a
+ * worktree, whose very existence is proof of a repo (see below).
  *
  * NOTE: the strip also hosts the Services segment, which is NOT git-scoped —
  * a dev server runs in any folder. So the row itself can outlive a null view;
@@ -86,7 +87,17 @@ export function workstreamStripView(input: {
   // Only real sessions get the dropdown: a sub inherits, and a loop has no
   // workstream of its own to change.
   const readOnly = chat.kind !== 'main'
-  if (!status?.isRepo) return null
+
+  // `worktreePath` counts as proof of a repo when no status has arrived yet:
+  // git only ever creates a worktree INSIDE a repository. That matters at
+  // exactly one moment, and it is the moment this screen exists for - a worktree
+  // materializing mid-turn moves the session onto a path the status map has
+  // never been keyed by, and reading that absent entry as "not a repo" would
+  // blank the row for a whole poll interval, right after it finally had
+  // something true to say. It does NOT outrank a status that actually arrived
+  // saying `isRepo: false`: that means the worktree went away underneath us, and
+  // the strip should go quiet.
+  if (status ? !status.isRepo : !owner.worktreePath) return null
 
   // A session that has ASKED for a workstream is not in the default one. Saying
   // "default workstream" there is not merely vague, it is wrong in the direction
@@ -102,8 +113,12 @@ export function workstreamStripView(input: {
     // Same trap on the branch: until the worktree exists the session has no
     // branch of its own, and falling back to the CURRENT branch would display
     // the very branch this workstream is meant to avoid.
-    branch: pending ? pendingBranch(owner.worktreePending) : (owner.branch ?? status.branch),
-    dirty: pending ? false : status.dirty,
+    branch: pending
+      ? pendingBranch(owner.worktreePending)
+      : (owner.branch ?? status?.branch ?? null),
+    // Unknown dirtiness reads as clean: the dot is a warning, and inventing one
+    // from a status we do not have yet would cry wolf on a fresh worktree.
+    dirty: pending ? false : (status?.dirty ?? false),
     readOnly,
     inWorktree: !!owner.worktreePath,
     pending

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -1922,6 +1922,46 @@ console.log('\nremote workspace ipc parity\n')
   )
   check('main emits remote:delta', service.includes('CHANNELS.remoteDelta'))
 
+  // ---- chats:updated parity ----
+  // The push that keeps the workstream strip honest. `worktree_path`, `branch`
+  // and `dev_port` are written by MAIN mid-turn (lazy worktree materialization),
+  // so without every link in this chain the strip reads "(pending) / branch
+  // pending" for the whole first turn — the exact bug this channel fixes. Same
+  // four-file contract as remote:*, asserted the same way.
+  {
+    const worktree = read('src/main/services/worktree.ts')
+    const events = read('src/main/services/session-events.ts')
+    check('chats:updated channel value', CHANNELS.chatsUpdated === 'chats:updated')
+    check(
+      'preload subscribes to chats:updated',
+      preload.includes('ipcRenderer.on(CHANNELS.chatsUpdated')
+    )
+    check(
+      'preload unsubscribes from chats:updated',
+      preload.includes('removeListener(CHANNELS.chatsUpdated')
+    )
+    check('main emits chats:updated', events.includes('CHANNELS.chatsUpdated'))
+    check('api declares chats.onUpdated', /\bonUpdated\(/.test(api))
+    // The emit must actually be wired to worktree materialization, not merely
+    // exist: a broadcaster nobody calls is the same bug with extra steps.
+    check(
+      'materialization announces the new worktree',
+      /emitSessionsUpdated\(\{[\s\S]{0,120}reason: 'worktree'/.test(worktree)
+    )
+    check(
+      '...and an agent-driven branch rename announces too',
+      /emitSessionsUpdated\(\{[\s\S]{0,120}reason: 'branch'/.test(worktree)
+    )
+    // The renderer has to consume it, and prime the status for the NEW path —
+    // otherwise the strip trades a stale label for a blank row.
+    const store = read('src/renderer/src/lib/store.ts')
+    check('renderer subscribes to chats.onUpdated', store.includes('api.chats.onUpdated'))
+    check(
+      'renderer primes git status for the new worktree path',
+      /applySessionsUpdated[\s\S]{0,900}api\.git\.status\(key\)/.test(store)
+    )
+  }
+
   // window.roxy.remote.* must match the RoxyApi type surface exactly.
   check('preload exposes remote.start', /\bstart:/.test(preloadRemote))
   check('preload exposes remote.stop', /\bstop:/.test(preloadRemote))
@@ -2284,6 +2324,30 @@ async function main(): Promise<void> {
       view(mk({ workspacePath: null })) === null
     )
     check('strip: hidden before the first status lands', view(mk(), NO_STATUS) === null)
+    // ...but NOT for a session that already owns a worktree. Git only creates
+    // worktrees inside repos, so the path proves the repo, and this is exactly
+    // the state a session is in for the instant after its worktree materializes
+    // mid-turn: on a brand-new path the status map has never been keyed by.
+    // Hiding here would blank the row for a poll interval at precisely the
+    // moment it finally had something true to say.
+    {
+      const fresh = view(mk({ worktreePath: '/wt/auth', branch: 'roxy/auth' }), NO_STATUS)
+      check('strip: a worktree session survives a missing status', fresh !== null)
+      check('strip: ...showing its own branch', fresh?.branch === 'roxy/auth')
+      check('strip: ...not flagged pending', fresh?.pending === false)
+      check('strip: ...and not invented as dirty', fresh?.dirty === false)
+      // A status that ACTUALLY says "not a repo" still wins: the worktree was
+      // deleted underneath us and the strip should go quiet.
+      check(
+        'strip: an arrived isRepo:false still hides a worktree session',
+        view(mk({ worktreePath: '/wt/auth', branch: 'roxy/auth' }), {
+          isRepo: false,
+          branch: null,
+          dirty: false,
+          changed: 0
+        }) === null
+      )
+    }
     check(
       'strip: hidden when the folder is not a repo',
       view(mk(), { isRepo: false, branch: null, dirty: false, changed: 0 }) === null

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -36,6 +36,7 @@ import {
   loadWorktreeConfig
 } from '../src/main/services/worktree'
 import { allocateDevPort, ensureDevPort } from '../src/main/services/ports'
+import { emitSessionsUpdated } from '../src/main/services/session-events'
 import { spawn } from 'node:child_process'
 import * as browser from '../src/main/services/browser'
 import {
@@ -1534,6 +1535,28 @@ async function main(): Promise<void> {
         'a materialized worktree gets a dev port',
         typeof repo.getChat(lazy.id)?.devPort === 'number',
         String(repo.getChat(lazy.id)?.devPort)
+      )
+
+      // Materialization announces itself to the renderer (chats:updated) so the
+      // workstream strip stops claiming "(pending) / branch pending" mid-turn.
+      // This smoke run has NO BrowserWindow at all, which is exactly the case
+      // the broadcast has to survive silently: it rides on the turn path, and
+      // throwing here would take the turn down with it. That the emit is wired
+      // to materialization at all is asserted statically in smoke:shared.
+      check(
+        'emitSessionsUpdated is safe with no windows open',
+        (() => {
+          try {
+            emitSessionsUpdated({
+              reason: 'worktree',
+              sessionIds: [lazy.id],
+              statusKey: mat.worktreePath
+            })
+            return true
+          } catch {
+            return false
+          }
+        })()
       )
 
       // The setup script runs in the NEW worktree, through the background path,


### PR DESCRIPTION
## The bug

A session's worktree is materialized **lazily**, in the main process, on its first turn — that's when `worktree_path`, `branch` and `dev_port` get written (`materializePendingWorktree`, `src/main/services/worktree.ts:110`).

Nothing told the renderer. The store only refetches chats on a few unrelated tool events and at the end of a turn, so the workstream strip kept rendering the rows it had at **session creation** — `(pending)` / `branch pending` — for the entire first turn. Which can be many minutes of the UI flatly contradicting what's already on disk.

Opening a new session appeared to "fix" it only because that path happens to call `refreshChats()`.

## The fix

**1. A `chats:updated` main → renderer push** (`src/main/services/session-events.ts`). Broadcast to all windows rather than replying to one, for the same reason `background-tasks.ts` does: the write happens on the turn path, which may have been started by the phone (remote host) or a loop heartbeat, so there is no "the window that asked" to answer.

**2. Emitted where main actually writes those rows** — after materialization (before the fire-and-forget setup script, which routinely runs for minutes), and after `syncBranchToTitle`. That second one had a real gap too: the renderer refreshes on that tool's `tool-end`, which races the DB write and only reaches the window that ran the turn.

**3. Stopped it trading a stale strip for a flickering one.** This was the non-obvious half. `gitStatus` is keyed by **path**, and the brand-new worktree path has never been polled, so it has no entry — and `workstreamStripView` returns `null` on a missing status. A plain refetch would therefore have swapped `(pending)` for an *empty row* that pops back a few seconds later on the next poll tick.

So two things: the store primes the git/forge status for the new key *before* the chat rows land, and `workstreamStripView` now treats `worktreePath` as proof of a repo — git only ever creates worktrees **inside** repositories. It deliberately does **not** outrank a status that actually arrived saying `isRepo: false`; that means the worktree went away underneath us and the strip should go quiet.

## Testing

- `smoke:shared`: **661 checks pass**, 14 new — four-file IPC parity for `chats:updated` (channel / preload subscribe + unsubscribe / main emit / api surface), assertions that the emit is genuinely *wired to* materialization and to the branch rename rather than merely existing, that the renderer subscribes and primes the new path, and the strip visibility rules (a worktree session survives a missing status showing its own branch, not pending, not invented as dirty — but an arrived `isRepo:false` still hides it).
- `smoke:app`: new check that `emitSessionsUpdated` is safe with **no BrowserWindow open at all** — it rides on the turn path, so throwing there would take the turn down with it.
- `typecheck` clean, `prettier --check` clean on every touched file, app builds and launches.

> [!NOTE]
> `smoke:app` has one pre-existing failure on this repo — `a session without a port does not set PORT`. I confirmed it fails identically on a stashed tree, so it is unrelated to this change.
