### PR TITLE
Fix the transcript rendering blank after a session switch

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   Check,
   ChevronRight,
@@ -8,6 +8,7 @@ import {
   ListTree,
   Loader2,
   Repeat,
+  RotateCw,
   Settings
 } from 'lucide-react'
 import type { Chat } from '@shared/types'
@@ -33,13 +34,28 @@ import {
 import { Button } from './ui'
 import roxy from '../assets/roxy.png'
 
-/** Only render the most recent N messages — older ones stay in the DB but off-screen. */
-/** Render the latest N messages; scrolling to the top reveals PAGE more. */
-const VISIBLE_MESSAGES = 8
-const PAGE = 8
+/**
+ * Render only the most recent N messages; scrolling near the top reveals PAGE
+ * more. Older turns stay in the DB, they are just not in the DOM.
+ *
+ * This cap exists because a single message is not cheap: an agent turn can carry
+ * dozens of tool cards, each with its own syntax-highlighted diff or terminal
+ * output, and the whole transcript is markdown re-parsed by Streamdown on every
+ * render. A few hundred of those is a visibly janky pane.
+ *
+ * 8 was too aggressive though — it is fewer turns than fit on a 1440p screen, so
+ * an ordinary session showed the "showing the last 8 of N" notice while its own
+ * content did not even fill the viewport, and any scroll up immediately paged.
+ * 30 still bounds the worst case while covering essentially every session you
+ * actually scroll through by hand.
+ */
+const VISIBLE_MESSAGES = 30
+const PAGE = 30
 
 export function ChatView(): JSX.Element {
   const messages = useRoxyStore((s) => s.messages)
+  const messagesChatId = useRoxyStore((s) => s.messagesChatId)
+  const messagesError = useRoxyStore((s) => s.messagesError)
   const streaming = useRoxyStore((s) =>
     s.activeChatId ? (s.streamingChats[s.activeChatId] ?? null) : null
   )
@@ -72,6 +88,11 @@ export function ChatView(): JSX.Element {
   // Show only the latest N; scrolling up loads older ones a page at a time.
   const [visibleCount, setVisibleCount] = useState(VISIBLE_MESSAGES)
   const restoreHeight = useRef<number | null>(null)
+  // Which chat `restoreHeight` was measured in — a height from another session
+  // is meaningless and must not be applied.
+  const restoreChatId = useRef<string | null>(null)
+  // The message column, watched so the bottom-pin survives late layout.
+  const contentRef = useRef<HTMLDivElement>(null)
   // Overlay scrollbars for the transcript. Because the element is initialized
   // as its own viewport, every read below (scrollTop / scrollHeight /
   // clientHeight / scrollTo) and the onScroll prop keep working unchanged.
@@ -84,29 +105,69 @@ export function ChatView(): JSX.Element {
     // Near the top with more history → reveal another page, preserving position.
     if (el.scrollTop < 80 && visibleCount < messages.length) {
       restoreHeight.current = el.scrollHeight
+      restoreChatId.current = activeChatId
       setVisibleCount((c) => Math.min(messages.length, c + PAGE))
     }
   }
 
   // Switching chats starts you pinned to the latest message + collapses details.
+  //
+  // The scroll offset has to be reset by hand here. This component is never
+  // remounted between sessions (no `key={activeChatId}` upstream), so the
+  // scroller is the same DOM node throughout and `scrollTop` is a DOM property
+  // that survives the swap. Leaving it alone meant arriving in a short session
+  // still scrolled to a long one's offset — past the end of the new content,
+  // showing nothing but background. Clamped by the browser only against the
+  // CURRENT scrollHeight, which at this point is still the outgoing session's.
   useEffect(() => {
     stickToBottom.current = true
+    // Drop any pending prepend-anchor: it holds the previous session's
+    // scrollHeight, and applying that delta to the new one throws the offset
+    // somewhere arbitrary.
+    restoreHeight.current = null
+    restoreChatId.current = null
     setInfoOpen(false)
     setVisibleCount(VISIBLE_MESSAGES)
+    if (scrollRef.current) scrollRef.current.scrollTop = 0
   }, [activeChatId])
 
   // Keep the scroll anchored when older messages prepend (no jump to the top).
+  // Guarded on the chat the measurement was taken in — `visibleCount` also
+  // changes on a session switch, which would otherwise replay a stale delta.
   useEffect(() => {
     const el = scrollRef.current
-    if (el && restoreHeight.current !== null) {
+    if (el && restoreHeight.current !== null && restoreChatId.current === activeChatId) {
       el.scrollTop += el.scrollHeight - restoreHeight.current
-      restoreHeight.current = null
     }
+    restoreHeight.current = null
+    restoreChatId.current = null
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visibleCount])
 
-  useEffect(() => {
-    if (!stickToBottom.current) return
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
+  // Follow the tail.
+  //
+  // Runs on layout (not after paint) so the jump is never a visible frame, and
+  // re-pins on the next frame as well: a turn's content keeps growing AFTER this
+  // commit — images decode, `lazy()` diff/file views resolve, Streamdown re-lays
+  // out — and a single scrollTo lands short of the real bottom every time.
+  useLayoutEffect(() => {
+    if (!stickToBottom.current || !scrollRef.current) return
+    const pin = (): void => {
+      if (stickToBottom.current && scrollRef.current) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+      }
+    }
+    pin()
+    const frame = requestAnimationFrame(pin)
+    // Content that settles later (a decoded screenshot is the common one) resizes
+    // the column well after any frame we could schedule; watch it instead of
+    // guessing a delay.
+    const observer = new ResizeObserver(pin)
+    if (contentRef.current) observer.observe(contentRef.current)
+    return () => {
+      cancelAnimationFrame(frame)
+      observer.disconnect()
+    }
   }, [messages, streaming])
 
   const activeChat = chats.find((c) => c.id === activeChatId)
@@ -145,7 +206,12 @@ export function ChatView(): JSX.Element {
     )
   }
 
-  const isEmpty = messages.length === 0 && (streaming === null || streaming.length === 0)
+  const hasContent = messages.length > 0 || (streaming !== null && streaming.length > 0)
+  // `messages` is cleared the instant you click a session and refilled only after
+  // the round trip, so an empty array on its own says nothing about whether the
+  // session HAS messages. Trusting it painted the empty state over every switch.
+  const loading = !hasContent && !messagesError && messagesChatId !== activeChatId
+  const isEmpty = !hasContent && !loading
 
   return (
     <div className="vibrancy-solid relative flex h-full min-w-0 flex-1 flex-col">
@@ -249,8 +315,36 @@ export function ChatView(): JSX.Element {
 
       {infoOpen && <SessionInfo chat={activeChat} />}
 
-      <div ref={scrollRef} onScroll={onScroll} className="min-h-0 flex-1 overflow-y-auto">
-        {isEmpty ? (
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        // overflow-anchor is off because this pane does its own scroll math:
+        // paging in older messages measures scrollHeight and re-applies the
+        // delta by hand. Chromium's anchoring would apply its own correction on
+        // top of that, and the two together overshoot.
+        style={{ overflowAnchor: 'none' }}
+        className="min-h-0 flex-1 overflow-y-auto"
+      >
+        {messagesError ? (
+          // A failed load used to be indistinguishable from an empty session:
+          // silent, blank, and with no way back other than clicking away and
+          // returning. Name it and make it recoverable.
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+            <p className="max-w-xs text-sm text-text-muted">
+              Couldn&apos;t load this session&apos;s messages.
+            </p>
+            <Button variant="ghost" onClick={() => void selectChat(activeChat.id)}>
+              <RotateCw className="h-4 w-4" /> Retry
+            </Button>
+          </div>
+        ) : loading ? (
+          // Deliberately blank: a transcript read is a local SQLite query, so it
+          // resolves within a frame or two and a spinner would be a flash of
+          // chrome rather than information. This branch exists to stop the EMPTY
+          // state (and its loop copy) from claiming the session has no messages
+          // before we know that.
+          <div className="h-full" />
+        ) : isEmpty ? (
           <div className="flex h-full flex-col items-center justify-center px-6 text-center">
             {activeLoop ? (
               <p className="max-w-xs text-sm text-text-muted">
@@ -265,7 +359,7 @@ export function ChatView(): JSX.Element {
         ) : (
           // pb clears the fade below: at max scroll the last line has to end
           // ABOVE the gradient, otherwise the final message always looks dimmed.
-          <div className="mx-auto max-w-3xl px-4 pb-6 pt-4">
+          <div ref={contentRef} className="mx-auto max-w-3xl px-4 pb-6 pt-4">
             {messages.length > visibleCount && (
               <p className="mb-3 text-center text-xs text-text-subtle">
                 Scroll up to load older — showing the last {visibleCount} of {messages.length}

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -50,6 +50,23 @@ interface RoxyStore {
   chats: Chat[]
   activeChatId: string | null
   messages: Message[]
+  /**
+   * Which chat `messages` actually holds, or `null` while a load is in flight.
+   *
+   * `selectChat` blanks `messages` synchronously and refills it only after an
+   * await, so in between `messages: []` means "not loaded yet" — indistinguishable
+   * from "this session is genuinely empty" if you only look at the array. The
+   * transcript rendered its empty state for both, so every switch flashed a blank
+   * pane, and a load that rejected left it blank permanently (nothing retried, and
+   * the rejection surfaced nowhere).
+   *
+   * Keyed on the chat id rather than a boolean because it also has to be wrong in
+   * the right way: during a switch it names the PREVIOUS chat, which is still not
+   * `activeChatId`, so the pane knows it is stale without a second flag.
+   */
+  messagesChatId: string | null
+  /** Set when a transcript load failed, so the pane can offer a retry. */
+  messagesError: boolean
   /** Chats with an in-flight send, keyed by chat id. Survives switching chats. */
   sendingChats: Record<string, boolean>
   /** In-progress assistant parts per chat while a reply streams in. */
@@ -315,7 +332,7 @@ async function mirrorSharedChat(sessionId: string, rev: number): Promise<void> {
     remoteMirror.deferred = true
     return
   }
-  useRoxyStore.setState({ messages })
+  useRoxyStore.setState({ messages, messagesChatId: sessionId })
 }
 
 /**
@@ -449,8 +466,9 @@ function applySubagentDelta(payload: SubagentDelta): void {
     // The run's transcript landed a moment ago — swap the live bubble for the
     // persisted message, and refresh the sidebar (a finished sub may now prune).
     void (async () => {
+      const subMessages = await api.messages.list(subChatId)
       if (useRoxyStore.getState().activeChatId === subChatId) {
-        useRoxyStore.setState({ messages: await api.messages.list(subChatId) })
+        useRoxyStore.setState({ messages: subMessages, messagesChatId: subChatId })
       }
       await useRoxyStore.getState().refreshChats()
     })()
@@ -562,6 +580,8 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   chats: [],
   activeChatId: null,
   messages: [],
+  messagesChatId: null,
+  messagesError: false,
   sendingChats: {},
   streamingChats: {},
   activeAgentId: DEFAULT_AGENT_ID,
@@ -601,8 +621,9 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
         set({ loops: fresh })
         const loop = fresh.find((l) => l.id === loopId)
         if (!loop) return
+        const loopMessages = await api.messages.list(loop.chatId)
         if (get().activeChatId === loop.chatId) {
-          set({ messages: await api.messages.list(loop.chatId) })
+          set({ messages: loopMessages, messagesChatId: loop.chatId })
         }
         // Real heartbeat: run the agent on the loop's prompt in its project each
         // beat — the "infinite prompting" session. Needs a connected provider.
@@ -1020,6 +1041,11 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     set({
       activeChatId: id,
       messages: [],
+      // `null` = loading. Without this the pane cannot tell a session that is
+      // still fetching from one with no messages, and shows the empty state for
+      // both — a blank flash on every switch.
+      messagesChatId: null,
+      messagesError: false,
       queue: [],
       activeAgentId: chat?.agentId ?? DEFAULT_AGENT_ID
     })
@@ -1031,14 +1057,25 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     // Opening a subagent mid-run: pull what it has already done so the live
     // bubble starts from the whole transcript, not from the next delta.
     if (chat?.kind === 'sub') void hydrateSubagent(id)
-    const [messages, queue] = await Promise.all([api.messages.list(id), api.queue.list(id)])
-    if (get().activeChatId === id) set({ messages, queue })
+    // A rejection here used to leave the pane blank forever: `messages` was
+    // already cleared above, the set below never ran, and the promise floated
+    // back into an onClick where nothing handled it. Now the failure is state,
+    // so the transcript can say so and offer a retry.
+    try {
+      const [messages, queue] = await Promise.all([api.messages.list(id), api.queue.list(id)])
+      if (get().activeChatId === id) set({ messages, queue, messagesChatId: id })
+    } catch (e) {
+      console.error('Failed to load transcript:', e)
+      if (get().activeChatId === id) set({ messagesError: true })
+    }
   },
 
   clearActive: () =>
     set({
       activeChatId: null,
       messages: [],
+      messagesChatId: null,
+      messagesError: false,
       queue: [],
       activeAgentId: DEFAULT_AGENT_ID
     }),
@@ -1449,7 +1486,11 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
               await get().refreshChats()
               const active = get().activeChatId
               if (active && get().chats.find((c) => c.id === active)?.kind === 'sub') {
-                set({ messages: await api.messages.list(active) })
+                const loaded = await api.messages.list(active)
+                // Re-check: two awaits have passed since `active` was read.
+                if (get().activeChatId === active) {
+                  set({ messages: loaded, messagesChatId: active })
+                }
               }
             })()
           } else if (
@@ -1584,7 +1625,10 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     try {
       await api.context.compact(chatId, provider.id, model)
       await get().refreshChats()
-      if (get().activeChatId === chatId) set({ messages: await api.messages.list(chatId) })
+      const compacted = await api.messages.list(chatId)
+      if (get().activeChatId === chatId) {
+        set({ messages: compacted, messagesChatId: chatId })
+      }
     } catch (e) {
       console.error('Compaction failed:', e)
     } finally {
@@ -1616,7 +1660,9 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     const active = get().activeChatId
     if (!active) return
     if (active === update.sessionId || active === update.subChatId) {
-      set({ messages: await api.messages.list(active) })
+      const loaded = await api.messages.list(active)
+      // `active` was captured before the await above — confirm it still holds.
+      if (get().activeChatId === active) set({ messages: loaded, messagesChatId: active })
     }
   }
 }))


### PR DESCRIPTION
Switching from a long session to a short one left the message pane empty: the content was mounted, but the scroller was still parked at the previous session's offset, far past the end of the new content.

Three separate things caused it, all rooted in the same fact -- ChatView is never remounted between sessions. There is no key={activeChatId} upstream, so the scrollport is one long-lived DOM node and everything hanging off it persists across the swap:

- scrollTop is a DOM property, and nothing reset it. The browser only clamps it against the CURRENT scrollHeight, which during a switch is still the outgoing session's, so a large offset survived into a session too short to justify it. Now reset explicitly on activeChatId.

- restoreHeight, the prepend-anchor used by scroll-up pagination, leaked across sessions. Its effect keys on visibleCount, which also changes on a switch (reset to VISIBLE_MESSAGES), so a height measured in the previous session got applied as a delta in the new one. It is now tagged with the chat it was measured in and dropped on a switch.

- The empty state was rendered off messages.length alone. selectChat clears messages synchronously and refills it after an await, so 'still loading' and 'genuinely empty' were the same value -- the pane painted a blank empty-state over every switch. messagesChatId now distinguishes them.

Also fixed while in here:

- A rejected transcript load stranded the pane blank forever: messages was already cleared, the set never ran, and the promise floated back into an onClick where nothing handled it. It is now caught, surfaced, and retryable.
- Several message reloads set state after an await using an activeChatId captured before it, which could paint one session's transcript into another. They now re-check.
- The bottom-pin fired once per commit, before images decode and before the lazy() diff/file chunks resolve, so it consistently landed short of the real bottom. It now runs on layout and re-pins via ResizeObserver.
- overflow-anchor: none on the scroller -- Chromium's scroll anchoring was applying its own correction on top of the manual prepend math.

VISIBLE_MESSAGES 8 -> 30. The cap is worth keeping (a turn can carry dozens of highlighted tool cards, and Streamdown re-parses on render), but 8 was fewer turns than fit on screen, so ordinary sessions showed the truncation notice without even filling the viewport.