### PR TITLE
Darken macOS sidebar vibrancy & remove footer divider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -405,7 +405,7 @@ body {
  * carries a `bg-*` utility.
  */
 [data-platform='darwin'] .vibrancy-pane {
-  background: color-mix(in srgb, var(--color-bg) 62%, transparent);
+  background: color-mix(in srgb, var(--color-bg) 88%, transparent);
 }
 
 /*

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1096,7 +1096,7 @@ function CustomizeNav({
     { label: 'MCP Servers', icon: Plug, onClick: () => navigate('/mcp'), count: counts.mcp }
   ]
   return (
-    <div className="border-t border-border px-3 py-2">
+    <div className="px-3 py-2">
       <div className="flex flex-col gap-0.5">
         {items.map((it) => (
           <button


### PR DESCRIPTION
## What
- Darken the macOS window vibrancy tint (62% -> 88% of --color-bg) so the translucent sidebar reads much darker for the dark theme
- Remove the border-t divider above the Remote Workspace / Skills / MCP Servers footer
- Bump version to 0.0.64

## Files
- src/renderer/src/assets/main.css — .vibrancy-pane background
- src/renderer/src/components/Sidebar.tsx — CustomizeNav footer border
- package.json — version bump