### PR TITLE
Give the sidebar native macOS vibrancy

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,12 +28,47 @@ function createWindow(): BrowserWindow {
     minHeight: 480,
     show: false,
     autoHideMenuBar: true,
-    backgroundColor: '#0a0a0a',
+    // On macOS an AppKit vibrancy view sits behind the web contents; it can
+    // only show through if the window itself paints nothing. Every other
+    // platform keeps the solid near-black, which also avoids a flash of white
+    // between window creation and first paint.
+    backgroundColor: isMac ? '#00000000' : '#0a0a0a',
     title: 'Roxy',
     // Native window controls, themed to match the app (no light OS title bar).
     titleBarStyle: 'hidden',
     ...(isMac
-      ? { trafficLightPosition: { x: 16, y: 17 } }
+      ? {
+          trafficLightPosition: { x: 16, y: 17 },
+          /*
+           * Translucent ("glass") sidebar — macOS only, deliberately.
+           *
+           * `sidebar` is the same NSVisualEffectView material Finder and Mail
+           * use for their source lists, so this reads as genuinely native
+           * rather than as a CSS imitation of one. Vibrancy is a *whole-window*
+           * effect, so the sidebar-only look comes from leaving only the
+           * sidebar translucent while every content pane paints opaque on top
+           * of it (see `.vibrancy-pane` / `.vibrancy-solid` in main.css).
+           *
+           * We deliberately do NOT set `transparent: true`. It's the usual
+           * advice online, but on macOS it disables the native rounded corners
+           * and window shadow, and it isn't needed for vibrancy to composite.
+           *
+           * Windows is intentionally excluded: `backgroundMaterial: 'acrylic'`
+           * degrades to a flat light-grey slab whenever the user has Settings →
+           * Personalization → Colors → "Transparency effects" off (which we
+           * can't detect from Electron), is unavailable before Win11 22H2, and
+           * paints black when maximized on Electron < 36. Verified by
+           * measurement on Win11 23H2 + Electron 33 and 38.
+           */
+          vibrancy: 'sidebar',
+          /*
+           * The default (`followWindow`) swaps to AppKit's lighter "inactive"
+           * material whenever the app loses focus. Nothing else in Roxy changes
+           * appearance on blur, so a sidebar that alone jumps lighter reads as a
+           * rendering glitch rather than as a focus cue. Pin the active state.
+           */
+          visualEffectState: 'active'
+        }
       : { titleBarOverlay: { color: '#0a0a0a', symbolColor: '#9a9aa3', height: 48 } }),
     ...(isMac ? {} : { icon }),
     webPreferences: {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,7 +11,7 @@ import Settings from './routes/Settings'
 
 function Splash(): JSX.Element {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-bg">
+    <div className="vibrancy-solid flex h-full w-full items-center justify-center">
       <img
         src={roxy}
         alt="Roxy"

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -318,3 +318,106 @@ body {
 [data-platform='darwin'] .sidebar-rail {
   width: 5rem;
 }
+
+/* ---------------------------------------------------------------------------
+ * macOS vibrancy ("glass" sidebar)
+ *
+ * The window is backed by an AppKit `sidebar` NSVisualEffectView (see
+ * `vibrancy` in src/main/index.ts). That material is a property of the *whole
+ * window*, so we get a sidebar-only effect by punching a hole through just the
+ * sidebar and keeping every content pane opaque on top:
+ *
+ *   body             -> paints nothing, so the material becomes visible
+ *   .vibrancy-pane   -> the sidebar: a translucent tint over the material
+ *   .vibrancy-solid  -> content panes: fully opaque, unaffected by any of this
+ *
+ * Everything here is scoped to [data-platform='darwin'], so Windows and Linux
+ * render byte-identically to before. The base (unscoped) declarations keep the
+ * opaque colors, which means the fallback is simply "the current design".
+ * ------------------------------------------------------------------------- */
+
+.vibrancy-pane {
+  background: var(--color-surface);
+}
+.vibrancy-solid {
+  background: var(--color-bg);
+}
+
+/* Reveal the native material behind the web contents. `data-platform` lives on
+   <html>, so this only ever matches on macOS; `body` keeps its opaque
+   `--color-bg` everywhere else. */
+[data-platform='darwin'] body {
+  background: transparent;
+}
+
+/*
+ * A tint over the material, not a replacement for it. The alpha is low enough
+ * that the desktop still reads through, but dark enough that text-muted
+ * (#9a9aa3) keeps its contrast over a bright wallpaper — the usual failure of
+ * glass sidebars is unreadable secondary text.
+ *
+ * No backdrop-filter here: AppKit already blurs everything behind the window,
+ * so a CSS blur on top would both double-darken the result and promote the
+ * whole sidebar to its own compositing layer (repainting as the project tree
+ * scrolls) for no visual gain.
+ *
+ * Left unlayered on purpose: Tailwind v4 puts its utilities in `@layer`, and
+ * unlayered rules outrank every layer, so this still wins if an element also
+ * carries a `bg-*` utility.
+ */
+[data-platform='darwin'] .vibrancy-pane {
+  background: color-mix(in srgb, var(--color-bg) 62%, transparent);
+}
+
+/*
+ * Fills that sit *on* the glass (selected rows, count pills). Opaque swatches
+ * over a translucent pane are the classic tell of a fake-looking glass sidebar,
+ * so on mac they become a frosted wash that lets the material through and
+ * brightens with the backdrop, the way AppKit's own selection does.
+ *
+ * These are light (white-alpha) rather than darker fills on purpose: a darker
+ * fill over glass reads as a hole punched through the sidebar, whereas a light
+ * one reads as raised — and it stays legible over both a dark and a bright
+ * wallpaper, which a fixed dark fill does not. Two weights keep the hierarchy
+ * that `bg-elevated` vs `bg-surface-2` carried before: selection is brightest.
+ */
+[data-platform='darwin'] .vibrancy-chip {
+  background: color-mix(in srgb, var(--color-text) 12%, transparent);
+}
+[data-platform='darwin'] .vibrancy-chip-weak {
+  background: color-mix(in srgb, var(--color-text) 7%, transparent);
+}
+
+/*
+ * The remote-status dot uses a 2px ring to separate itself from the icon under
+ * it. That ring is `--color-surface` (opaque) so it reads as a hole punched in
+ * a solid sidebar; over glass it would be a visible dark halo. Match the pane's
+ * own tint instead, so it still separates without looking like a sticker.
+ */
+[data-platform='darwin'] .vibrancy-ring {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-bg) 55%, transparent);
+}
+
+/*
+ * Accessibility: System Settings → Accessibility → Display → "Reduce
+ * transparency". macOS already flattens the native material, so the CSS tint
+ * must go fully opaque too — otherwise the sidebar would sit at 62% over a
+ * now-solid backdrop and render *lighter* than intended.
+ */
+@media (prefers-reduced-transparency: reduce) {
+  [data-platform='darwin'] body {
+    background: var(--color-bg);
+  }
+  [data-platform='darwin'] .vibrancy-pane {
+    background: var(--color-surface);
+  }
+  [data-platform='darwin'] .vibrancy-chip {
+    background: var(--color-elevated);
+  }
+  [data-platform='darwin'] .vibrancy-chip-weak {
+    background: var(--color-surface-2);
+  }
+  [data-platform='darwin'] .vibrancy-ring {
+    box-shadow: 0 0 0 2px var(--color-surface);
+  }
+}

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -125,7 +125,7 @@ export function ChatView(): JSX.Element {
   // No workspace open — prompt to open a folder to start a session.
   if (!activeChat) {
     return (
-      <div className="flex h-full min-w-0 flex-1 flex-col bg-bg">
+      <div className="vibrancy-solid flex h-full min-w-0 flex-1 flex-col">
         <div className="titlebar reserve-controls-right h-12 shrink-0" />
         <div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
           <img
@@ -148,7 +148,7 @@ export function ChatView(): JSX.Element {
   const isEmpty = messages.length === 0 && (streaming === null || streaming.length === 0)
 
   return (
-    <div className="relative flex h-full min-w-0 flex-1 flex-col bg-bg">
+    <div className="vibrancy-solid relative flex h-full min-w-0 flex-1 flex-col">
       <header className="titlebar reserve-controls-right flex h-12 shrink-0 items-center justify-between gap-3 px-4">
         {activeLoop ? (
           <div className="flex min-w-0 items-center gap-2">

--- a/src/renderer/src/components/PageShell.tsx
+++ b/src/renderer/src/components/PageShell.tsx
@@ -16,7 +16,7 @@ export function PageShell({
   children: ReactNode
 }): JSX.Element {
   return (
-    <div className="flex h-full w-full flex-col bg-bg">
+    <div className="vibrancy-solid flex h-full w-full flex-col">
       <header className="titlebar reserve-controls-left reserve-controls-right flex h-12 shrink-0 items-center gap-3 px-4">
         <button
           onClick={onBack}

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -373,7 +373,7 @@ export function Sidebar(): JSX.Element {
 
   if (railed) {
     return (
-      <aside className="sidebar-rail flex h-full shrink-0 flex-col items-center border-r border-border bg-surface">
+      <aside className="vibrancy-pane sidebar-rail flex h-full shrink-0 flex-col items-center border-r border-border">
         <div className="titlebar reserve-controls-left h-[54px] w-full shrink-0" />
         <div className="flex flex-col items-center gap-1 pt-1">
           <button
@@ -401,7 +401,7 @@ export function Sidebar(): JSX.Element {
             {remoteDot && (
               <span
                 className={cn(
-                  'absolute right-1 top-1 h-1.5 w-1.5 rounded-full ring-2 ring-surface',
+                  'vibrancy-ring absolute right-1 top-1 h-1.5 w-1.5 rounded-full ring-2 ring-surface',
                   remoteDot === 'green' ? 'bg-success' : 'bg-warning'
                 )}
               />
@@ -437,7 +437,7 @@ export function Sidebar(): JSX.Element {
   return (
     <aside
       style={{ width }}
-      className="relative flex h-full shrink-0 flex-col border-r border-border bg-surface"
+      className="vibrancy-pane relative flex h-full shrink-0 flex-col border-r border-border"
     >
       <div className="titlebar reserve-controls-left flex items-center gap-2 px-4 py-3.5">
         <div className="sidebar-brand flex items-center gap-2.5">
@@ -672,7 +672,7 @@ export function Sidebar(): JSX.Element {
                                     'group flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm transition-colors',
                                     dragId && 'cursor-grabbing',
                                     chat.id === activeChatId
-                                      ? 'bg-elevated text-text'
+                                      ? 'vibrancy-chip bg-elevated text-text'
                                       : 'text-text-muted hover:bg-white/5 hover:text-text'
                                   )}
                                 >
@@ -770,7 +770,7 @@ export function Sidebar(): JSX.Element {
                                         'flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums transition-[opacity,color,background-color]',
                                         liveSubs > 0
                                           ? 'bg-accent/10 text-accent'
-                                          : 'bg-surface-2 text-text-subtle hover:text-text',
+                                          : 'vibrancy-chip-weak bg-surface-2 text-text-subtle hover:text-text',
                                         // This pill is a disclosure control, not a status light,
                                         // so it earns space only while the row is hovered or the
                                         // list it toggles is actually open. Live subagents used to
@@ -801,7 +801,7 @@ export function Sidebar(): JSX.Element {
                                           className={cn(
                                             'group/sub flex items-center gap-2 rounded-lg px-2 py-1 text-xs transition-colors',
                                             sub.id === activeChatId
-                                              ? 'bg-elevated text-text'
+                                              ? 'vibrancy-chip bg-elevated text-text'
                                               : 'text-text-muted hover:bg-white/5 hover:text-text'
                                           )}
                                         >

--- a/src/renderer/src/routes/Onboarding.tsx
+++ b/src/renderer/src/routes/Onboarding.tsx
@@ -24,7 +24,7 @@ export default function Onboarding(): JSX.Element {
   }
 
   return (
-    <div className="flex h-full w-full flex-col bg-bg">
+    <div className="vibrancy-solid flex h-full w-full flex-col">
       <header className="titlebar reserve-controls-left reserve-controls-right flex h-14 shrink-0 items-center px-5">
         <div className="flex items-center gap-2.5">
           <img


### PR DESCRIPTION
The left sidebar is now a translucent "glass" pane backed by AppKit's `sidebar` NSVisualEffectView — the same material Finder and Mail use for their source lists, so it reads as genuinely native rather than as a CSS imitation of one.

**macOS only, deliberately.**

## Why not Windows

I built a measurement harness (screen-capture the real compositor, swap a red vs blue window behind the app, check whether the sidebar pixels track it) and ran it on Win11 23H2 against **both Electron 33 and 38**. `backgroundMaterial: 'acrylic'`:

| Condition | Result |
|---|---|
| Transparency effects **on** | works (delta 60) |
| Transparency effects **off** | flat light-grey `#6a6a6b` slab — not the dark theme (delta 0) |
| Maximized, Electron 33 | paints solid black (`rgb(9,9,10)`) |
| Maximized, Electron 38 | fixed (`rgb(63,63,64)`) |
| `mica` | never worked (needs a wallpaper to sample) |

That first failure is the blocker: Settings → Personalization → Colors → "Transparency effects" is a user toggle we **cannot read from Electron**, and when it's off the sidebar turns into a light-grey slab. Add Win11 22H2+ gating and an Electron 36+ requirement for maximize, and the cost/benefit isn't there. Windows keeps exactly what it has today.

## How it works

Vibrancy is a **whole-window** effect — you can't scope it to one pane. The sidebar-only look comes from letting the window be glass and painting content opaque on top:

- `body` → paints nothing, so the material shows through
- `.vibrancy-pane` → the sidebar: a translucent tint *over* the material
- `.vibrancy-solid` → content panes: fully opaque

## Two things that go against the usual advice

**No `transparent: true`.** Nearly every guide says to set it. Per `native_window_mac.mm:224` it forces `[NSColor clearColor]`, which costs the native window shadow — and it isn't needed for vibrancy to composite. On Windows it actively *breaks* acrylic (measured: delta 60 → 0).

**No `backdrop-filter`.** AppKit already blurs behind the window; a CSS blur on top would double-darken and promote the whole sidebar to its own compositing layer, repainting on every scroll of the project tree.

## Craft details

Fills sitting *on* the glass (selected rows, subagent pills) were opaque swatches — the classic tell of fake-looking glass. They become light frosted washes at two weights, preserving the `bg-elevated` vs `bg-surface-2` hierarchy. Light rather than dark on purpose: a dark fill over glass reads as a hole punched through the pane, and stays legible over a bright wallpaper. The remote-status dot's `ring-surface` would have been a dark halo, so it's tinted to match.

Also handles `prefers-reduced-transparency` — macOS flattens its own material there, so the CSS tint must go opaque too, otherwise the sidebar would sit at 62% over a now-solid backdrop and render *lighter* than intended.

## Verification

Every rule is scoped to `[data-platform='darwin']`, and the unscoped declarations keep the existing opaque colors — so the fallback is literally the current design. Confirmed by reading computed styles in Chromium 130 with the real class lists from the components:

| Element | win32 / linux | darwin |
|---|---|---|
| `body` | `rgb(10,10,10)` | `rgba(0,0,0,0)` |
| sidebar | `rgb(15,15,16)` | `srgb .039 / 0.62` |
| content pane | `rgb(10,10,10)` | `rgb(10,10,10)` |
| selected row | `rgb(29,29,32)` | `srgb .93 / 0.12` |
| subagent pill | `rgb(22,22,24)` | `srgb .93 / 0.07` |

**Windows and Linux are identical on every element.** The content pane stays opaque on mac while the sidebar goes translucent — that's the sidebar-only effect.

`typecheck` clean · `build` clean · **shared 666 / smoke 522 passing**

## Note for review

I developed this on Windows, so the material's exact appearance over a wallpaper is the one thing I could not eyeball. The logic and the platform gating are verified by measurement; the aesthetics need a look on a Mac.