### PR TITLE
UI polish: overlay scrollbars, calmer chrome, copyable worktree path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "d3-shape": "^3.2.0",
         "electron-updater": "^6.3.9",
         "lucide-react": "^1.21.0",
+        "overlayscrollbars": "^2.16.0",
         "qrcode.react": "^4.2.0",
         "react-router-dom": "^7.18.0",
         "streamdown": "^2.5.0",
@@ -10152,6 +10153,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/overlayscrollbars": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.16.0.tgz",
+      "integrity": "sha512-N03oje/q7j93D0aLZtoCdsDSYLmhheSsv8H7oSLE7HhdV9P/bmCURtLV/KbPye7P/bpfyt/obSfDpGUYoJ0OWg==",
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "d3-shape": "^3.2.0",
     "electron-updater": "^6.3.9",
     "lucide-react": "^1.21.0",
+    "overlayscrollbars": "^2.16.0",
     "qrcode.react": "^4.2.0",
     "react-router-dom": "^7.18.0",
     "streamdown": "^2.5.0",

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -207,23 +207,77 @@ body {
   background: color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
 
-/* Thin, Cursor-like scrollbars */
-::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+/* Scrollbars.
+ *
+ * Every scroller in the app runs OverlayScrollbars (see lib/overlayScroll.ts),
+ * which draws its own handle and needs the native one gone. Hiding it here
+ * rather than per-component also covers the scrollers we don't render
+ * ourselves -- Streamdown's code blocks and tables inside every markdown
+ * message -- which would otherwise still show a 10px platform bar.
+ *
+ * SCOPED TO #root ON PURPOSE. OverlayScrollbars decides at startup whether this
+ * platform already draws overlay scrollbars natively (macOS trackpad) by
+ * measuring a probe element it appends to <body>. A global
+ * `* { scrollbar-width: none }` makes that probe measure 0, so the library
+ * concludes "already overlaid" and CANCELS every initialization -- silently,
+ * leaving the app with no scrollbars at all. Keeping the rule inside #root lets
+ * the probe see a real native scrollbar while still hiding every scrollbar the
+ * user can actually look at.
+ *
+ * `scrollbar-width: none` is the standard property; the ::-webkit rule is what
+ * Chromium actually obeys today. Both are needed. */
+#root * {
+  scrollbar-width: none;
 }
-::-webkit-scrollbar-thumb {
-  background: var(--color-border-strong);
-  border-radius: 9999px;
-  border: 2px solid transparent;
-  background-clip: content-box;
+#root *::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
 }
