### PR TITLE
Cap anchored menu height, soften the composer seam, drop the Customize label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.58",
+      "version": "0.0.59",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -263,7 +263,9 @@ export function ChatView(): JSX.Element {
             )}
           </div>
         ) : (
-          <div className="mx-auto max-w-3xl px-4 py-4">
+          // pb clears the fade below: at max scroll the last line has to end
+          // ABOVE the gradient, otherwise the final message always looks dimmed.
+          <div className="mx-auto max-w-3xl px-4 pb-11 pt-4">
             {messages.length > visibleCount && (
               <p className="mb-3 text-center text-xs text-text-subtle">
                 Scroll up to load older — showing the last {visibleCount} of {messages.length}
@@ -276,6 +278,27 @@ export function ChatView(): JSX.Element {
           </div>
         )}
       </div>
+
+      {/* The transcript used to end on a hard clip: the scrollport edge sliced
+          text mid-glyph, straight into the composer’s flat gutter, and the two
+          together read as a black bar cutting the pane in half. This is a
+          gradient of the pane’s own background laid over the last 44px of the
+          scroller, so lines dissolve into the composer instead of being cut.
+
+          Pulled back up by its own height (-mt-11) so it costs no layout — the
+          scroller keeps every pixel of flex-1 — and inert to the pointer, so
+          scrolling and text selection still work underneath it. The matching
+          pb-11 on the message column is what keeps the last line legible: at
+          max scroll it ends above the gradient instead of under it.
+
+          The mr-2.5 is the overlay scrollbar’s width (--os-size in main.css):
+          the handle is drawn inside the scroller, so a full-width fade would
+          paint over its last 44px and swallow the handle exactly when you drag
+          it to the end. */}
+      <div
+        aria-hidden
+        className="pointer-events-none relative z-10 -mt-11 mr-2.5 h-11 shrink-0 bg-gradient-to-b from-transparent to-bg"
+      />
 
       {queue.length > 0 && (
         <div className="bg-bg px-4 pt-2">

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1071,7 +1071,7 @@ function useCustomizeCounts(): { skills: number; mcp: number } {
 }
 
 /**
- * The "Customize" section pinned to the bottom of the sidebar — quick access to
+ * The utility section pinned to the bottom of the sidebar — quick access to
  * Remote Workspace (share to phone), plus the Skills and MCP Servers pages
  * (à la VS Code's Customizations panel), with a live count/indicator on each.
  */
@@ -1097,10 +1097,7 @@ function CustomizeNav({
   ]
   return (
     <div className="border-t border-border px-3 py-2">
-      <span className="px-1 text-[10px] font-semibold uppercase tracking-wide text-text-subtle">
-        Customize
-      </span>
-      <div className="mt-1 flex flex-col gap-0.5">
+      <div className="flex flex-col gap-0.5">
         {items.map((it) => (
           <button
             key={it.label}

--- a/src/renderer/src/lib/anchor.ts
+++ b/src/renderer/src/lib/anchor.ts
@@ -82,6 +82,18 @@ export type MenuSide = 'top' | 'bottom'
  * bar, not a 30px sliver that can't show a single row.
  */
 export const MIN_MENU_H = 120
+/**
+ * ...and never grows past this, even when there is room. The cap used to be the
+ * viewport edge alone, which sounds right and is not: these menus hang off a
+ * trigger at the BOTTOM of the window, so "all the room above" is nearly the
+ * whole screen. A provider with forty models then rendered forty rows as one
+ * 900px column -- taller than the conversation behind it, and a list you scan
+ * by moving your eyes across the whole display rather than reading a menu.
+ *
+ * ~13 rows at a glance, scroll for the rest. Long lists are what the search
+ * field above them is for.
+ */
+export const MAX_MENU_H = 360
 
 /**
  * The menu's left edge, expressed RELATIVE TO ITS TRIGGER — i.e. exactly what an
@@ -105,20 +117,25 @@ export function alignMenu(
 }
 
 /**
- * How tall the menu may be before it has to scroll, given the room between the
- * trigger and the viewport edge it opens toward. `gap` is the space the menu
- * already reserves between itself and the trigger.
+ * How tall the menu may be before it has to scroll: the room between the
+ * trigger and the viewport edge it opens toward, bounded by `max`. `gap` is the
+ * space the menu already reserves between itself and the trigger.
+ *
+ * Both bounds apply and MIN wins the tie: hard against an edge there can be
+ * less room than MIN_MENU_H, and we return MIN anyway, because overflowing a
+ * little beats a menu too short to show a single row.
  */
 export function menuMaxHeight(
   triggerTop: number,
   triggerBottom: number,
   viewportHeight: number,
   side: MenuSide = 'top',
-  gap = 6
+  gap = 6,
+  max = MAX_MENU_H
 ): number {
   const room =
     side === 'top' ? triggerTop - gap - MARGIN : viewportHeight - triggerBottom - gap - MARGIN
-  return Math.max(MIN_MENU_H, Math.floor(room))
+  return Math.max(MIN_MENU_H, Math.min(max, Math.floor(room)))
 }
 
 /**

--- a/src/renderer/src/lib/useMenuAnchor.ts
+++ b/src/renderer/src/lib/useMenuAnchor.ts
@@ -18,7 +18,7 @@
  * The geometry itself lives in lib/anchor.ts, pure and tested.
  */
 import { useCallback, useEffect, useState, type CSSProperties, type RefObject } from 'react'
-import { alignMenu, menuMaxHeight, type MenuAlign, type MenuSide } from './anchor'
+import { alignMenu, MAX_MENU_H, menuMaxHeight, type MenuAlign, type MenuSide } from './anchor'
 
 interface Options {
   /** Which trigger edge to line up with when there's room. */
@@ -27,6 +27,12 @@ interface Options {
   side?: MenuSide
   /** Space reserved between menu and trigger — must match the menu's own padding. */
   gap?: number
+  /**
+   * Ceiling on the menu height, overriding the shared MAX_MENU_H. Raise it for
+   * a menu whose content genuinely earns more vertical space. There is no way
+   * to opt out of a ceiling entirely, which is the point.
+   */
+  maxHeight?: number
 }
 
 /**
@@ -38,12 +44,15 @@ export function useMenuAnchor(
   ref: RefObject<HTMLElement>,
   open: boolean,
   width: number,
-  { align = 'start', side = 'top', gap = 6 }: Options = {}
+  { align = 'start', side = 'top', gap = 6, maxHeight = MAX_MENU_H }: Options = {}
 ): CSSProperties {
   // Start with the un-nudged position so the FIRST paint is already anchored:
   // measuring in an effect means one frame exists before we know better, and a
   // menu that visibly jumps sideways on open is worse than one slightly off.
-  const [style, setStyle] = useState<CSSProperties>({ width })
+  // The height ceiling is in here for the same reason -- it does not depend on
+  // the measurement, and leaving it out let a long list paint at full height for
+  // one frame and then snap shorter.
+  const [style, setStyle] = useState<CSSProperties>({ width, maxHeight })
 
   const measure = useCallback((): void => {
     const el = ref.current
@@ -52,9 +61,9 @@ export function useMenuAnchor(
     setStyle({
       width,
       left: alignMenu(r.left, r.width, width, window.innerWidth, align),
-      maxHeight: menuMaxHeight(r.top, r.bottom, window.innerHeight, side, gap)
+      maxHeight: menuMaxHeight(r.top, r.bottom, window.innerHeight, side, gap, maxHeight)
     })
-  }, [ref, width, align, side, gap])
+  }, [ref, width, align, side, gap, maxHeight])
 
   useEffect(() => {
     if (!open) return

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -197,6 +197,7 @@ import {
   MAX_H,
   CHROME_H,
   MIN_MENU_H,
+  MAX_MENU_H,
   type Rect
 } from '../src/renderer/src/lib/anchor'
 
@@ -3772,6 +3773,38 @@ async function main(): Promise<void> {
     }
   }
   check('menu: height cap is always finite and usable', badCap === 0, String(badCap))
+
+  // The ceiling is the half of this that regressed: these menus hang off a
+  // trigger at the bottom of the window, so "room above" is nearly the whole
+  // screen and an unbounded cap let a long model list render as one ~900px
+  // column. Room still wins when room is the smaller number.
+  check(
+    'menu: height cap never exceeds the ceiling',
+    menuMaxHeight(1400, 1424, 1440, 'top') === MAX_MENU_H,
+    String(menuMaxHeight(1400, 1424, 1440, 'top'))
+  )
+  check(
+    'menu: a cramped trigger is bounded by room, not the ceiling',
+    menuMaxHeight(300, 324, 1440, 'top') === 300 - 6 - MARGIN
+  )
+  check(
+    'menu: an explicit ceiling overrides the default',
+    menuMaxHeight(1400, 1424, 1440, 'top', 6, 500) === 500
+  )
+  // MIN outranks MAX, so a nonsense ceiling still yields a usable menu.
+  check(
+    'menu: the floor outranks the ceiling',
+    menuMaxHeight(1400, 1424, 1440, 'top', 6, 10) === MIN_MENU_H
+  )
+  let overTall = 0
+  for (const vh of [480, 600, 780, 1080, 1440]) {
+    for (let y = 0; y < vh - 24; y += 13) {
+      for (const side of ['top', 'bottom'] as const) {
+        if (menuMaxHeight(y, y + 24, vh, side) > MAX_MENU_H) overTall++
+      }
+    }
+  }
+  check('menu: height cap is bounded on every viewport', overTall === 0, String(overTall))
 
   // ---- context menus open AT THE CURSOR (sidebar right-click) --------------
   //


### PR DESCRIPTION
Three bits of chrome that drew attention to themselves.

### The model picker filled the window

It rendered as a single ~900px column â€” every model from every connected provider, one row each, taller than the conversation behind it. You scanned it by moving your eyes across the whole display rather than by reading a menu.

The height cap was already there and already applied; it just resolved to the wrong number. `menuMaxHeight` returned all the room between the trigger and the viewport edge it opens toward â€” correct as a *bound*, useless as a *size*. These menus hang off the composer footer at the **bottom** of the window, so "room above" is nearly the entire screen, and every one of them was free to grow into it. The model picker was just the first with enough content to notice.

So the room calculation gets a ceiling (`MAX_MENU_H = 360`, ~13 rows) alongside its existing floor. `MIN` still outranks `MAX` â€” a trigger pinned against an edge can have less room than `MIN_MENU_H`, and a slightly overflowing menu beats one too short to show a single row. Callers can raise the ceiling per menu, but not opt out of having one.

Nothing else needed changing: every consumer already pairs the anchor's `maxHeight` with `overflow-y-auto`, so the ceiling turns a long list into a scroll rather than a clip, and the pickers already have a search field for reaching past what's visible. The initial style now carries the ceiling too â€” it doesn't depend on the measurement, and leaving it to the effect let a long list paint at full height for one frame and then snap.

### The seam above the composer

Not a colour seam â€” the scroller and composer share a background. It was a **hard clip**: text ran into `overflow-y-auto`'s bottom edge and got sliced mid-glyph, with the composer's gutter right below. Against the lighter input box that read as a bar splitting the pane.

A 44px `bg-gradient-to-b from-transparent to-bg` now overlays the bottom of the scroller. `-mt-11` pulls it up by its own height so it **costs no layout**; `pointer-events-none` keeps scrolling and selection working through it; `pb-11` on the message column means the last line ends *above* the gradient at max scroll instead of sitting dimmed under it; `mr-2.5` matches `--os-size` so the fade can't swallow the scrollbar handle at the end of a drag.

A `mask-image` on the scroller would have masked the handle too and forces a compositing layer that repaints every scroll frame. Making the composer transparent is out â€” on macOS `body` is transparent to expose native vibrancy, so it'd show the desktop through it.

### The sidebar label

`CUSTOMIZE` is gone. Three labelled, icon'd rows above a section border already read as a group.

### Checks

`npm run typecheck` clean, `smoke:shared` green at 676 checks â€” including five new ones covering the ceiling: it holds, room still wins when room is smaller, an explicit override applies, the floor outranks the ceiling, and no viewport/trigger combination exceeds it.