### PR TITLE
Sidebar: right-click a session to fork its history or delete it

### DIFF
--- a/src/main/db/repo.ts
+++ b/src/main/db/repo.ts
@@ -450,7 +450,15 @@ function parseWorktreeIntent(json: string | null): WorktreeIntent | null {
   try {
     const v = JSON.parse(json) as WorktreeIntent
     if (!v || (v.mode !== 'new' && v.mode !== 'fromBranch' && v.mode !== 'attach')) return null
-    return { mode: v.mode, branch: typeof v.branch === 'string' ? v.branch : undefined }
+    // Rebuilt field by field rather than returned as-is, so a hand-edited or
+    // future-version row can't smuggle an unexpected shape onto the turn path.
+    // Every field the intent carries must therefore be listed HERE - one that
+    // isn't is silently dropped on the round trip through this column.
+    return {
+      mode: v.mode,
+      branch: typeof v.branch === 'string' ? v.branch : undefined,
+      baseRef: typeof v.baseRef === 'string' ? v.baseRef : undefined
+    }
   } catch {
     return null
   }
@@ -568,6 +576,92 @@ export function createChat(input: CreateChatInput = {}): Chat {
   if (input.workspacePath && (input.kind ?? 'main') !== 'sub') ensureProject(input.workspacePath)
   const chat = getChat(id)
   if (!chat) throw new Error('Failed to create chat')
+  return chat
+}
+
+/**
+ * Copy a session — its transcript and everything that shapes the next turn —
+ * into a brand-new session, leaving the original untouched.
+ *
+ * This is for carrying context sideways: you've spent an hour teaching a
+ * session about a codebase and now want to take that understanding somewhere
+ * else without re-explaining it, and without derailing the work already in
+ * flight. So the fork inherits the things the model reads (messages, the
+ * compaction summary and its watermark, the inference config) and inherits
+ * NOTHING that identifies the original as a running piece of work: no worktree,
+ * no branch, no dev port, no queued prompts, no subagent children. Those are
+ * resources, not context, and sharing them would make two sessions fight over
+ * one checkout.
+ *
+ * Message rows keep their ORIGINAL `created_at`, and that is what makes the
+ * copy faithful rather than merely similar. `messages` is ordered by that
+ * column, and `context_summary_at` is a timestamp watermark INTO it (see
+ * shared/context.ts): a compacted session's early turns are left out of the
+ * window on the promise that the summary covers them. Restamp the messages to
+ * now() and every one of them lands on the wrong side of that watermark - the
+ * fork would open looking complete and silently reason from nothing. Ids are
+ * fresh, of course; two chats must never share one.
+ *
+ * `tasks` is deliberately NOT copied - it's a live checklist owned by the run
+ * in flight, and a fork opening with someone else's half-ticked plan states
+ * something untrue about itself. The one-line `description` does travel: it
+ * describes the subject matter, which is exactly what the fork inherits.
+ *
+ * A `sub` session forks into a normal `main` one: its transcript is the useful
+ * part, its subordinate status is not.
+ */
+export function forkChat(sourceId: string, input: { title?: string } = {}): Chat {
+  const db = getDb()
+  const source = getChat(sourceId)
+  if (!source) throw new Error('Chat not found')
+
+  // A subagent's `workspace_path` is its runtime cwd, which for a session with a
+  // worktree is the WORKTREE - not a project folder. Registering that as a
+  // project would put a checkout dir in the sidebar, so resolve the owning
+  // session's project instead.
+  const workspacePath =
+    source.kind === 'sub'
+      ? (getChatWorkspace(rootSessionId(sourceId)) ?? source.workspacePath)
+      : source.workspacePath
+
+  const id = randomUUID()
+  const now = Date.now()
+  const title = input.title?.trim() || `${source.title} (fork)`
+  const messages = db
+    .prepare('SELECT role, content, parts, created_at FROM messages WHERE chat_id = ?')
+    .all(sourceId) as Pick<MessageRow, 'role' | 'content' | 'parts' | 'created_at'>[]
+
+  const insertMessage = db.prepare(
+    'INSERT INTO messages(id, chat_id, role, content, parts, created_at) VALUES(?, ?, ?, ?, ?, ?)'
+  )
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO chats(id, title, kind, provider_id, model, agent_id, reasoning_effort, context_limit, workspace_path, parent_id, context_summary, context_summary_at, description, sort_order, created_at, updated_at)
+       VALUES(?, ?, 'main', ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      id,
+      title,
+      source.providerId,
+      source.model,
+      source.agentId,
+      source.reasoningEffort,
+      source.contextLimit,
+      workspacePath,
+      source.contextSummary,
+      source.contextSummaryAt,
+      source.description,
+      now, // sort_order: the fork lands at the top of its project, like any new session
+      now,
+      now
+    )
+    for (const m of messages) {
+      insertMessage.run(randomUUID(), id, m.role, m.content, m.parts, m.created_at)
+    }
+  })()
+
+  if (workspacePath) ensureProject(workspacePath)
+  const chat = getChat(id)
+  if (!chat) throw new Error('Failed to fork chat')
   return chat
 }
 

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -6,6 +6,7 @@ import type {
   CreateLoopInput,
   CreateWorktreeInput,
   CreateWorktreeResult,
+  ForkChatInput,
   GitStatusView,
   LlmStartInput,
   McpServerView,
@@ -147,6 +148,43 @@ export function registerIpc(): void {
   // ---- chats ----
   ipcMain.handle(CHANNELS.chatsList, () => repo.listChats())
   ipcMain.handle(CHANNELS.chatsCreate, (_e, input?: CreateChatInput) => repo.createChat(input))
+  ipcMain.handle(CHANNELS.chatsFork, async (_e, id: string, input?: ForkChatInput) => {
+    const source = repo.getChat(id)
+    if (!source) throw new Error('Chat not found')
+
+    // The fork's CODE has to match the transcript it inherits. If the source runs
+    // in a workstream, the fork gets its own worktree branched off the commit
+    // that workstream is sitting on RIGHT NOW - not off origin/main, which would
+    // hand the copy a history describing files that aren't in its checkout.
+    //
+    // Read through the ROOT session: a subagent owns no worktree of its own but
+    // works inside its parent's, and forking one is a normal thing to want (it
+    // is often where the interesting exploration happened).
+    //
+    // A source with no worktree at all - auto-workstream off, or a folder that
+    // isn't a repo - forks in place and shares the project checkout, exactly as
+    // the source does. Inventing an isolated tree for the copy would put it
+    // somewhere the user's editor isn't.
+    //
+    // A source whose workstream is still PENDING (created but never run) counts:
+    // it will get a tree on its first turn, and a fork that quietly opted out of
+    // one would then be editing the project folder its parent is about to stop
+    // using. There is no commit to inherit yet - both will branch off the
+    // default - so the baseRef is simply absent, not wrong.
+    const root = repo.getChat(repo.rootSessionId(id))
+    const wantsWorktree =
+      input?.worktree !== false && !!(root?.worktreePath || root?.worktreePending)
+    const baseRef = root?.worktreePath
+      ? await git.resolveCommit(sessionCwd(id)).catch(() => null)
+      : null
+
+    const chat = repo.forkChat(id, { title: input?.title })
+    if (!wantsWorktree) return chat
+    // Parked, not created: like any new session, the worktree is materialized on
+    // the first turn, so a fork that is opened and abandoned costs nothing.
+    repo.setChatWorktreePending(chat.id, { mode: 'new', ...(baseRef ? { baseRef } : {}) })
+    return repo.getChat(chat.id) ?? chat
+  })
   ipcMain.handle(CHANNELS.chatsRename, (_e, id: string, title: string) =>
     repo.renameChat(id, title)
   )

--- a/src/main/services/git.ts
+++ b/src/main/services/git.ts
@@ -274,6 +274,21 @@ export async function currentBranch(cwd: string): Promise<string | null> {
 }
 
 /**
+ * Resolve `rev` to a commit sha in `cwd`, or null when it doesn't exist.
+ *
+ * The null is the point: callers use this to check that a ref they recorded
+ * earlier (a fork's base commit, say) is still there, so a branch deleted in
+ * the meantime degrades to a different base instead of a `fatal:` on the path
+ * that was going to use it. Defaults to HEAD.
+ */
+export async function resolveCommit(cwd: string, rev = 'HEAD'): Promise<string | null> {
+  if (!cwd) return null
+  const r = await git(['rev-parse', '--verify', '--quiet', `${rev}^{commit}`], cwd)
+  const sha = r.stdout.trim()
+  return r.ok && sha ? sha : null
+}
+
+/**
  * Local branches plus remote-tracking branches, deduped and sorted.
  *
  * `origin/feature` collapses to `feature` so the picker shows one entry per

--- a/src/main/services/worktree.ts
+++ b/src/main/services/worktree.ts
@@ -187,7 +187,14 @@ async function createForWorkspace(
       // Name the branch after the session, so `roxy/legacy-ogre-apprentice`
       // shows up in `git branch` and on the PR instead of `roxy/6fdc60b8`.
       const branch = intent.branch?.trim() || (await git.branchNameForTitle(root, title))
-      const r = await git.createWorktree({ repoRoot: root, branch })
+      // A fork asked to start from the commit its source was sitting on. It's
+      // advisory: a ref that no longer resolves (the source worktree was
+      // deleted in between) falls through to the usual origin/<default> base
+      // rather than failing the fork's first turn.
+      const baseRef = intent.baseRef?.trim()
+        ? ((await git.resolveCommit(root, intent.baseRef.trim())) ?? undefined)
+        : undefined
+      const r = await git.createWorktree({ repoRoot: root, branch, baseRef })
       if (!r.ok || !r.worktree)
         return { ok: false, error: r.error ?? 'Could not create the worktree.' }
       return { ok: true, worktreePath: r.worktree.path, branch: r.worktree.branch ?? branch }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,6 +40,7 @@ const roxy: RoxyApi = {
   chats: {
     list: () => ipcRenderer.invoke(CHANNELS.chatsList),
     create: (input) => ipcRenderer.invoke(CHANNELS.chatsCreate, input),
+    fork: (id, input) => ipcRenderer.invoke(CHANNELS.chatsFork, id, input),
     rename: (id, title) => ipcRenderer.invoke(CHANNELS.chatsRename, id, title),
     remove: (id) => ipcRenderer.invoke(CHANNELS.chatsRemove, id),
     reorder: (workspacePath, ids) => ipcRenderer.invoke(CHANNELS.chatsReorder, workspacePath, ids),

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -6,11 +6,13 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent
 } from 'react'
+import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import {
   ChevronRight,
   FolderOpen,
   GitBranch,
+  GitFork,
   Hammer,
   Lightbulb,
   MonitorSmartphone,
@@ -20,6 +22,7 @@ import {
   Plus,
   Repeat,
   Settings as SettingsIcon,
+  SquarePen,
   Trash2
 } from 'lucide-react'
 import type { Chat, Loop } from '@shared/types'
@@ -29,6 +32,7 @@ import { statusKeyForSession } from '@shared/workstream'
 import { formatInterval } from '@shared/format'
 import { useRoxyStore } from '../lib/store'
 import { api } from '../lib/api'
+import { placeContextMenu } from '../lib/anchor'
 import { cn } from '../lib/cn'
 import { TONE_BG, TONE_TEXT_STATIC } from '../lib/lifecycle'
 import { HeartbeatDot, NewLoopDialog } from './LoopsSection'
@@ -92,6 +96,7 @@ export function Sidebar(): JSX.Element {
   const newSession = useRoxyStore((s) => s.newSession)
   const newSessionInProject = useRoxyStore((s) => s.newSessionInProject)
   const deleteChat = useRoxyStore((s) => s.deleteChat)
+  const forkChat = useRoxyStore((s) => s.forkChat)
   const renameChat = useRoxyStore((s) => s.renameChat)
   const sendingChats = useRoxyStore((s) => s.sendingChats)
   const loops = useRoxyStore((s) => s.loops)
@@ -107,6 +112,8 @@ export function Sidebar(): JSX.Element {
   })
   const [railed, setRailed] = useState<boolean>(() => localStorage.getItem(COLLAPSED_KEY) === '1')
   const [loopDialogFor, setLoopDialogFor] = useState<{ path: string; name: string } | null>(null)
+  // The open right-click menu: which session, and where the cursor was.
+  const [contextMenu, setContextMenu] = useState<{ chat: Chat; x: number; y: number } | null>(null)
   const [remoteOpen, setRemoteOpen] = useState(false)
   const remotePhase = useRoxyStore((s) => s.remote.phase)
   // Green only when truly live; amber while spinning up or reconnecting.
@@ -182,6 +189,29 @@ export function Sidebar(): JSX.Element {
     setDraftTitle(chat.title)
     setEditingId(chat.id)
   }
+
+  // Right-click anywhere on a session row. Renaming is excluded: the row is an
+  // <input> then, and stealing its native text menu (cut/paste/spelling) to
+  // offer "Rename" would be strictly worse.
+  const openContextMenu = (e: ReactMouseEvent, chat: Chat): void => {
+    if (editingId === chat.id) return
+    e.preventDefault()
+    // Native menus close a stale one and open the new one in a single gesture;
+    // matching that means overwriting whatever was open, not toggling.
+    setContextMenu({ chat, x: e.clientX, y: e.clientY })
+  }
+
+  // The rows a right-click offers, in escalating order of consequence.
+  const contextMenuItems = (chat: Chat): MenuItem[] => [
+    { label: 'Fork session history', icon: GitFork, onSelect: () => void forkChat(chat.id) },
+    { label: 'Rename', icon: SquarePen, onSelect: () => beginRename(chat) },
+    {
+      label: 'Delete session',
+      icon: Trash2,
+      danger: true,
+      onSelect: () => void deleteChat(chat.id)
+    }
+  ]
 
   const commitRename = (): void => {
     const id = editingId
@@ -668,10 +698,18 @@ export function Sidebar(): JSX.Element {
                                 )}
                               >
                                 <div
+                                  onContextMenu={(e) => openContextMenu(e, chat)}
                                   className={cn(
                                     'group flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm transition-colors',
                                     dragId && 'cursor-grabbing',
-                                    chat.id === activeChatId
+                                    // Keep the right-clicked row visibly selected
+                                    // for as long as its menu is open, so a menu
+                                    // floating over a dense list still says which
+                                    // session it is about to act on. It borrows
+                                    // the selected look wholesale, vibrancy and
+                                    // all: a second, lesser highlight would just
+                                    // be a new thing to learn.
+                                    chat.id === activeChatId || contextMenu?.chat.id === chat.id
                                       ? 'vibrancy-chip bg-elevated text-text'
                                       : 'text-text-muted hover:bg-white/5 hover:text-text'
                                   )}
@@ -798,9 +836,11 @@ export function Sidebar(): JSX.Element {
                                     {subs.map((sub) => (
                                       <li key={sub.id}>
                                         <div
+                                          onContextMenu={(e) => openContextMenu(e, sub)}
                                           className={cn(
                                             'group/sub flex items-center gap-2 rounded-lg px-2 py-1 text-xs transition-colors',
-                                            sub.id === activeChatId
+                                            sub.id === activeChatId ||
+                                              contextMenu?.chat.id === sub.id
                                               ? 'vibrancy-chip bg-elevated text-text'
                                               : 'text-text-muted hover:bg-white/5 hover:text-text'
                                           )}
@@ -857,6 +897,15 @@ export function Sidebar(): JSX.Element {
         </section>
       </Scroller>
 
+      {contextMenu && (
+        <SessionContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={contextMenuItems(contextMenu.chat)}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+
       {loopDialogFor && (
         <NewLoopDialog
           workspacePath={loopDialogFor.path}
@@ -879,6 +928,122 @@ export function Sidebar(): JSX.Element {
         className="absolute inset-y-0 right-0 z-20 w-1 cursor-col-resize transition-colors hover:bg-accent/50"
       />
     </aside>
+  )
+}
+
+/** One row of the session context menu. */
+interface MenuItem {
+  label: string
+  icon: typeof Trash2
+  onSelect: () => void
+  danger?: boolean
+}
+
+/** Fixed width, so the menu can be positioned before it has rendered. */
+const CONTEXT_MENU_W = 208
+/** Row height + the surface's 4px top/bottom padding — used for the same reason. */
+const CONTEXT_ROW_H = 30
+
+/**
+ * The right-click menu on a session row.
+ *
+ * Positioned at the cursor rather than at the row: a context menu that opens
+ * somewhere other than where you clicked makes you re-find it, and with rows
+ * this dense you'd routinely be pointing at a different session than the one
+ * the menu belongs to.
+ *
+ * Portalled to `document.body` and `fixed` because the sidebar's session list
+ * is a scroll container — an absolutely-positioned child would be clipped by it
+ * near the bottom edge, which is exactly where a long list gets right-clicked.
+ *
+ * Dismissal is deliberately broad (outside mousedown, scroll, Escape, window
+ * blur): every one of those means attention has moved on, and a menu still
+ * floating over a list you're now scrolling is pointing at the wrong row.
+ */
+function SessionContextMenu({
+  x,
+  y,
+  items,
+  onClose
+}: {
+  x: number
+  y: number
+  items: MenuItem[]
+  onClose: () => void
+}): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null)
+  const height = items.length * CONTEXT_ROW_H + 8
+  const { left, top, origin } = placeContextMenu(
+    x,
+    y,
+    CONTEXT_MENU_W,
+    height,
+    window.innerWidth,
+    window.innerHeight
+  )
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    // Dismiss on mousedown rather than click, so the menu is gone before
+    // whatever is underneath reacts - but only for a press OUTSIDE it. Closing
+    // on a press inside would unmount the button between its own mousedown and
+    // click, and the item would simply never fire.
+    const onDown = (e: MouseEvent): void => {
+      if (!ref.current?.contains(e.target as Node)) onClose()
+    }
+    // Capture phase throughout: `scroll` does not bubble, so this is the only
+    // way to hear the session list move - and a stopPropagation anywhere in the
+    // sidebar must not be able to strand an open menu.
+    //
+    // Scroll, rather than wheel, is the precise condition: the menu is pinned to
+    // viewport coordinates while the row it acts on is inside a scroll
+    // container, so the moment that container moves the menu is pointing at a
+    // different session. That covers the thumb drag and the keyboard just as
+    // well as the trackpad, and correctly ignores a wheel gesture over a list
+    // that is already at its end - nothing moved, so nothing is stale.
+    window.addEventListener('mousedown', onDown, true)
+    window.addEventListener('scroll', onClose, true)
+    window.addEventListener('blur', onClose)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown, true)
+      window.removeEventListener('scroll', onClose, true)
+      window.removeEventListener('blur', onClose)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  return createPortal(
+    <div
+      ref={ref}
+      style={{ left, top, width: CONTEXT_MENU_W, transformOrigin: origin }}
+      // Swallow the right-click so chording onto the menu doesn't reopen it at
+      // a new point over itself.
+      onContextMenu={(e) => e.preventDefault()}
+      className="animate-pop-in fixed z-50 overflow-hidden rounded-lg border border-border bg-elevated py-1 shadow-2xl"
+    >
+      {items.map((item) => (
+        <button
+          key={item.label}
+          onClick={() => {
+            onClose()
+            item.onSelect()
+          }}
+          className={cn(
+            'press-scale flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors',
+            item.danger
+              ? 'text-text-muted hover:bg-danger/10 hover:text-danger'
+              : 'text-text-muted hover:bg-white/5 hover:text-text'
+          )}
+        >
+          <item.icon className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{item.label}</span>
+        </button>
+      ))}
+    </div>,
+    document.body
   )
 }
 

