### PR TITLE
Bump version to 0.0.58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.57",
+      "version": "0.0.58",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",


### PR DESCRIPTION
Version-only bump: `0.0.57` -> `0.0.58` in `package.json` and `package-lock.json`.

The whole diff is three lines. No dependency edits, so this can sit here and be merged **last**, after the other in-flight sessions land, without conflicting with any of them.

Note: `npm install --package-lock-only` wanted to additionally add six bundled `@tailwindcss/oxide-wasm32-wasi` sub-entries that no dependency change asked for. Those were reverted -- the lockfile's two version strings are the only change.

### What 0.0.58 ships (already on main since 0.0.57, via #18)
- Overlay scrollbars on every scroller -- auto-hiding handles instead of the permanent native gutter.
- The sidebar project row's "+" creates a session directly; loop creation moved to a hover-revealed icon.
- The subagent count pill is hover-only again; the row's status dot goes accent-colored while a delegate runs.
- Agent picker dropped the per-agent taglines.
- Header shows the `worktreePath` the agent actually runs in, and copies it on click.