-::-webkit-scrollbar-thumb:hover {
-  background: #3d3d43;
-  background-clip: content-box;
+
+/* The overlay handle itself: a translucent capsule with nothing behind it, so
+ * it reads as floating over the content instead of sitting in a gutter. Sized
+ * 10px like the old native bar, but since it's an overlay it costs no layout
+ * width -- content no longer reflows when a pane starts overflowing. */
+.os-theme-roxy {
+  --os-size: 10px;
+  --os-padding-perpendicular: 2px;
+  --os-padding-axis: 2px;
+  --os-track-bg: transparent;
+  --os-track-bg-hover: transparent;
+  --os-track-bg-active: transparent;
+  --os-track-border-radius: 9999px;
+  --os-handle-border-radius: 9999px;
+  --os-handle-bg: var(--color-border-strong);
+  --os-handle-bg-hover: #3d3d43;
+  --os-handle-bg-active: #4a4a52;
+  --os-handle-min-size: 28px;
+  /* Widen the grab target past the visible capsule: a 6px handle is painful to
+   * hit deliberately, and this costs nothing visually. */
+  --os-handle-interactive-area-offset: 4px;
 }
-::-webkit-scrollbar-track {
-  background: transparent;
+/* Idle handles sit back; they come up to full strength once you're aiming at
+ * them. The transition is on the SCROLLBAR (not the handle) because that's the
+ * element OverlayScrollbars toggles `os-visible` on when it auto-hides. */
+.os-theme-roxy .os-scrollbar-handle {
+  opacity: 0.75;
+  transition: opacity 120ms var(--ease-out-quart);
+}
+.os-theme-roxy:is(:hover, :active) .os-scrollbar-handle {
+  opacity: 1;
+}
+/* The auto-hide fade. OverlayScrollbars' own transition is a hard 0.3s linear;
+ * matching the app's easing keeps it from feeling like a different toolkit. */
+.os-theme-roxy.os-scrollbar {
+  transition:
+    opacity 220ms var(--ease-out-quart),
+    visibility 220ms var(--ease-out-quart);
+}
+@media (prefers-reduced-motion: reduce) {
+  .os-theme-roxy.os-scrollbar,
+  .os-theme-roxy .os-scrollbar-handle {
+    transition: none;
+  }
 }
 
 /* Electron custom title bar: make a region draggable, keep controls clickable. */

--- a/src/renderer/src/browser/main.tsx
+++ b/src/renderer/src/browser/main.tsx
@@ -1,5 +1,6 @@
 import '@fontsource-variable/geist/index.css'
 import '@fontsource-variable/geist-mono/index.css'
+import 'overlayscrollbars/overlayscrollbars.css'
 import '../assets/main.css'
 import React from 'react'
 import ReactDOM from 'react-dom/client'

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import {
+  Check,
   ChevronRight,
   CornerUpLeft,
   FolderOpen,
@@ -9,7 +10,9 @@ import {
   Repeat,
   Settings
 } from 'lucide-react'
+import type { Chat } from '@shared/types'
 import { useRoxyStore } from '../lib/store'
+import { useOverlayScroll } from '../lib/overlayScroll'
 import { formatInterval } from '@shared/format'
 import { cn } from '../lib/cn'
 import { MessageBubble } from './MessageBubble'
@@ -69,6 +72,10 @@ export function ChatView(): JSX.Element {
   // Show only the latest N; scrolling up loads older ones a page at a time.
   const [visibleCount, setVisibleCount] = useState(VISIBLE_MESSAGES)
   const restoreHeight = useRef<number | null>(null)
+  // Overlay scrollbars for the transcript. Because the element is initialized
+  // as its own viewport, every read below (scrollTop / scrollHeight /
+  // clientHeight / scrollTo) and the onScroll prop keep working unchanged.
+  useOverlayScroll(scrollRef)
 
   const onScroll = (): void => {
     const el = scrollRef.current
@@ -162,25 +169,20 @@ export function ChatView(): JSX.Element {
             <span className="shrink-0 text-sm font-medium">{activeChat.title}</span>
             {/* A delegate's session is only legible in context — who sent it, and
                 a way back. The folder path is the parent's business. */}
-            {isSub
-              ? parentChat && (
-                  <button
-                    onClick={() => void selectChat(parentChat.id)}
-                    title={`Back to ${parentChat.title}`}
-                    className="flex min-w-0 items-center gap-1 truncate text-xs text-text-subtle transition-colors hover:text-text"
-                  >
-                    <CornerUpLeft className="h-3 w-3 shrink-0" />
-                    <span className="truncate">{parentChat.title}</span>
-                  </button>
-                )
-              : activeChat.workspacePath && (
-                  <span
-                    className="truncate text-xs text-text-subtle"
-                    title={activeChat.workspacePath}
-                  >
-                    {activeChat.workspacePath}
-                  </span>
-                )}
+            {isSub ? (
+              parentChat && (
+                <button
+                  onClick={() => void selectChat(parentChat.id)}
+                  title={`Back to ${parentChat.title}`}
+                  className="flex min-w-0 items-center gap-1 truncate text-xs text-text-subtle transition-colors hover:text-text"
+                >
+                  <CornerUpLeft className="h-3 w-3 shrink-0" />
+                  <span className="truncate">{parentChat.title}</span>
+                </button>
+              )
+            ) : (
+              <WorkspacePath chat={activeChat} />
+            )}
             {subagentRunning && (
               <span
                 title="This subagent is working"
@@ -321,5 +323,78 @@ export function ChatView(): JSX.Element {
         />
       )}
     </div>
+  )
+}
+
+/**
+ * The folder this session's agent actually runs in, click to copy.
+ *
+ * Shows `worktreePath` in preference to `workspacePath`. Those differ for every
+ * workstream: the project folder is the repo you opened, but the agent's cwd is
+ * an isolated checkout under `worktrees/`. Showing the project path meant the
+ * header named a directory the session was NOT editing — actively misleading
+ * when several workstreams are open and you are trying to work out which
+ * checkout a dev server or an editor tab belongs to.
+ *
+ * Copying is the point: these paths are long, truncated by the header, and
+ * mostly wanted for pasting into a terminal. Selecting truncated text by hand
+ * is fiddly, so the whole thing is one click.
+ */
+function WorkspacePath({ chat }: { chat: Chat }): JSX.Element | null {
+  const path = chat.worktreePath ?? chat.workspacePath
+  const [copied, setCopied] = useState(0)
+
+  // Keyed on the click COUNT, not a boolean: clicking again while the
+  // confirmation is still up restarts the window, instead of the first click's
+  // timer cutting the second one short.
+  useEffect(() => {
+    if (!copied) return
+    const t = setTimeout(() => setCopied(0), 1200)
+    return () => clearTimeout(t)
+  }, [copied])
+
+  if (!path) return null
+
+  const copy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(path)
+      setCopied((n) => n + 1)
+    } catch {
+      // Clipboard can be denied; the path stays readable in the tooltip.
+    }
+  }
+
+  return (
+    <button
+      onClick={() => void copy()}
+      // The label is truncated, so the tooltip carries the full path.
+      title={`${path}\nClick to copy`}
+      className="press-scale relative flex min-w-0 items-center rounded-md px-1 py-0.5 text-xs text-text-subtle hover:bg-white/5 hover:text-text-muted"
+    >
+      {/* The path fades rather than unmounting, so the button keeps its width
+          and nothing in the header shifts while the confirmation shows. */}
+      <span
+        className={cn(
+          'truncate transition-opacity duration-150 ease-out-quart',
+          copied && 'opacity-0'
+        )}
+      >
+        {path}
+      </span>
+      {/* Confirmation sits ON TOP of the path, left-aligned to it, so it reads
+          as the same object changing state. Fires often enough that a moving
+          toast would be noise -- this is the smallest thing that still answers
+          "did that work?". */}
+      <span
+        aria-live="polite"
+        className={cn(
+          'absolute inset-y-0 left-1 flex items-center gap-1 text-success transition-[opacity,transform] duration-150 ease-out-quart',
+          copied ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-0.5 opacity-0'
+        )}
+      >
+        <Check className="h-3 w-3 shrink-0" />
+        Copied
+      </span>
+    </button>
   )
 }

--- a/src/renderer/src/components/InferenceControls.tsx
+++ b/src/renderer/src/components/InferenceControls.tsx
@@ -12,6 +12,7 @@ import {
 } from '@shared/session-config'
 import { useMenuAnchor } from '../lib/useMenuAnchor'
 import { cn } from '../lib/cn'
+import { Scroller } from './Scroller'
 
 /**
  * Close-on-outside-click / Escape for a small popover, plus the geometry that
@@ -111,7 +112,8 @@ const popoverClass =
   'animate-pop-in absolute bottom-full z-50 mb-2 flex flex-col overflow-y-auto rounded-xl border border-border bg-elevated shadow-2xl origin-bottom-left'
 /** Menu widths in px, matching what each picker renders. */
 const POPOVER_W = 288
-const AGENT_POPOVER_W = 256
+/** Just wide enough for "Build"/"Plan" + the check, now that blurbs are gone. */
+const AGENT_POPOVER_W = 160
 
 // ---- Thinking effort ---------------------------------------------------------
 
@@ -145,7 +147,7 @@ export function ThinkingPicker(): JSX.Element | null {
         <span>{currentLabel}</span>
       </button>
       {open && (
-        <div className={popoverClass} style={anchor}>
+        <Scroller className={popoverClass} style={anchor}>
           <div className="shrink-0 border-b border-border px-3 py-2 text-[11px] font-medium text-text-subtle">
             Thinking Effort
           </div>
@@ -179,19 +181,13 @@ export function ThinkingPicker(): JSX.Element | null {
           <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-text-subtle">
             Higher levels of thinking may increase cost.
           </div>
-        </div>
+        </Scroller>
       )}
     </div>
   )
 }
 
 // ---- Agent (Build vs Plan) ---------------------------------------------------
-
-/** One-line taglines for the picker — the full `description`s are for the model. */
-const AGENT_TAGLINE: Record<string, string> = {
-  build: 'Reads, edits, and runs commands',
-  plan: 'Read-only — explores and proposes'
-}
 
 /**
  * Primary-agent selector. Switching to Plan makes the next turn read-only: the
@@ -217,7 +213,7 @@ export function AgentPicker(): JSX.Element {
         <span>{active.name}</span>
       </button>
       {open && (
-        <div className={popoverClass} style={anchor}>
+        <Scroller className={popoverClass} style={anchor}>
           <div className="p-1">
             {PRIMARY_AGENTS.map((a) => {
               const selected = a.id === active.id
@@ -230,26 +226,24 @@ export function AgentPicker(): JSX.Element {
                     setOpen(false)
                   }}
                   className={cn(
-                    'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition',
+                    'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition',
                     selected ? 'bg-accent/15' : 'hover:bg-white/5'
                   )}
+                  title={a.description}
                 >
                   <span
                     className="h-2 w-2 shrink-0 rounded-full"
                     style={{ backgroundColor: a.color }}
                   />
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-xs font-medium text-text">{a.name}</span>
-                    <span className="block truncate text-[11px] text-text-subtle">
-                      {AGENT_TAGLINE[a.id] ?? a.description}
-                    </span>
+                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-text">
+                    {a.name}
                   </span>
                   {selected && <Check className="h-3.5 w-3.5 shrink-0 text-accent" />}
                 </button>
               )
             })}
           </div>
-        </div>
+        </Scroller>
       )}
     </div>
   )
@@ -294,7 +288,7 @@ export function ContextPicker(): JSX.Element | null {
         <span>{formatTokens(current)}</span>
       </button>
       {open && (
-        <div className={popoverClass} style={anchor}>
+        <Scroller className={popoverClass} style={anchor}>
           <div className="shrink-0 border-b border-border px-3 py-2 text-[11px] font-medium text-text-subtle">
             Context Size
           </div>
@@ -332,7 +326,7 @@ export function ContextPicker(): JSX.Element | null {
           <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-text-subtle">
             Larger context may increase cost.
           </div>
-        </div>
+        </Scroller>
       )}
     </div>
   )

--- a/src/renderer/src/components/LoopDetailsPane.tsx
+++ b/src/renderer/src/components/LoopDetailsPane.tsx
@@ -2,6 +2,7 @@ import { Repeat, X } from 'lucide-react'
 import type { Chat, Loop } from '@shared/types'
 import { formatInterval } from '@shared/format'
 import { cn } from '../lib/cn'
+import { Scroller } from './Scroller'
 
 function fmtTime(ts: number | null): string {
   return ts ? new Date(ts).toLocaleString() : '—'
@@ -35,7 +36,9 @@ function Row({
       <span className="text-[10px] font-semibold uppercase tracking-wider text-text-subtle">
         {label}
       </span>
-      <div className={cn('break-words text-sm text-text', mono && 'font-mono text-xs text-text-muted')}>
+      <div
+        className={cn('break-words text-sm text-text', mono && 'font-mono text-xs text-text-muted')}
+      >
         {children}
       </div>
     </div>
@@ -72,16 +75,13 @@ export function LoopDetailsPane({
         </button>
       </div>
 
-      <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+      <Scroller className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
         <Row label="Name">{loop.name}</Row>
 
         <Row label="Status">
           <span className="flex items-center gap-2">
             <span
-              className={cn(
-                'h-2 w-2 rounded-full',
-                loop.enabled ? 'bg-success' : 'bg-text-subtle'
-              )}
+              className={cn('h-2 w-2 rounded-full', loop.enabled ? 'bg-success' : 'bg-text-subtle')}
             />
             {loop.enabled ? 'Running' : 'Paused'} · every {formatInterval(loop.intervalMinutes)}
           </span>
@@ -95,7 +95,9 @@ export function LoopDetailsPane({
 
         <Row label="Next run">
           {fmtTime(loop.nextRunAt)}
-          {rel(loop.nextRunAt) && <span className="text-text-subtle"> · {rel(loop.nextRunAt)}</span>}
+          {rel(loop.nextRunAt) && (
+            <span className="text-text-subtle"> · {rel(loop.nextRunAt)}</span>
+          )}
         </Row>
 
         <Row label="Last run">
@@ -125,7 +127,7 @@ export function LoopDetailsPane({
           Read-only. Ask Roxy to change a loop with the loop tools (e.g. “pause the {loop.name}
           loop”).
         </p>
-      </div>
+      </Scroller>
     </aside>
   )
 }

--- a/src/renderer/src/components/ModelPicker.tsx
+++ b/src/renderer/src/components/ModelPicker.tsx
@@ -6,6 +6,7 @@ import { ProviderLogo } from '../lib/providerLogos'
 import { triggerClass } from './InferenceControls'
 import { useMenuAnchor } from '../lib/useMenuAnchor'
 import { cn } from '../lib/cn'
+import { Scroller } from './Scroller'
 
 /**
  * A cute, searchable model picker: the active provider's logo + model on the
@@ -110,7 +111,7 @@ export function ModelPicker(): JSX.Element {
               className="w-full bg-transparent text-xs text-text outline-none placeholder:text-text-subtle"
             />
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto py-1">
+          <Scroller className="min-h-0 flex-1 overflow-y-auto py-1">
             {loading && <div className="px-3 py-3 text-xs text-text-subtle">Loading models…</div>}
             {!loading &&
               providers.map((p) => {
@@ -154,7 +155,7 @@ export function ModelPicker(): JSX.Element {
                 model.
               </div>
             )}
-          </div>
+          </Scroller>
         </div>
       )}
     </div>

--- a/src/renderer/src/components/PageShell.tsx
+++ b/src/renderer/src/components/PageShell.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react'
 import { ArrowLeft } from 'lucide-react'
+import { Scroller } from './Scroller'
 
 export function PageShell({
   title,
@@ -27,12 +28,12 @@ export function PageShell({
         <span className="text-sm font-medium">{title}</span>
         {actions && <div className="ml-auto">{actions}</div>}
       </header>
-      <div className="min-h-0 flex-1 overflow-y-auto border-t border-border">
+      <Scroller className="min-h-0 flex-1 overflow-y-auto border-t border-border">
         <div className="mx-auto max-w-3xl px-6 py-8">
           {subtitle && <p className="mb-6 text-sm text-text-muted">{subtitle}</p>}
           {children}
         </div>
-      </div>
+      </Scroller>
     </div>
   )
 }

--- a/src/renderer/src/components/Queue.tsx
+++ b/src/renderer/src/components/Queue.tsx
@@ -18,6 +18,7 @@ import {
 import { ChevronRight } from 'lucide-react'
 import { cn } from '../lib/cn'
 import { HOVERABLE_THUMB, ImagePreview } from './ImagePreview'
+import { Scroller } from './Scroller'
 
 // ---- Collapsible section context --------------------------------------------
 
@@ -137,7 +138,13 @@ export function QueueSectionContent({
 // ---- List + items ------------------------------------------------------------
 
 export function QueueList({ className, ...props }: HTMLAttributes<HTMLUListElement>): JSX.Element {
-  return <ul className={cn('flex max-h-52 flex-col gap-1 overflow-y-auto', className)} {...props} />
+  return (
+    <Scroller
+      as="ul"
+      className={cn('flex max-h-52 flex-col gap-1 overflow-y-auto', className)}
+      {...props}
+    />
+  )
 }
 
 export function QueueItem({ className, ...props }: LiHTMLAttributes<HTMLLIElement>): JSX.Element {

--- a/src/renderer/src/components/Scroller.tsx
+++ b/src/renderer/src/components/Scroller.tsx
@@ -1,0 +1,35 @@
+/**
+ * A scrolling container with overlay scrollbars.
+ *
+ * Drop-in replacement for `<div className="… overflow-y-auto">`: it renders
+ * exactly that element and attaches the scrollbars to it, so no wrapper enters
+ * the tree and layout (flex sizing, sticky children, `max-h-*` caps) is
+ * unchanged. See lib/overlayScroll.ts for why that matters.
+ *
+ * `as` switches the tag — `ul` for lists, `pre` for log panes — and the props
+ * type follows it, so `<Scroller as="ul">` still type-checks its `<ul>` events.
+ *
+ * Deliberately does NOT forward a ref: this owns the element's ref to attach
+ * the scrollbars, and on React 18 a `ref` prop would silently do nothing here.
+ * If you need the node (to drive scroll position yourself, as ChatView does),
+ * keep your own `<div ref>` and call `useOverlayScroll(ref)` instead.
+ */
+import { useRef, type ComponentPropsWithoutRef, type ElementType } from 'react'
+import type { PartialOptions } from 'overlayscrollbars'
+import { useOverlayScroll } from '../lib/overlayScroll'
+
+type Props<T extends ElementType> = {
+  as?: T
+  options?: PartialOptions
+} & Omit<ComponentPropsWithoutRef<T>, 'as' | 'options'>
+
+export function Scroller<T extends ElementType = 'div'>({
+  as,
+  options,
+  ...rest
+}: Props<T>): JSX.Element {
+  const Tag = (as ?? 'div') as ElementType
+  const ref = useRef<HTMLElement>(null)
+  useOverlayScroll(ref, options)
+  return <Tag ref={ref} {...rest} />
+}

--- a/src/renderer/src/components/ServicesSegment.tsx
+++ b/src/renderer/src/components/ServicesSegment.tsx
@@ -6,6 +6,7 @@ import { isServiceFailure, serviceStatusLabel, servicesSummary } from '@shared/s
 import { useRoxyStore } from '../lib/store'
 import { cn } from '../lib/cn'
 import { TerminalOutput } from './TerminalOutput'
+import { Scroller } from './Scroller'
 
 /**
  * The Services segment — what this session is actually running.
@@ -185,7 +186,7 @@ function ServicesMenu({
         {/* Scrolls instead of growing past the top of the window: a worktree
             setup can leave several processes behind, and the header has to stay
             on screen or the list loses its label. */}
-        <div className="min-h-0 overflow-y-auto">
+        <Scroller className="min-h-0 overflow-y-auto">
           {services.map((svc) => (
             <ServiceRow
               key={svc.id}
@@ -195,7 +196,7 @@ function ServicesMenu({
               onToggleLogs={() => onToggleLogs(svc.id)}
             />
           ))}
-        </div>
+        </Scroller>
       </div>
     </div>
   )

--- a/src/renderer/src/components/SessionInfo.tsx
+++ b/src/renderer/src/components/SessionInfo.tsx
@@ -1,6 +1,7 @@
 import { Check } from 'lucide-react'
 import type { Chat } from '@shared/types'
 import { cn } from '../lib/cn'
+import { Scroller } from './Scroller'
 
 /**
  * A slim strip under the chat header showing the session's agent-set
@@ -24,7 +25,7 @@ export function SessionInfo({ chat }: { chat: Chat }): JSX.Element | null {
               {done}/{tasks.length}
             </span>
           </div>
-          <ul className="flex max-h-40 flex-col gap-1 overflow-y-auto">
+          <Scroller as="ul" className="flex max-h-40 flex-col gap-1 overflow-y-auto">
             {tasks.map((t, i) => (
               <li key={i} className="flex items-center gap-2 text-xs">
                 <span
@@ -57,7 +58,7 @@ export function SessionInfo({ chat }: { chat: Chat }): JSX.Element | null {
                 </span>
               </li>
             ))}
-          </ul>
+          </Scroller>
         </div>
       )}
     </div>

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -13,7 +13,6 @@ import {
   GitBranch,
   Hammer,
   Lightbulb,
-  MessageSquarePlus,
   MonitorSmartphone,
   PanelLeftClose,
   PanelLeftOpen,
@@ -36,6 +35,7 @@ import { HeartbeatDot, NewLoopDialog } from './LoopsSection'
 import { RemoteWorkspaceDialog } from './RemoteWorkspaceDialog'
 import { BrailleSpinner } from './ThinkingIndicator'
 import { UpdateCard } from './UpdateCard'
+import { Scroller } from './Scroller'
 import roxy from '../assets/roxy.png'
 
 const MIN_WIDTH = 220
@@ -107,8 +107,6 @@ export function Sidebar(): JSX.Element {
   })
   const [railed, setRailed] = useState<boolean>(() => localStorage.getItem(COLLAPSED_KEY) === '1')
   const [loopDialogFor, setLoopDialogFor] = useState<{ path: string; name: string } | null>(null)
-  // Which project's "+" (new Session / Loop) menu is open, keyed by path.
-  const [addMenuFor, setAddMenuFor] = useState<string | null>(null)
   const [remoteOpen, setRemoteOpen] = useState(false)
   const remotePhase = useRoxyStore((s) => s.remote.phase)
   // Green only when truly live; amber while spinning up or reconnecting.
@@ -125,23 +123,6 @@ export function Sidebar(): JSX.Element {
   useEffect(() => {
     localStorage.setItem(COLLAPSED_KEY, railed ? '1' : '0')
   }, [railed])
-
-  // Close the per-project "+" menu on any outside click or Escape.
-  useEffect(() => {
-    if (!addMenuFor) return
-    const onDown = (e: MouseEvent): void => {
-      if (!(e.target as HTMLElement).closest('[data-add-menu]')) setAddMenuFor(null)
-    }
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setAddMenuFor(null)
-    }
-    window.addEventListener('mousedown', onDown)
-    window.addEventListener('keydown', onKey)
-    return () => {
-      window.removeEventListener('mousedown', onDown)
-      window.removeEventListener('keydown', onKey)
-    }
-  }, [addMenuFor])
 
   // Double-click a session name to rename it inline. Enter / click-away saves,
   // Escape cancels. `cancelRef` lets the shared blur handler tell the two apart.
@@ -495,7 +476,7 @@ export function Sidebar(): JSX.Element {
         </button>
       </div>
 
-      <div className="mt-4 flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-3 pb-3">
+      <Scroller className="mt-4 flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-3 pb-3">
         <section className="flex min-h-0 flex-1 flex-col">
           <div className="mb-2 flex items-center px-1">
             <span className="text-xs font-medium text-text-muted">Projects</span>
@@ -539,7 +520,7 @@ export function Sidebar(): JSX.Element {
                   >
                     <div
                       className={cn(
-                        'flex items-center gap-1 px-1',
+                        'group/project flex items-center gap-1 px-1',
                         projectDrag && 'cursor-grabbing'
                       )}
                       draggable={canDragProject}
@@ -570,54 +551,27 @@ export function Sidebar(): JSX.Element {
                           {project.name}
                         </span>
                       </button>
-                      {project.path !== '(no folder)' ? (
-                        <div className="relative shrink-0" data-add-menu>
-                          <button
-                            onClick={() =>
-                              setAddMenuFor((cur) => (cur === project.path ? null : project.path))
-                            }
-                            title="New session or loop"
-                            className={cn(
-                              'flex h-5 w-5 items-center justify-center rounded text-text-subtle transition-colors hover:bg-white/5 hover:text-text',
-                              addMenuFor === project.path && 'bg-white/5 text-text'
-                            )}
-                          >
-                            <Plus className="h-3.5 w-3.5" />
-                          </button>
-                          {addMenuFor === project.path && (
-                            <div className="animate-pop-in absolute right-0 top-6 z-30 w-36 origin-top-right overflow-hidden rounded-lg border border-border bg-elevated py-1 shadow-lg">
-                              <button
-                                onClick={() => {
-                                  setAddMenuFor(null)
-                                  void newSessionInProject(project.path)
-                                }}
-                                className="press-scale flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-muted hover:bg-white/5 hover:text-text"
-                              >
-                                <MessageSquarePlus className="h-3.5 w-3.5 shrink-0" />
-                                Session
-                              </button>
-                              <button
-                                onClick={() => {
-                                  setAddMenuFor(null)
-                                  setLoopDialogFor({ path: project.path, name: project.name })
-                                }}
-                                className="press-scale flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-muted hover:bg-white/5 hover:text-text"
-                              >
-                                <Repeat className="h-3.5 w-3.5 shrink-0" />
-                                Loop
-                              </button>
-                            </div>
-                          )}
-                        </div>
-                      ) : (
+                      {/* Loops are the rarer action, so they hide until the
+                          row is hovered -- that leaves "+" to mean exactly one
+                          thing: new session. */}
+                      {project.path !== '(no folder)' && (
                         <button
-                          onClick={() => void newSessionInProject(project.path)}
-                          title="New session in this project"
-                          className="press-scale flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-subtle hover:bg-white/5 hover:text-text"
+                          onClick={() =>
+                            setLoopDialogFor({ path: project.path, name: project.name })
+                          }
+                          title="New loop in this project"
+                          className="press-scale flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-subtle opacity-0 transition-[opacity,color,background-color] hover:bg-white/5 hover:text-text focus-visible:opacity-100 group-hover/project:opacity-100"
                         >
-                          <Plus className="h-3.5 w-3.5" />
+                          <Repeat className="h-3.5 w-3.5" />
                         </button>
                       )}
+                      <button
+                        onClick={() => void newSessionInProject(project.path)}
+                        title="New session in this project"
+                        className="press-scale flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-subtle hover:bg-white/5 hover:text-text"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                      </button>
                     </div>
                     {!isCollapsed && (
                       <>
@@ -725,7 +679,16 @@ export function Sidebar(): JSX.Element {
                                   {sending ? (
                                     <BrailleSpinner className="shrink-0 text-sm text-accent" />
                                   ) : (
-                                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-subtle/50" />
+                                    <span
+                                      className={cn(
+                                        'h-1.5 w-1.5 shrink-0 rounded-full transition-colors',
+                                        // A BACKGROUND delegate runs while its parent sits idle,
+                                        // so without this the row would look asleep now that the
+                                        // count pill is hover-only. Tinting the dot the row
+                                        // already has keeps that signal at zero layout cost.
+                                        liveSubs > 0 ? 'bg-accent' : 'bg-text-subtle/50'
+                                      )}
+                                    />
                                   )}
                                   {editingId === chat.id ? (
                                     <input
@@ -808,12 +771,13 @@ export function Sidebar(): JSX.Element {
                                         liveSubs > 0
                                           ? 'bg-accent/10 text-accent'
                                           : 'bg-surface-2 text-text-subtle hover:text-text',
-                                        // Idle and collapsed, this pill is just noise parked on
-                                        // every row - so reveal it on hover, like the delete button
-                                        // beside it. It stays pinned only when it carries state:
-                                        // a subagent is working, or the list is expanded.
+                                        // This pill is a disclosure control, not a status light,
+                                        // so it earns space only while the row is hovered or the
+                                        // list it toggles is actually open. Live subagents used to
+                                        // pin it too, which parked a badge on the row for the whole
+                                        // run - the dot above carries that signal instead.
                                         // Fading opacity (not unmounting) keeps the row stable.
-                                        liveSubs > 0 || subsOpen
+                                        subsOpen
                                           ? 'opacity-100'
                                           : 'opacity-0 focus-visible:opacity-100 group-hover:opacity-100'
                                       )}
@@ -891,7 +855,7 @@ export function Sidebar(): JSX.Element {
             </div>
           )}
         </section>
-      </div>
+      </Scroller>
 
       {loopDialogFor && (
         <NewLoopDialog

--- a/src/renderer/src/components/TerminalOutput.tsx
+++ b/src/renderer/src/components/TerminalOutput.tsx
@@ -1,4 +1,5 @@
 import { renderAnsi } from '../lib/ansi'
+import { Scroller } from './Scroller'
 
 /**
  * Shell output as a colored terminal block — prompt line, ANSI body, status
@@ -47,7 +48,8 @@ export function TerminalOutput({
       : '#9a9aa3'
   const trimmed = body.replace(/[\r\n]+$/, '')
   return (
-    <pre
+    <Scroller
+      as="pre"
       className={
         className ??
         'max-h-72 overflow-auto border-t border-border bg-[#0b0b0d] px-3 py-2 font-mono text-xs leading-relaxed text-[#d4d4d4]'
@@ -61,6 +63,6 @@ export function TerminalOutput({
           {footer}
         </div>
       )}
-    </pre>
+    </Scroller>
   )
 }

--- a/src/renderer/src/components/ToolCall.tsx
+++ b/src/renderer/src/components/ToolCall.tsx
@@ -22,6 +22,7 @@ import type { MessagePart, ToolDiff } from '@shared/types'
 import { cn } from '../lib/cn'
 import { TerminalOutput } from './TerminalOutput'
 import { BrailleSpinner } from './ThinkingIndicator'
+import { Scroller } from './Scroller'
 
 const FileDiffView = lazy(() => import('./FileDiffView'))
 const FileView = lazy(() => import('./FileView'))
@@ -229,7 +230,7 @@ export function ToolCall({
       {/* Collapsed + running: a live one-liner of what the delegate is doing now. */}
       {showNested && live && !open && <ActivityLine parts={nested!} />}
       {open && diff ? (
-        <div className="animate-fade-in max-h-96 overflow-auto border-t border-border bg-surface">
+        <Scroller className="animate-fade-in max-h-96 overflow-auto border-t border-border bg-surface">
           <Suspense
             fallback={
               <div className="px-3 py-2 font-mono text-xs text-text-subtle">Loading diff…</div>
@@ -237,40 +238,46 @@ export function ToolCall({
           >
             <FileDiffView path={diff.path} before={diff.before} after={diff.after} />
           </Suspense>
-        </div>
+        </Scroller>
       ) : open && tool === 'read' && state === 'done' && body && !image ? (
-        <div className="animate-fade-in max-h-96 overflow-auto border-t border-border bg-surface">
+        <Scroller className="animate-fade-in max-h-96 overflow-auto border-t border-border bg-surface">
           <Suspense
             fallback={<div className="px-3 py-2 font-mono text-xs text-text-subtle">Loading…</div>}
           >
             <FileView name={title || 'file.txt'} contents={body} />
           </Suspense>
-        </div>
+        </Scroller>
       ) : open && (tool === 'bash' || tool === 'bash_output') ? (
         <TerminalOutput text={body} state={state} />
       ) : open && showNested ? (
         <div className="animate-fade-in border-t border-border bg-surface">
           {/* The subagent's own transcript, indented under a rail so it reads as a
               separate agent's work rather than more of the parent's. */}
-          <div className="max-h-[28rem] overflow-auto px-3 py-2">
+          <Scroller className="max-h-[28rem] overflow-auto px-3 py-2">
             <div className="border-l-2 border-border pl-3">{renderNested!(nested!)}</div>
             <div ref={tailRef} />
-          </div>
+          </Scroller>
           {body && !live && (
             <div className="border-t border-border">
               <div className="px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wide text-text-subtle">
                 Report
               </div>
-              <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words px-3 pb-2 font-mono text-xs leading-relaxed text-text-muted">
+              <Scroller
+                as="pre"
+                className="max-h-72 overflow-auto whitespace-pre-wrap break-words px-3 pb-2 font-mono text-xs leading-relaxed text-text-muted"
+              >
                 {body}
-              </pre>
+              </Scroller>
             </div>
           )}
         </div>
       ) : open ? (
-        <pre className="animate-fade-in max-h-72 overflow-auto border-t border-border bg-surface px-3 py-2 font-mono text-xs leading-relaxed text-text-muted">
+        <Scroller
+          as="pre"
+          className="animate-fade-in max-h-72 overflow-auto border-t border-border bg-surface px-3 py-2 font-mono text-xs leading-relaxed text-text-muted"
+        >
           {body || (state === 'running' ? 'Running…' : '(no output)')}
-        </pre>
+        </Scroller>
       ) : null}
       {image && (
         <div className="border-t border-border bg-surface p-2">

--- a/src/renderer/src/components/UsageMeter.tsx
+++ b/src/renderer/src/components/UsageMeter.tsx
@@ -16,6 +16,7 @@ import { cn } from '../lib/cn'
 import { BarChart } from './dither-kit/bar-chart'
 import { Bar } from './dither-kit/bar'
 import type { ChartConfig } from './dither-kit/chart-context'
+import { Scroller } from './Scroller'
 
 /** Close-on-outside-click / Escape for the popover. */
 function usePopover(): {
@@ -273,7 +274,7 @@ export function UsageMeter(): JSX.Element | null {
       {open && (
         <div className="animate-pop-in absolute right-0 top-full z-50 mt-2 w-80 origin-top-right overflow-hidden rounded-xl border border-border bg-elevated shadow-2xl">
           {/* Tabs */}
-          <div className="flex items-center gap-1 overflow-x-auto border-b border-border p-1.5">
+          <Scroller className="flex items-center gap-1 overflow-x-auto border-b border-border p-1.5">
             {tabs.map((t) => (
               <button
                 key={t.id}
@@ -290,7 +291,7 @@ export function UsageMeter(): JSX.Element | null {
                 {t.label}
               </button>
             ))}
-          </div>
+          </Scroller>
           {tab === 'overview'
             ? overviewPanel(usageStats)
             : activeProvider

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -15,6 +15,7 @@ import type { Chat } from '@shared/types'
 import { useRoxyStore } from '../lib/store'
 import { workstreamStripView, statusKeyForSession } from '@shared/workstream'
 import { branchNameError } from '@shared/branch'
+import { worktreeSlug } from '@shared/format'
 import { ServicesSegment, useServices } from './ServicesSegment'
 import { useMenuAnchor } from '../lib/useMenuAnchor'
 import { cn } from '../lib/cn'
@@ -22,6 +23,7 @@ import { cn } from '../lib/cn'
 // would drift, and a `merged` PR that is green in one place and grey in the
 // other teaches the user that the colour means nothing.
 import { TONE_BG, TONE_TEXT } from '../lib/lifecycle'
+import { Scroller } from './Scroller'
 
 /**
  * The workstream strip — one quiet row under the composer answering "where does
@@ -267,7 +269,7 @@ function UnknownHostChip({ host }: { host: string }): JSX.Element {
     <div className="relative" ref={ref}>
       {open && (
         <div className="absolute bottom-full z-50 flex flex-col pb-1.5" style={anchor}>
-          <div className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-border bg-elevated py-1 shadow-2xl">
+          <Scroller className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-border bg-elevated py-1 shadow-2xl">
             <div className="px-3 py-1.5 text-[11px] text-text-subtle">
               What does <span className="text-text-muted">{host}</span> run?
             </div>
@@ -281,7 +283,7 @@ function UnknownHostChip({ host }: { host: string }): JSX.Element {
                 {FORGE_NAMES[k]}
               </button>
             ))}
-          </div>
+          </Scroller>
         </div>
       )}
       <button
@@ -743,6 +745,30 @@ function BranchSegment({
 }
 
 /**
+ * Tooltip for anything that names a workstream.
+ *
+ * The point is the FOLDER. A workstream's directory is named once, from the
+ * session's opening title, and never renamed; the branch then drifts away from
+ * it as `syncBranchToTitle` retitles the branch to match what the session turned
+ * out to be about. That is good for stable paths (open editors and dev servers
+ * keep working) but it means the sidebar, the branch and the directory on disk
+ * can all read differently, with no way to tell which folder a session owns.
+ * Surfacing the slug on hover makes that answerable without leaving the app.
+ *
+ * Only shown for real worktrees: a session in the default workstream has no
+ * folder of its own, and a pending one has no folder yet.
+ */
+function workstreamTitle(chat: Chat, pending: boolean, base?: string): string {
+  const fallback =
+    base ??
+    (pending
+      ? 'This workstream is created when the session starts'
+      : 'Workstreams — isolated checkouts you can run in parallel')
+  const slug = worktreeSlug(chat.worktreePath)
+  return slug ? `${fallback}\nFolder: ${slug}` : fallback
+}
+
+/**
  * Segment 1 — the workstream picker. This IS the branch picker: every workstream
  * is a branch, so a separate branch dropdown would be a second way to do the
  * same thing with worse semantics (switching a branch in the DEFAULT workstream
@@ -786,7 +812,7 @@ function WorkstreamSegment({
     return (
       <span
         className="flex min-w-0 items-center gap-1.5 px-1.5 py-1 text-text-subtle"
-        title="Subagents run in the workstream that spawned them"
+        title={workstreamTitle(chat, false, 'Subagents run in the workstream that spawned them')}
       >
         <SquareStack className="h-3.5 w-3.5 shrink-0 opacity-70" />
         <span className="truncate">{label}</span>
@@ -800,11 +826,7 @@ function WorkstreamSegment({
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        title={
-          pending
-            ? 'This workstream is created when the session starts'
-            : 'Workstreams — isolated checkouts you can run in parallel'
-        }
+        title={workstreamTitle(chat, pending)}
         className={cn(
           'flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 transition hover:bg-white/5',
           open ? 'text-text' : 'text-text-muted hover:text-text'
@@ -887,7 +909,7 @@ function WorkstreamMenu({
       {/* The whole menu scrolls, not just the branch list: a project with a
           dozen sessions makes the workstream list itself taller than the window,
           and `maxHeight` without `overflow` would only clip it differently. */}
-      <div className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-border bg-elevated py-1 shadow-2xl">
+      <Scroller className="flex min-h-0 flex-col overflow-y-auto rounded-xl border border-border bg-elevated py-1 shadow-2xl">
         <MenuLabel>Workstreams</MenuLabel>
 
         {/* The default workstream is the project folder itself — always present,
@@ -922,6 +944,10 @@ function WorkstreamMenu({
             icon={<GitBranch className="h-3.5 w-3.5 opacity-70" />}
             trailing={s.id === chat.id ? <Check className="h-3.5 w-3.5 text-accent" /> : undefined}
             hint={s.branch ?? undefined}
+            // The row already shows title + branch; the folder is the third
+            // identity a workstream has, and the only one you need when
+            // matching a session against what is actually on disk.
+            title={workstreamTitle(s, false)}
           >
             {s.title}
           </MenuItem>
@@ -960,7 +986,7 @@ function WorkstreamMenu({
                 ← branches
               </button>
             </MenuLabel>
-            <div className="max-h-56 overflow-y-auto">
+            <Scroller className="max-h-56 overflow-y-auto">
               {projectBranches.length === 0 && (
                 <div className="px-3 py-1.5 text-[11px] text-text-subtle">No branches found.</div>
               )}
@@ -989,10 +1015,10 @@ function WorkstreamMenu({
                   </MenuItem>
                 )
               })}
-            </div>
+            </Scroller>
           </>
         )}
-      </div>
+      </Scroller>
     </div>
   )
 }
@@ -1006,18 +1032,21 @@ function MenuItem({
   onClick,
   icon,
   hint,
-  trailing
+  trailing,
+  title
 }: {
   children: React.ReactNode
   onClick: () => void
   icon?: React.ReactNode
   hint?: string
   trailing?: React.ReactNode
+  title?: string
 }): JSX.Element {
   return (
     <button
       type="button"
       onClick={onClick}
+      title={title}
       className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-muted transition hover:bg-white/5 hover:text-text"
     >
       {icon}

--- a/src/renderer/src/lib/overlayScroll.ts
+++ b/src/renderer/src/lib/overlayScroll.ts
@@ -1,0 +1,116 @@
+/**
+ * App-wide overlay scrollbars.
+ *
+ * The native Windows/Linux scrollbar is a 10px opaque gutter that permanently
+ * steals layout width and repaints as a bright bar over a near-black UI. No
+ * amount of `::-webkit-scrollbar` styling fixes the two things that actually
+ * make it look cheap: it is ALWAYS there, and it CHANGES THE LAYOUT when
+ * content grows past its container. macOS solved this years ago by overlaying
+ * the scrollbar and fading it out when you stop scrolling. This gives every
+ * platform that behavior.
+ *
+ * ## Why `elements.viewport` points at the target itself
+ *
+ * By default OverlayScrollbars wraps your element: it injects a `viewport` div
+ * inside, moves the children into it, and that inner div becomes the thing that
+ * actually scrolls. That would silently break every piece of scroll logic in
+ * this app, because they all hold a ref to the OUTER element:
+ *
+ *   - ChatView's stick-to-bottom + prepend-anchoring reads `scrollTop`,
+ *     `scrollHeight`, `clientHeight` and calls `scrollTo` on its own ref.
+ *   - ChatView's infinite-scroll-up pagination is a React `onScroll` prop,
+ *     which only fires for a scroll event on THAT element.
+ *   - ServicesSegment finds its log pane with `querySelector('pre')` and
+ *     listens via `onScrollCapture` on a wrapper.
+ *   - Sticky headers (ModelPicker's search box) are positioned against their
+ *     scrollport; a new intermediate div changes what that is.
+ *
+ * Passing `viewport: target` tells the library "this element is already the
+ * scrollport, do not build one". It then only observes and draws — no wrapper
+ * div, no moved children, no changed containing block. The stylesheet's
+ * `[data-overlayscrollbars-viewport]:not([data-overlayscrollbars])` rules are
+ * written for exactly this mode. So every existing ref, event handler and
+ * sticky child keeps working untouched, and the scrollbars become cosmetic.
+ *
+ * The tradeoff is that we keep the element's own `overflow` from Tailwind
+ * (`overflow-y-auto` etc.) rather than letting the library manage it, which is
+ * why `overflow` is left at its default here.
+ */
+import { useEffect, useRef, type RefObject } from 'react'
+import { OverlayScrollbars, type PartialOptions } from 'overlayscrollbars'
+
+/**
+ * Shared defaults.
+ *
+ * `autoHide: 'scroll'` is the macOS behavior the native Windows bar lacks: the
+ * bar exists only while you are actually scrolling, then fades. `leave` was the
+ * other candidate, but it keeps the bar visible the whole time the pointer is
+ * anywhere over a pane — for the chat transcript, which fills the window, that
+ * is indistinguishable from always-on.
+ *
+ * `autoHideSuspend: false` matters more than it looks: with `true` the library
+ * keeps scrollbars visible until the FIRST scroll interaction, so every pane
+ * would show a bar on mount and only start hiding after you touch it. We want
+ * them hidden from the start.
+ */
+const BASE: PartialOptions = {
+  scrollbars: {
+    theme: 'os-theme-roxy',
+    autoHide: 'scroll',
+    autoHideDelay: 500,
+    autoHideSuspend: false,
+    // Click-drag the handle like a normal scrollbar; jump-on-track-click too.
+    dragScroll: true,
+    clickScroll: true
+  }
+}
+
+/**
+ * Attach overlay scrollbars to an element you already have a ref to.
+ *
+ * Use this when the element needs its own ref for scroll logic (ChatView) or
+ * when it is rendered by a component you don't control the markup of. For
+ * plain containers prefer `<Scroller>` below.
+ */
+export function useOverlayScroll(
+  ref: RefObject<HTMLElement | null>,
+  options?: PartialOptions
+): void {
+  // Keep the latest options in a ref so a caller passing an inline object
+  // literal (the common case) doesn't tear down and rebuild the instance on
+  // every render — which would lose scroll position.
+  const optionsRef = useRef(options)
+  optionsRef.current = options
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const instance = OverlayScrollbars(
+      // `viewport: el` == "the target already IS the scrollport". See the file
+      // comment: this is what keeps refs and scroll math valid.
+      //
+      // `nativeScrollbarsOverlaid: false` forces initialization even on
+      // platforms that already draw overlay scrollbars (macOS with a trackpad).
+      // It has to: main.css hides native scrollbars inside #root
+      // unconditionally, so cancelling there would leave macOS with no
+      // scrollbar at all rather than falling back to a good native one.
+      {
+        target: el,
+        elements: { viewport: el },
+        cancel: { nativeScrollbarsOverlaid: false, body: null }
+      },
+      merge(BASE, optionsRef.current)
+    )
+    return () => instance.destroy()
+  }, [ref])
+}
+
+/** Shallow-merge that keeps the nested `scrollbars` defaults intact. */
+function merge(base: PartialOptions, extra?: PartialOptions): PartialOptions {
+  if (!extra) return base
+  return {
+    ...base,
+    ...extra,
+    scrollbars: { ...base.scrollbars, ...extra.scrollbars }
+  }
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,5 +1,6 @@
 import '@fontsource-variable/geist/index.css'
 import '@fontsource-variable/geist-mono/index.css'
+import 'overlayscrollbars/overlayscrollbars.css'
 import './assets/main.css'
 import 'streamdown/styles.css'
 import React from 'react'

--- a/src/renderer/src/routes/Onboarding.tsx
+++ b/src/renderer/src/routes/Onboarding.tsx
@@ -6,6 +6,7 @@ import { api } from '../lib/api'
 import { Button } from '../components/ui'
 import roxy from '../assets/roxy.png'
 import { ProviderStep } from './onboarding/ProviderStep'
+import { Scroller } from '../components/Scroller'
 
 export default function Onboarding(): JSX.Element {
   const navigate = useNavigate()
@@ -26,16 +27,20 @@ export default function Onboarding(): JSX.Element {
     <div className="flex h-full w-full flex-col bg-bg">
       <header className="titlebar reserve-controls-left reserve-controls-right flex h-14 shrink-0 items-center px-5">
         <div className="flex items-center gap-2.5">
-          <img src={roxy} alt="Roxy" className="h-7 w-7 rounded-lg object-cover ring-1 ring-border" />
+          <img
+            src={roxy}
+            alt="Roxy"
+            className="h-7 w-7 rounded-lg object-cover ring-1 ring-border"
+          />
           <span className="text-sm font-semibold">Roxy</span>
         </div>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <Scroller className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl px-6 py-8">
           <ProviderStep />
         </div>
-      </div>
+      </Scroller>
 
       <footer className="flex h-16 shrink-0 items-center justify-between border-t border-border px-6">
         <span className="text-xs text-text-subtle">

--- a/src/renderer/src/routes/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/routes/onboarding/ProviderStep.tsx
@@ -1,5 +1,14 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { ArrowLeft, ArrowRight, Check, ChevronRight, Copy, ExternalLink, Loader2, Search } from 'lucide-react'
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Loader2,
+  Search
+} from 'lucide-react'
 import { AUTH_LABELS, SEED_PROVIDERS, isConnectableNow, resolveSeed } from '@shared/providers'
 import { pickDefaultModel } from '@shared/models'
 import type { DeviceFlowStart, SeedProvider } from '@shared/types'
@@ -7,6 +16,7 @@ import { api } from '../../lib/api'
 import { useRoxyStore } from '../../lib/store'
 import { Button, Input } from '../../components/ui'
 import { ProviderLogo } from '../../lib/providerLogos'
+import { Scroller } from '../../components/Scroller'
 
 // The searchable list leads with Roxy too — a fallback for anyone who breezes
 // past the featured hero card above — followed by every other provider. (Roxy
@@ -29,8 +39,8 @@ export function ProviderStep(): JSX.Element {
     <div>
       <h1 className="text-2xl font-semibold tracking-tight">Connect a provider</h1>
       <p className="mt-2 text-sm text-text-muted">
-        Start with Roxy&rsquo;s own inference — one key for 300+ models — or bring your own provider.
-        Add more anytime in Settings.
+        Start with Roxy&rsquo;s own inference — one key for 300+ models — or bring your own
+        provider. Add more anytime in Settings.
       </p>
 
       {providers.length > 0 && (
@@ -64,7 +74,7 @@ export function ProviderStep(): JSX.Element {
         />
       </div>
 
-      <div className="mt-3 max-h-[320px] overflow-y-auto rounded-xl border border-border bg-surface">
+      <Scroller className="mt-3 max-h-[320px] overflow-y-auto rounded-xl border border-border bg-surface">
         {filtered.length === 0 ? (
           <p className="px-4 py-8 text-center text-sm text-text-subtle">
             No providers match “{query}”.
@@ -81,7 +91,7 @@ export function ProviderStep(): JSX.Element {
             ))}
           </div>
         )}
-      </div>
+      </Scroller>
 
       {setupId && <ProviderSetup seed={resolveSeed(setupId)} onClose={() => setSetupId(null)} />}
     </div>
@@ -161,7 +171,13 @@ function ProviderRow({
   )
 }
 
-function ProviderSetup({ seed, onClose }: { seed: SeedProvider; onClose: () => void }): JSX.Element {
+function ProviderSetup({
+  seed,
+  onClose
+}: {
+  seed: SeedProvider
+  onClose: () => void
+}): JSX.Element {
   const refreshProviders = useRoxyStore((s) => s.refreshProviders)
   const [apiKey, setApiKey] = useState('')
   const [baseURL, setBaseURL] = useState(seed.baseURL ?? '')
@@ -231,7 +247,7 @@ function ProviderSetup({ seed, onClose }: { seed: SeedProvider; onClose: () => v
         </div>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <Scroller className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-md px-6 py-10">
           {isCopilot ? (
             <CopilotSetup onConnected={onConnected} />
@@ -302,7 +318,7 @@ function ProviderSetup({ seed, onClose }: { seed: SeedProvider; onClose: () => v
             </div>
           )}
         </div>
-      </div>
+      </Scroller>
     </div>
   )
 }
@@ -381,8 +397,13 @@ function CopilotSetup({ onConnected }: { onConnected: () => void }): JSX.Element
         </span>
         <Copy className="h-4 w-4 text-text-subtle transition-colors group-hover:text-text" />
       </button>
-      <span className="text-xs text-text-subtle">{copied ? 'Copied!' : 'Click the code to copy'}</span>
-      <Button variant="secondary" onClick={() => flow && api.system.openExternal(flow.verificationUri)}>
+      <span className="text-xs text-text-subtle">
+        {copied ? 'Copied!' : 'Click the code to copy'}
+      </span>
+      <Button
+        variant="secondary"
+        onClick={() => flow && api.system.openExternal(flow.verificationUri)}
+      >
         <ExternalLink className="h-4 w-4" /> Open GitHub
       </Button>
       <div className="mt-1 flex items-center gap-2 text-sm text-text-muted">

--- a/src/shared/format.ts
+++ b/src/shared/format.ts
@@ -36,3 +36,23 @@ export function formatInterval(minutes: number): string {
   const head = `${days} day${days === 1 ? '' : 's'}`
   return hrs ? `${head} ${hrs}hr${hrs === 1 ? '' : 's'}` : head
 }
+
+/**
+ * The folder name a worktree lives in — its "slug".
+ *
+ * Worth its own helper because this name DRIFTS from the branch. A workstream's
+ * directory is created once from the session's opening title and then never
+ * moved, while `syncBranchToTitle` renames the branch as the session's real
+ * subject emerges. So a session showing branch `fred/fix-auth-refresh` can be
+ * running in a folder called `fred-legacy-sylphie-compiler`, and nothing in the
+ * UI used to connect the two — which is exactly what makes a stray worktree on
+ * disk hard to identify.
+ *
+ * Handles both separators because worktree paths are stored as the platform
+ * produced them, and drops a trailing slash so `/a/b/` still yields `b`.
+ */
+export function worktreeSlug(path: string | null | undefined): string | null {
+  if (!path) return null
+  const segment = path.split(/[\\/]/).filter(Boolean).pop()
+  return segment || null
+}


### PR DESCRIPTION
## What

Five small cosmetic passes over the app chrome.

### Scrollbars — overlay, auto-hiding

Every scroller in the app now uses [OverlayScrollbars](https://kingsora.github.io/OverlayScrollbars/) instead of the native one. The native Windows/Linux bar is a permanent 10px opaque gutter that also *changes layout* the moment content overflows; this replaces it with a handle that floats over the content and fades out when you stop scrolling.

Each element is initialized as its **own viewport** (`elements: { viewport: el }`), which is the detail that makes this safe. By default the library injects a wrapper div and moves your children into it, so the scrolling element changes — that would have silently broken `ChatView`'s stick-to-bottom math, its `onScroll` pagination, `ServicesSegment`'s `querySelector('pre')`, and `ModelPicker`'s sticky search header. In this mode it only observes and draws, so every existing ref and handler keeps working.

Two non-obvious things, both called out in comments because they'd be easy to "clean up" into a bug:

- **The native-scrollbar kill in `main.css` is scoped to `#root` on purpose.** OverlayScrollbars measures a probe element appended to `<body>` to decide whether the platform already draws overlay scrollbars. A global `* { scrollbar-width: none }` makes that probe measure `0`, so the library concludes "already overlaid" and **cancels every initialization** — the whole feature ships as a silent no-op. Scoping to `#root` lets the probe see a real scrollbar while the user never does.
- **`cancel.nativeScrollbarsOverlaid` is `false`.** The CSS hides native scrollbars unconditionally, so cancelling on macOS would leave it with *no* scrollbar rather than falling back to a good native one.

### Sidebar — `+` creates a session

The project row's `+` opened a two-item menu (Session / Loop). It now creates a session directly; loop creation moves to a hover-revealed icon beside it, matching the delete buttons already on those rows.

### Sidebar — subagent pill is hover-only

The count pill used to stay pinned while a delegate was running, parking a badge on the row for the whole turn. It's hover-only again. Since that pin was the only cue that work was happening under a *collapsed, idle* parent, the row's existing status dot now turns accent-colored instead — same signal, no extra element, no layout shift.

### Agent picker — no taglines

Dropped the one-line blurbs under Build / Plan. The full descriptions still go to the model via `src/shared/agents.ts` and are one hover away.

### Header path — the worktree, and click-to-copy

The header showed `workspacePath` (the project folder you opened). It now shows `worktreePath` — the checkout the agent actually runs in. Those differ for every workstream, so the old header was naming a directory the session wasn't editing.

Clicking copies it. The confirmation is overlaid on the path rather than floating in as a toast (this is a thing you hit repeatedly; a toast flying across the screen each time is noise), and the path fades instead of unmounting so the header never reflows.

Workstream tooltips now name the folder too. A worktree directory is created once from the session's opening title and never renamed, while `syncBranchToTitle` keeps renaming the *branch* — so title, branch and directory drift apart with nothing connecting them. This makes the mapping answerable without leaving the app.

## Testing

- `npm run typecheck` (node + web) and `npm run build` pass.
- Prettier clean on every file touched. Five files elsewhere in the repo were already unformatted on `main`; left alone.
- Scrollbar behavior verified in a browser against the **actual built stylesheet**, not a mock: initializes, theme applies, 10px bar / 6px capsule handle, hidden at rest → visible on scroll → re-hidden after the delay, `scrollTop` and scroll events intact, **no layout width stolen**, scrollbars absolutely positioned so they add no scroll height and don't disturb flex `gap`, `prefers-reduced-motion` respected.
- `worktreeSlug` checked against 8 cases (Windows `\`, POSIX `/`, trailing separator, `null` / `undefined` / empty / single segment).
- Copy confirmation measured at 439px in both states — zero layout shift — and the multi-line `title` verified to survive the DOM round trip.

## Notes / limitations

- **`@pierre/diffs` renders into shadow DOM**, which neither the CSS nor the library can reach. Those diff viewers keep native scrollbars; fixing that needs a change in that package.
- Also slipped in a missing `min-h-0` on `LoopDetailsPane` — it had `flex-1` without it, so the pane grew past its container instead of scrolling.
- `overlayscrollbars-react` was installed then removed: the wrapper component doesn't support target-as-viewport the way this needs, so `Scroller` is a ~30-line local component instead. Only `overlayscrollbars` is a dependency.
