### PR TITLE
Stop painting agent process failures red

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.61",
+      "version": "0.0.62",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",

--- a/src/renderer/src/components/ServicesSegment.tsx
+++ b/src/renderer/src/components/ServicesSegment.tsx
@@ -152,8 +152,15 @@ export function ServicesSegment({
         )}
         {/* Collapsed, this is the ONLY thing most people read, so it states the
             outcome rather than the process state: a setup script that succeeded
-            must not look like one that died. */}
-        <span className={cn('truncate', failed > 0 && 'text-danger')}>
+            must not look like one that died.
+
+            A failure here is deliberately NOT red. These are the agent's own
+            background processes: a probe that exits 1, a build the model ran to
+            see what breaks. None of them are emergencies the user must act on.
+            Red is a claim on attention, and spending it on routine debugging
+            noise teaches people to ignore it everywhere else in the app. Grey
+            states the fact and leaves it there. */}
+        <span className={cn('truncate', failed > 0 && 'text-text-muted')}>
           {servicesSummary(services)}
         </span>
       </button>
@@ -235,7 +242,7 @@ function ServiceRow({
         <span
           className={cn(
             'h-1.5 w-1.5 shrink-0 rounded-full',
-            isRunning ? 'bg-success' : failed ? 'bg-danger' : 'bg-text-subtle/50'
+            isRunning ? 'bg-success' : failed ? 'bg-text-muted' : 'bg-text-subtle/50'
           )}
           title={service.status}
         />
@@ -247,7 +254,7 @@ function ServiceRow({
           <span className="shrink-0 tabular-nums text-text-subtle">:{service.port}</span>
         )}
         <span
-          className={cn('shrink-0 tabular-nums', failed ? 'text-danger' : 'text-text-subtle')}
+          className={cn('shrink-0 tabular-nums', failed ? 'text-text-muted' : 'text-text-subtle')}
           title={service.state}
         >
           {serviceStatusLabel(service)}

--- a/src/renderer/src/components/TerminalOutput.tsx
+++ b/src/renderer/src/components/TerminalOutput.tsx
@@ -15,6 +15,18 @@ import { Scroller } from './Scroller'
 /** A trailing status line our bash wrapper appends, e.g. `[exit 1]` / `[timed out after 60s …]`. */
 const FOOTER_RE = /^\[(exit \d+|timed out[\s\S]*|error:[\s\S]*)\]$/
 
+/**
+ * One grey for every footer, success or not.
+ *
+ * `[exit 1]` in an agent's shell is ordinary: the model runs a build to see what
+ * breaks, greps for a match that isn't there, probes a port before the server is
+ * up. Rendering each of those in red made a perfectly normal transcript read
+ * like a disaster log, and a colour that fires on routine events stops meaning
+ * anything when something is genuinely wrong. The footer still says "exit 1" —
+ * the fact is intact, it just doesn't shout.
+ */
+const FOOTER_COLOR = '#9a9aa3'
+
 export function TerminalOutput({
   text,
   state,
@@ -33,7 +45,7 @@ export function TerminalOutput({
     prompt = nl === -1 ? body : body.slice(0, nl)
     body = nl === -1 ? '' : body.slice(nl + 1)
   }
-  // Pull off a trailing status line so we can color it green/amber/red.
+  // Pull off a trailing status line so we can set it apart from the body.
   let footer = ''
   const lines = body.split('\n')
   const lastLine = lines[lines.length - 1]
@@ -41,11 +53,6 @@ export function TerminalOutput({
     footer = lastLine
     body = lines.slice(0, -1).join('\n')
   }
-  const footerColor = footer.startsWith('[timed')
-    ? '#fbbf24'
-    : footer.startsWith('[exit') || footer.startsWith('[error')
-      ? '#f87171'
-      : '#9a9aa3'
   const trimmed = body.replace(/[\r\n]+$/, '')
   return (
     <Scroller
@@ -59,7 +66,7 @@ export function TerminalOutput({
       {trimmed && <span>{renderAnsi(trimmed)}</span>}
       {!prompt && !trimmed && !footer && (state === 'running' ? 'Running…' : '(no output)')}
       {footer && (
-        <div className="mt-0.5" style={{ color: footerColor }}>
+        <div className="mt-0.5" style={{ color: FOOTER_COLOR }}>
           {footer}
         </div>
       )}

--- a/src/renderer/src/components/ToolCall.tsx
+++ b/src/renderer/src/components/ToolCall.tsx
@@ -224,7 +224,11 @@ export function ToolCall({
           )}
           {state === 'running' && <Loader2 className="h-3.5 w-3.5 animate-spin text-text-subtle" />}
           {state === 'done' && <Check className="h-3.5 w-3.5 text-success" />}
-          {state === 'error' && <TriangleAlert className="h-3.5 w-3.5 text-danger" />}
+          {/* Grey, not red: a failed tool is part of how the agent works — grep
+              finds nothing, a build surfaces the error it was run to surface.
+              The icon shape already sets it apart; red would make routine
+              debugging read like an incident. */}
+          {state === 'error' && <TriangleAlert className="h-3.5 w-3.5 text-text-muted" />}
         </span>
       </button>
       {/* Collapsed + running: a live one-liner of what the delegate is doing now. */}


### PR DESCRIPTION
The strip read `1 failed - 2 done` in red, tool calls got a red warning triangle, and every `[exit 1]` footer in a terminal block was red. None of those are incidents - they are the texture of an agent working: a grep that matches nothing, a build run to see what breaks, a port probed before the server is up.

Red is a claim on the user's attention. Spending it on routine debugging output makes a normal transcript read like a disaster log, and wears the colour out for the one case that genuinely needs it. Every fact is unchanged - `failed`, `exit 1`, the triangle all still say what happened, just in grey.

### Changed
- `ServicesSegment`: summary text, per-row status dot and status label now use `text-text-muted` instead of `text-danger`
- `ToolCall`: error triangle greyed
- `TerminalOutput`: one grey `FOOTER_COLOR` for all footers (drops the amber-timeout / red-exit branches)
- Version bump 0.0.61 -> 0.0.62

Destructive-action red (reset confirm, danger zone, delete) is untouched - that is where the colour still earns its keep.