### PR TITLE
Keep the transcript pinned when the queue resizes the pane

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -170,6 +170,33 @@ export function ChatView(): JSX.Element {
     }
   }, [messages, streaming])
 
+  // Re-pin when the SCROLLPORT resizes, not just its content.
+  //
+  // Everything stacked below the transcript takes its height out of this pane's
+  // `flex-1`: the queue appearing, expanding or collapsing, the composer
+  // auto-growing as you type, the workstream strip. The browser does not adjust
+  // `scrollTop` for that, and both directions are visibly wrong:
+  //
+  //   shrinking (queue opens) — the max scroll offset grows, so an offset that
+  //     WAS the bottom is now short of it and the last messages slide out of
+  //     view. Reads as the queue shoving the transcript upward.
+  //   growing (queue collapses) — the reclaimed height appears BELOW the last
+  //     message as dead space, because the offset never moves back down. Reads
+  //     as the collapsed queue still holding its space.
+  //
+  // Kept separate from the effect above on purpose: this one is installed once
+  // and must keep observing across queue toggles, which change neither
+  // `messages` nor `streaming` and so would never re-run that effect.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const observer = new ResizeObserver(() => {
+      if (stickToBottom.current) el.scrollTop = el.scrollHeight
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   const activeChat = chats.find((c) => c.id === activeChatId)
   const isSub = activeChat?.kind === 'sub'
   const parentChat = activeChat?.parentId


### PR DESCRIPTION
Collapsing the queue left a hole where it used to be, and opening it shoved the last messages out of view.

## Cause

The queue renders **below** the transcript inside the same flex column, so its height comes out of the scroller's `flex-1`. Opening it shrinks the scrollport; collapsing it grows it back. The browser does not adjust `scrollTop` for either, and both directions were visibly wrong:

- **Opening** — the max scroll offset grows, so the offset that *was* the bottom now falls short of it and the last messages slide out of view. Reads as the queue pushing the chat up.
- **Collapsing** — the reclaimed height appears as dead space below the last message, because the offset never moves back down. Reads as the collapsed queue still holding its space.

`ChatView` already had a `ResizeObserver`, but it watched the message **column** (`contentRef`), which does not change size when the queue toggles. Nothing was watching the **scrollport** itself, so neither resize ever re-pinned.

## Fix

Observe the scroller element too, and re-pin to the bottom on resize — gated on the existing `stickToBottom` ref, so anyone scrolled up reading history is still never yanked down.

It is a separate effect on purpose: the content observer re-runs on `[messages, streaming]`, and a queue toggle changes neither, so it would never have re-attached. This one installs once and lives for the life of the pane.

Same class of jump is fixed for the composer auto-growing on multi-line input and for the workstream strip appearing.

## Testing

- `npm run typecheck` (node + web) passes.
- Manually: queued a message mid-turn, toggled the section open/closed repeatedly — the last message stays glued to the bottom in both states and no gap is left behind. Scrolled up into history and toggled again — the view stays put, as intended.