--- a/src/renderer/src/lib/anchor.ts
+++ b/src/renderer/src/lib/anchor.ts
@@ -121,6 +121,37 @@ export function menuMaxHeight(
   return Math.max(MIN_MENU_H, Math.floor(room))
 }
 
+/**
+ * Where a menu opened AT A POINT (a right-click) should sit.
+ *
+ * Different problem from `alignMenu` above, which lines a menu up with a
+ * trigger box it can measure. Here the anchor is the cursor, and the rule that
+ * matters is that the pointer must not end up sitting ON the menu: so when
+ * there isn't room in the natural down-right direction, the box FLIPS to the
+ * other side of the point rather than sliding under it. Clamping is the last
+ * resort, for a menu too big to fit on either side.
+ *
+ * Returns viewport coordinates (the menu is `fixed`, portalled out of the
+ * scroll container it was summoned from) plus the `transform-origin` that makes
+ * it scale out of the cursor rather than out of the void.
+ */
+export function placeContextMenu(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  vw: number,
+  vh: number
+): { left: number; top: number; origin: string } {
+  const flipX = x + w + MARGIN > vw && x - w >= MARGIN
+  const flipY = y + h + MARGIN > vh && y - h >= MARGIN
+  return {
+    left: clamp(flipX ? x - w : x, MARGIN, Math.max(MARGIN, vw - MARGIN - w)),
+    top: clamp(flipY ? y - h : y, MARGIN, Math.max(MARGIN, vh - MARGIN - h)),
+    origin: `${flipX ? 'right' : 'left'} ${flipY ? 'bottom' : 'top'}`
+  }
+}
+
 /** Largest the image can be drawn inside `availW`×`availH`, or null if it can't. */
 function fit(
   natW: number,

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -149,6 +149,12 @@ interface RoxyStore {
   /** Load + cache a workspace's instruction files (AGENTS.md etc.) for sizing. */
   ensureProjectInstructions: (workspacePath: string) => Promise<void>
   deleteChat: (id: string) => Promise<void>
+  /**
+   * Copy a session's history into a new session and open it. Use it to take a
+   * line of work somewhere else without starting from scratch or disturbing
+   * what's already running there.
+   */
+  forkChat: (id: string) => Promise<void>
   renameChat: (id: string, title: string) => Promise<void>
   /** Persist a project's session order (optimistic). `ids` = full project list, top-to-bottom. */
   reorderSessions: (workspacePath: string | null, ids: string[]) => Promise<void>
@@ -1127,6 +1133,21 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       return { sendingChats, streamingChats, stopChats }
     })
     if (get().activeChatId === id) get().clearActive()
+  },
+
+  forkChat: async (id) => {
+    const source = get().chats.find((c) => c.id === id)
+    // Name the copy like a new session rather than "X (fork)": the fork is about
+    // to go somewhere else, and inheriting the old title (plus, for a
+    // workstream, a branch derived from it) would make two unrelated pieces of
+    // work look like the same one. The agent renames it on its first turn, same
+    // as any other session.
+    const taken = get()
+      .chats.filter((c) => c.kind === 'main' && c.workspacePath === source?.workspacePath)
+      .map((c) => c.title)
+    const chat = await api.chats.fork(id, { title: uniqueSlug(taken) })
+    await get().refreshChats()
+    await get().selectChat(chat.id)
   },
 
   renameChat: async (id, title) => {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -103,6 +103,19 @@ export interface CreateChatInput {
   worktree?: WorktreeIntent
 }
 
+export interface ForkChatInput {
+  /** Defaults to `<source title> (fork)`. */
+  title?: string
+  /**
+   * Give the fork its own worktree, branched off the commit the source is
+   * sitting on right now. Only honoured when the source has a workstream (main
+   * process decides); a session running in the project folder forks in place,
+   * because putting the copy somewhere else would strand the transcript it just
+   * inherited.
+   */
+  worktree?: boolean
+}
+
 /**
  * A background process owned by a session — a dev server, a watcher, an install.
  *
@@ -529,6 +542,11 @@ export interface RoxyApi {
   chats: {
     list(): Promise<Chat[]>
     create(input?: CreateChatInput): Promise<Chat>
+    /**
+     * Copy a session's transcript + context into a NEW session, so a line of
+     * work can branch without re-explaining itself. The source is untouched.
+     */
+    fork(id: string, input?: ForkChatInput): Promise<Chat>
     rename(id: string, title: string): Promise<void>
     remove(id: string): Promise<void>
     /** Pin part of one session's inference config (model / mode / effort / context). */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -17,6 +17,8 @@ export const CHANNELS = {
 
   chatsList: 'chats:list',
   chatsCreate: 'chats:create',
+  /** Copy a session's history into a new session (see repo.forkChat). */
+  chatsFork: 'chats:fork',
   chatsRename: 'chats:rename',
   chatsRemove: 'chats:remove',
   chatsReorder: 'chats:reorder',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -99,6 +99,16 @@ export interface SessionTask {
 export interface WorktreeIntent {
   mode: 'new' | 'fromBranch' | 'attach'
   branch?: string
+  /**
+   * For `new`: the commit the fresh branch starts from, instead of the usual
+   * `origin/<default>`. Set when a session is FORKED, so the copy continues
+   * from the code its inherited transcript is actually about — branching a fork
+   * off main would hand it a history describing files that aren't there.
+   *
+   * Advisory: a ref that no longer resolves (the source branch was deleted in
+   * between) falls back to the normal base rather than failing the first turn.
+   */
+  baseRef?: string
 }
 
 export interface Chat {

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -190,6 +190,7 @@ import {
   place,
   alignMenu,
   menuMaxHeight,
+  placeContextMenu,
   GAP,
   MARGIN,
   MAX_W,
@@ -3771,6 +3772,54 @@ async function main(): Promise<void> {
     }
   }
   check('menu: height cap is always finite and usable', badCap === 0, String(badCap))
+
+  // ---- context menus open AT THE CURSOR (sidebar right-click) --------------
+  //
+  // The invariant that matters: the menu must never end up under the pointer
+  // that summoned it, because the next click would then hit a row the user
+  // never aimed at. Near an edge it FLIPS to the other side of the point rather
+  // than sliding over it.
+  const CTX_W = 208
+  const CTX_H = 98
+  const openDown = placeContextMenu(300, 200, CTX_W, CTX_H, 1400, 900)
+  check(
+    'context menu: opens down-right of the cursor when there is room',
+    openDown.left === 300 && openDown.top === 200 && openDown.origin === 'left top'
+  )
+  const flipped = placeContextMenu(1380, 880, CTX_W, CTX_H, 1400, 900)
+  check(
+    'context menu: flips to the other side of the cursor near a corner',
+    flipped.left === 1380 - CTX_W && flipped.top === 880 - CTX_H,
+    `${flipped.left},${flipped.top}`
+  )
+  check('context menu: flip reports the matching origin', flipped.origin === 'right bottom')
+
+  let covered = 0
+  let offscreen = 0
+  for (const [vw, vh] of [
+    [760, 480],
+    [1100, 700],
+    [1920, 1080]
+  ]) {
+    for (let x = 0; x <= vw; x += 11) {
+      for (let y = 0; y <= vh; y += 7) {
+        const p = placeContextMenu(x, y, CTX_W, CTX_H, vw, vh)
+        // The cursor sits strictly outside the box on at least one axis - unless
+        // the viewport is too small to place it on either side, where staying
+        // on screen wins.
+        const under = x > p.left && x < p.left + CTX_W && y > p.top && y < p.top + CTX_H
+        const roomX = x - CTX_W >= MARGIN || x + CTX_W + MARGIN <= vw
+        const roomY = y - CTX_H >= MARGIN || y + CTX_H + MARGIN <= vh
+        if (under && roomX && roomY) covered++
+        if (p.left < MARGIN - 0.5 || p.top < MARGIN - 0.5) offscreen++
+        if (CTX_W <= vw - MARGIN * 2 && p.left + CTX_W > vw - MARGIN + 0.5) offscreen++
+        if (CTX_H <= vh - MARGIN * 2 && p.top + CTX_H > vh - MARGIN + 0.5) offscreen++
+      }
+    }
+  }
+  check('context menu: never opens underneath the cursor', covered === 0, String(covered))
+  check('context menu: never lands outside the viewport', offscreen === 0, String(offscreen))
+
   if (fails.length) {
     console.error(`\nSHARED FAILED \u2014 ${fails.length} failing: ${fails.join(', ')}`)
     process.exit(1)

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -405,6 +405,74 @@ async function main(): Promise<void> {
     msgs[0].parts.length === 1 && userPart.type === 'text' && userPart.text === 'hi'
   )
 
+  // ---- fork: copy a session's context into a new one ----
+  //
+  // The point of a fork is that the copy can carry on a conversation the source
+  // already had, so the transcript has to arrive in the same ORDER with the
+  // same timestamps - `context_summary_at` is a watermark into `created_at`, so
+  // restamped messages would silently fall out of the fork's context window.
+  // Its own source session, not the shared `chat`: a fork test that left a
+  // compaction summary behind on the fixture would break assertions further
+  // down for reasons no one would look for here.
+  const forkSrc = repo.createChat({ title: 'fork source', kind: 'main', workspacePath: ws })
+  repo.addMessage({ chatId: forkSrc.id, role: 'user', content: 'hi' })
+  repo.addMessage({ chatId: forkSrc.id, role: 'assistant', content: 'done', parts })
+  const srcMsgs = repo.listMessages(forkSrc.id)
+  repo.setChatSummary(forkSrc.id, 'a summary of earlier turns', srcMsgs[0].createdAt)
+  repo.enqueue(forkSrc.id, 'not forked')
+  repo.createChat({ title: 'fork src sub', kind: 'sub', parentId: forkSrc.id })
+  const forked = repo.forkChat(forkSrc.id, { title: 'forked session' })
+  const forkedMsgs = repo.listMessages(forked.id)
+  const sourceMsgs = repo.listMessages(forkSrc.id)
+  check('forkChat leaves the source transcript intact', sourceMsgs.length === srcMsgs.length)
+  check(
+    'forkChat copies the whole transcript, in order, at the original times',
+    forkedMsgs.length === sourceMsgs.length &&
+      forkedMsgs.every(
+        (m, i) =>
+          m.role === sourceMsgs[i].role &&
+          m.content === sourceMsgs[i].content &&
+          m.createdAt === sourceMsgs[i].createdAt
+      )
+  )
+  check(
+    'forkChat rewrites message ids (rows are never shared)',
+    forkedMsgs.every((m) => m.chatId === forked.id) &&
+      !forkedMsgs.some((m) => sourceMsgs.some((s) => s.id === m.id))
+  )
+  check(
+    'forkChat carries structured parts across',
+    forkedMsgs[1].parts.length === 3 && forkedMsgs[1].parts[1].type === 'tool'
+  )
+  check(
+    'forkChat carries the compaction summary + its watermark',
+    forked.contextSummary === 'a summary of earlier turns' &&
+      forked.contextSummaryAt === srcMsgs[0].createdAt
+  )
+  check(
+    'forkChat inherits the project + inference config',
+    forked.workspacePath === forkSrc.workspacePath && forked.agentId === forkSrc.agentId
+  )
+  check('forkChat is a main session with no parent', forked.kind === 'main' && !forked.parentId)
+  // Resources, as opposed to context, must NOT come along: two sessions sharing
+  // one checkout (or one queue) would fight over it.
+  check(
+    'forkChat takes no worktree, branch, port or queue',
+    !forked.worktreePath &&
+      !forked.branch &&
+      !forked.devPort &&
+      repo.listQueue(forked.id).length === 0
+  )
+  check('forkChat does not copy subagent children', repo.listSubchats(forked.id).length === 0)
+  // Deleting a fork must not touch the session it came from - the whole feature
+  // is worthless if the copies are entangled.
+  repo.removeChat(forked.id)
+  check(
+    'deleting a fork leaves the source and its messages alone',
+    !!repo.getChat(forkSrc.id) && repo.listMessages(forkSrc.id).length === sourceMsgs.length
+  )
+  repo.removeChat(forkSrc.id)
+
   // ---- queue (FIFO) ----
   const q1 = repo.enqueue(chat.id, 'q1')
   const q2 = repo.enqueue(chat.id, 'q2')
@@ -1606,6 +1674,67 @@ async function main(): Promise<void> {
         await fs.rm(path.join(gitRepo, '.roxy'), { recursive: true, force: true })
         await removeWorktreeForChat(withSetup.id, { force: true })
         repo.removeChat(withSetup.id)
+      }
+
+      // ---- a fork continues from ITS SOURCE's commit, not from main ----
+      //
+      // This is the part of forking that is easy to get silently wrong: the copy
+      // inherits a transcript about work that exists only on the source's
+      // branch, so branching it off origin/<default> - what a plain `mode:'new'`
+      // does - would hand it a history describing files it cannot see.
+      {
+        const srcPath = repo.getChat(lazy.id)!.worktreePath!
+        await fs.writeFile(path.join(srcPath, 'only-on-this-branch.txt'), 'fork me')
+        await runGit(['add', '.'], srcPath)
+        await runGit(['commit', '-m', 'work that exists only on the source branch'], srcPath)
+        const sourceHead = await git.resolveCommit(srcPath)
+        check('the source branch has a commit of its own', !!sourceHead)
+
+        const fork = repo.forkChat(lazy.id, { title: 'forked workstream' })
+        repo.setChatWorktreePending(fork.id, { mode: 'new', baseRef: sourceHead! })
+        // The intent has to survive the DB round trip WITH its baseRef: the
+        // parser rebuilds the object field by field, so one it forgets to list
+        // is dropped silently and the fork quietly starts from main instead.
+        check(
+          'a fork parks its baseRef alongside the worktree intent',
+          repo.getChat(fork.id)?.worktreePending?.baseRef === sourceHead,
+          String(repo.getChat(fork.id)?.worktreePending?.baseRef)
+        )
+
+        const forkMat = await materializePendingWorktree(fork.id)
+        check('the fork materializes a worktree of its own', forkMat.ok, forkMat.error ?? '')
+        check(
+          "...on its own branch, not the source's",
+          !!forkMat.branch && forkMat.branch !== repo.getChat(lazy.id)?.branch,
+          `${forkMat.branch} vs ${repo.getChat(lazy.id)?.branch}`
+        )
+        check(
+          '...starting from the commit the source was sitting on',
+          (await git.resolveCommit(forkMat.worktreePath!)) === sourceHead
+        )
+        check(
+          '...so work that never reached main is present in the fork',
+          existsSync(path.join(forkMat.worktreePath!, 'only-on-this-branch.txt'))
+        )
+
+        // A stale baseRef (the source branch was deleted in between) must
+        // degrade to the normal base, not fail the fork's first turn.
+        const stale = repo.createChat({
+          title: 'stale base',
+          kind: 'main',
+          workspacePath: gitRepo,
+          worktree: { mode: 'new', baseRef: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }
+        })
+        const staleMat = await materializePendingWorktree(stale.id)
+        check(
+          'an unresolvable baseRef falls back instead of failing',
+          staleMat.ok && !!staleMat.worktreePath,
+          staleMat.error ?? ''
+        )
+        await removeWorktreeForChat(stale.id, { force: true })
+        repo.removeChat(stale.id)
+        await removeWorktreeForChat(fork.id, { force: true })
+        repo.removeChat(fork.id)
       }
 
       // A sub-session must never take a worktree of its own.


### PR DESCRIPTION
Sessions could only be deleted by hunting for a hover-revealed trash icon, and there was no way at all to carry a session's context into new work. Right-clicking a row now opens a menu: Fork session history, Rename, Delete.

Forking exists because context is expensive. After an hour of teaching a session about a codebase, taking that understanding somewhere else meant either re-explaining it from scratch or derailing the work already in flight. The fork copies what the model reads and nothing that identifies the source as a running piece of work:

  - transcript, compaction summary + watermark, description and inference config travel;
  - worktree, branch, dev port, queue and subagent children do not - those are resources, and sharing them would make two sessions fight over one checkout.

Two details are load-bearing rather than cosmetic:

Messages keep their ORIGINAL created_at. context_summary_at is a timestamp watermark into that column, so restamping to now() would put every inherited message on the wrong side of the summary - the fork would look complete and silently reason from nothing.

A fork of a workstream branches off the commit its source is sitting on, not off origin/main (new WorktreeIntent.baseRef). The copy inherits a transcript about work that exists only on that branch; branching it off main would hand it a history describing files it cannot see. The ref is advisory - a source branch deleted in between falls back to the usual base rather than failing the fork's first turn.

The menu opens at the cursor, portalled and fixed, because the session list is a scroll container that would clip an absolutely-positioned child exactly where a long list gets right-clicked. Near a viewport edge it flips to the other side of the click rather than sliding under the pointer - a menu the cursor is already inside eats the next click for a row nobody aimed at.

Tests: transcript order/timestamp fidelity, summary inheritance, resource isolation, delete-independence, the baseRef round trip through the DB, and the end-to-end "fork sees work that never reached main" case; plus placement invariants for the menu (never under the cursor, never off screen).