### PR TITLE
Land session switches at the newest message, and stop the streaming jank

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   Check,
   ChevronRight,
@@ -78,11 +78,29 @@ export function ChatView(): JSX.Element {
     s.activeChatId ? !!s.runningSubagents[s.activeChatId] : false
   )
 
+  const hasContent = messages.length > 0 || (streaming !== null && streaming.length > 0)
+  // `messages` is cleared the instant you click a session and refilled only after
+  // the round trip, so an empty array on its own says nothing about whether the
+  // session HAS messages. Trusting it painted the empty state over every switch.
+  const loading = !hasContent && !messagesError && messagesChatId !== activeChatId
+  const isEmpty = !hasContent && !loading
+  // The transcript has resolved one way or another (content, empty, or failed),
+  // so the scroll effects below have something real to measure. Computed up here
+  // rather than beside the JSX because the arrival pin depends on it.
+  const transcriptReady = !loading
+
   const scrollRef = useRef<HTMLDivElement>(null)
   // Follow the conversation only while you're already at the bottom. If you've
   // scrolled up to read history, new messages/stream chunks must NOT yank you
   // back down — resume following once you scroll back to the end.
   const stickToBottom = useRef(true)
+  // The chat we have already jumped to the end of. Cleared on every switch, so
+  // until it matches `activeChatId` the pane is still "arriving" and the tail
+  // effect below owns the offset outright.
+  const arrivedChatId = useRef<string | null>(null)
+  // The last offset WE wrote. A scroll event replaying our own write must not be
+  // mistaken for the user scrolling away (see `onScroll`).
+  const pinnedTop = useRef(-1)
   const [loopPaneOpen, setLoopPaneOpen] = useState(false)
   const [infoOpen, setInfoOpen] = useState(false)
   // Show only the latest N; scrolling up loads older ones a page at a time.
@@ -91,17 +109,36 @@ export function ChatView(): JSX.Element {
   // Which chat `restoreHeight` was measured in — a height from another session
   // is meaningless and must not be applied.
   const restoreChatId = useRef<string | null>(null)
-  // The message column, watched so the bottom-pin survives late layout.
-  const contentRef = useRef<HTMLDivElement>(null)
   // Overlay scrollbars for the transcript. Because the element is initialized
   // as its own viewport, every read below (scrollTop / scrollHeight /
   // clientHeight / scrollTo) and the onScroll prop keep working unchanged.
   useOverlayScroll(scrollRef)
 
+  /** Jump to the newest message, recording the offset as ours. */
+  const pinToBottom = useCallback((): void => {
+    const el = scrollRef.current
+    if (!el) return
+    const top = el.scrollHeight - el.clientHeight
+    pinnedTop.current = top
+    el.scrollTop = top
+  }, [])
+
   const onScroll = (): void => {
     const el = scrollRef.current
     if (!el) return
-    stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    // Before the arrival pin lands, every scroll event here is our own doing:
+    // the outgoing transcript unmounting collapses scrollHeight and the browser
+    // clamps scrollTop to 0. Reading that back as "the user scrolled to the top"
+    // is what left switches parked at the top — it cleared `stickToBottom` for a
+    // session you had not even seen yet, so nothing ever pinned it, and at
+    // scrollTop 0 it also paged in another 30 messages on the way past.
+    if (arrivedChatId.current !== activeChatId) return
+    // Landing exactly on the offset we last wrote counts as "still following"
+    // even if the arithmetic below would say otherwise: the event is delivered a
+    // beat after the write, and a turn that grew in between would look like a
+    // gap the user had opened by hand. The ResizeObserver re-pins that growth.
+    stickToBottom.current =
+      el.scrollTop === pinnedTop.current || el.scrollHeight - el.scrollTop - el.clientHeight < 80
     // Near the top with more history → reveal another page, preserving position.
     if (el.scrollTop < 80 && visibleCount < messages.length) {
       restoreHeight.current = el.scrollHeight
@@ -112,15 +149,19 @@ export function ChatView(): JSX.Element {
 
   // Switching chats starts you pinned to the latest message + collapses details.
   //
-  // The scroll offset has to be reset by hand here. This component is never
-  // remounted between sessions (no `key={activeChatId}` upstream), so the
-  // scroller is the same DOM node throughout and `scrollTop` is a DOM property
-  // that survives the swap. Leaving it alone meant arriving in a short session
-  // still scrolled to a long one's offset — past the end of the new content,
-  // showing nothing but background. Clamped by the browser only against the
-  // CURRENT scrollHeight, which at this point is still the outgoing session's.
-  useEffect(() => {
+  // This runs on LAYOUT and deliberately does NOT touch `scrollTop`. It used to
+  // do both after paint (`useEffect` + `scrollTop = 0`), which is a race it lost
+  // every time: the new transcript arrives a commit LATER than the switch, so
+  // the reset ran after the tail effect had already pinned and stomped the pin
+  // back to zero — and the scroll event that write produced then cleared
+  // `stickToBottom`, so nothing pinned again. That is the whole "switching to a
+  // session lands at the top" bug. Marking the session "not arrived" instead
+  // hands the offset to the tail effect below, which lands it whenever the
+  // content actually shows up, in whatever order the effects happen to run.
+  useLayoutEffect(() => {
     stickToBottom.current = true
+    arrivedChatId.current = null
+    pinnedTop.current = -1
     // Drop any pending prepend-anchor: it holds the previous session's
     // scrollHeight, and applying that delta to the new one throws the offset
     // somewhere arbitrary.
@@ -128,7 +169,6 @@ export function ChatView(): JSX.Element {
     restoreChatId.current = null
     setInfoOpen(false)
     setVisibleCount(VISIBLE_MESSAGES)
-    if (scrollRef.current) scrollRef.current.scrollTop = 0
   }, [activeChatId])
 
   // Keep the scroll anchored when older messages prepend (no jump to the top).
@@ -150,25 +190,49 @@ export function ChatView(): JSX.Element {
   // re-pins on the next frame as well: a turn's content keeps growing AFTER this
   // commit — images decode, `lazy()` diff/file views resolve, Streamdown re-lays
   // out — and a single scrollTo lands short of the real bottom every time.
+  //
+  // The first pin after a switch is unconditional. `stickToBottom` cannot be
+  // trusted yet at that point: the outgoing transcript unmounting fires a scroll
+  // to 0 which, before this, was read as the user scrolling up.
   useLayoutEffect(() => {
-    if (!stickToBottom.current || !scrollRef.current) return
-    const pin = (): void => {
-      if (stickToBottom.current && scrollRef.current) {
-        scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-      }
-    }
-    pin()
-    const frame = requestAnimationFrame(pin)
-    // Content that settles later (a decoded screenshot is the common one) resizes
-    // the column well after any frame we could schedule; watch it instead of
-    // guessing a delay.
-    const observer = new ResizeObserver(pin)
-    if (contentRef.current) observer.observe(contentRef.current)
-    return () => {
-      cancelAnimationFrame(frame)
-      observer.disconnect()
-    }
-  }, [messages, streaming])
+    if (!scrollRef.current) return
+    if (arrivedChatId.current !== activeChatId) {
+      // Still waiting on this session's transcript — nothing to land on yet.
+      // This effect re-runs when it arrives.
+      if (!transcriptReady) return
+      arrivedChatId.current = activeChatId
+    } else if (!stickToBottom.current) return
+    pinToBottom()
+    const frame = requestAnimationFrame(() => {
+      if (stickToBottom.current) pinToBottom()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [messages, streaming, activeChatId, transcriptReady, pinToBottom])
+
+  // Content that settles late (a decoded screenshot is the common one) resizes
+  // the column well after any frame we could schedule, so watch it rather than
+  // guessing a delay.
+  //
+  // Attached by ref callback and kept for the column's lifetime. This used to be
+  // built inside the tail effect above, whose deps include `streaming` — a fresh
+  // array on EVERY streamed delta — so a live turn tore down and rebuilt a
+  // ResizeObserver on each one, every rebuild firing an immediate observation
+  // and forcing layout. That was a large share of the streaming jank.
+  const resizeObserver = useRef<ResizeObserver | null>(null)
+  const setContentNode = useCallback(
+    (node: HTMLDivElement | null): void => {
+      resizeObserver.current?.disconnect()
+      resizeObserver.current = null
+      if (!node) return
+      const observer = new ResizeObserver(() => {
+        if (stickToBottom.current) pinToBottom()
+      })
+      observer.observe(node)
+      resizeObserver.current = observer
+    },
+    [pinToBottom]
+  )
+  useEffect(() => () => resizeObserver.current?.disconnect(), [])
 
   const activeChat = chats.find((c) => c.id === activeChatId)
   const isSub = activeChat?.kind === 'sub'
@@ -205,13 +269,6 @@ export function ChatView(): JSX.Element {
       </div>
     )
   }
-
-  const hasContent = messages.length > 0 || (streaming !== null && streaming.length > 0)
-  // `messages` is cleared the instant you click a session and refilled only after
-  // the round trip, so an empty array on its own says nothing about whether the
-  // session HAS messages. Trusting it painted the empty state over every switch.
-  const loading = !hasContent && !messagesError && messagesChatId !== activeChatId
-  const isEmpty = !hasContent && !loading
 
   return (
     <div className="vibrancy-solid relative flex h-full min-w-0 flex-1 flex-col">
@@ -359,7 +416,7 @@ export function ChatView(): JSX.Element {
         ) : (
           // pb clears the fade below: at max scroll the last line has to end
           // ABOVE the gradient, otherwise the final message always looks dimmed.
-          <div ref={contentRef} className="mx-auto max-w-3xl px-4 pb-6 pt-4">
+          <div ref={setContentNode} className="mx-auto max-w-3xl px-4 pb-6 pt-4">
             {messages.length > visibleCount && (
               <p className="mb-3 text-center text-xs text-text-subtle">
                 Scroll up to load older — showing the last {visibleCount} of {messages.length}

--- a/src/renderer/src/components/MessageBubble.tsx
+++ b/src/renderer/src/components/MessageBubble.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { User } from 'lucide-react'
 import roxy from '../assets/roxy.png'
 import type { MessagePart, MessageRole } from '@shared/types'
@@ -10,7 +11,7 @@ function partsToText(parts: MessagePart[]): string {
   return parts.map((p) => (p.type === 'text' || p.type === 'reasoning' ? p.text : '')).join('')
 }
 
-export function MessageBubble({
+function MessageBubbleImpl({
   role,
   parts,
   streaming = false
@@ -71,3 +72,18 @@ export function MessageBubble({
     </div>
   )
 }
+
+/**
+ * Memoized because the transcript re-renders on every streamed token.
+ *
+ * `streaming` writes a brand-new parts array into the store on each delta, which
+ * re-renders ChatView, which previously re-rendered all 30 settled bubbles with
+ * it — re-parsing every markdown block through Streamdown ~80 times a second for
+ * messages whose content had not changed since they were written to SQLite.
+ *
+ * A settled message's `parts` array is a stable reference (it comes straight off
+ * the loaded row and is never rebuilt), so the default shallow compare is both
+ * correct and enough: only the live bubble, whose array genuinely changes,
+ * re-renders.
+ */
+export const MessageBubble = memo(MessageBubbleImpl)

--- a/src/renderer/src/components/MessageParts.tsx
+++ b/src/renderer/src/components/MessageParts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { memo, useCallback, useEffect, useState } from 'react'
 import { Streamdown } from 'streamdown'
 import { Brain, ChevronRight } from 'lucide-react'
 import type { MessagePart } from '@shared/types'
@@ -66,6 +66,19 @@ export function MessageParts({
   const liveText =
     (last?.type === 'text' || last?.type === 'reasoning') && last.text.trim() !== '' && !quiet
   const waiting = streaming && !runningTool && !liveText
+
+  // Stable across renders so a memoized ToolCall can actually hit. It used to be
+  // an inline arrow that closed over the specific part's `state`, giving every
+  // card a fresh callback identity on every delta — which alone defeated any
+  // memo on ToolCall. The card passes its own liveness in instead, leaving this
+  // dependent only on the turn-level `streaming` boolean.
+  const renderNested = useCallback(
+    (children: MessagePart[], live: boolean) => (
+      <MessageParts parts={children} streaming={streaming && live} />
+    ),
+    [streaming]
+  )
+
   return (
     <div className="flex flex-col gap-1 text-sm leading-relaxed text-text">
       {parts.map((part, i) => {
@@ -86,12 +99,10 @@ export function MessageParts({
               // Passed as a callback (not a self-import) to keep the recursion
               // explicit and one-directional: ToolCall never reaches back up.
               //
-              // `streaming` is gated on the CARD's state, not the turn's: once a
-              // subagent has reported, its transcript is history and must stop
-              // animating even while the parent turn keeps going.
-              renderNested={(children) => (
-                <MessageParts parts={children} streaming={streaming && part.state === 'running'} />
-              )}
+              // The card supplies its own `live` flag: once a subagent has
+              // reported, its transcript is history and must stop animating even
+              // while the parent turn keeps going.
+              renderNested={renderNested}
             />
           )
         }
@@ -108,13 +119,7 @@ export function MessageParts({
             />
           )
         }
-        return (
-          <div key={i} className="streamdown max-w-none">
-            <Streamdown animated={STREAM_ANIMATION} isAnimating={streaming && isLast}>
-              {part.text}
-            </Streamdown>
-          </div>
-        )
+        return <Prose key={i} text={part.text} animating={streaming && isLast} />
       })}
       {waiting && (
         <ThinkingIndicator
@@ -130,7 +135,38 @@ export function MessageParts({
   )
 }
 
-function ReasoningBlock({ text, streaming }: { text: string; streaming: boolean }): JSX.Element {
+/**
+ * One markdown block.
+ *
+ * Split out and memoized because Streamdown re-parses its whole source on every
+ * render, and a live turn re-renders this list on every token. Without this, a
+ * turn that had already written five paragraphs and was streaming a sixth
+ * re-parsed all six per token instead of one — the cost grew with the length of
+ * the reply, which is exactly why long answers got progressively choppier.
+ */
+const Prose = memo(function Prose({
+  text,
+  animating
+}: {
+  text: string
+  animating: boolean
+}): JSX.Element {
+  return (
+    <div className="streamdown max-w-none">
+      <Streamdown animated={STREAM_ANIMATION} isAnimating={animating}>
+        {text}
+      </Streamdown>
+    </div>
+  )
+})
+
+const ReasoningBlock = memo(function ReasoningBlock({
+  text,
+  streaming
+}: {
+  text: string
+  streaming: boolean
+}): JSX.Element {
   const [open, setOpen] = useState(false)
   const expanded = open || streaming
   return (
@@ -156,4 +192,4 @@ function ReasoningBlock({ text, streaming }: { text: string; streaming: boolean 
       )}
     </div>
   )
-}
+})

--- a/src/renderer/src/components/ToolCall.tsx
+++ b/src/renderer/src/components/ToolCall.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, memo, Suspense, useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import {
   Camera,
@@ -133,7 +133,7 @@ function ActivityLine({ parts }: { parts: MessagePart[] }): JSX.Element {
  * stream into `children` and render nested inside this card (via `renderNested`,
  * a callback rather than a direct import so the recursion stays one-directional).
  */
-export function ToolCall({
+export const ToolCall = memo(function ToolCall({
   tool,
   state,
   title,
@@ -151,8 +151,13 @@ export function ToolCall({
   diff?: ToolDiff
   /** A subagent's live transcript, for a `task` card. */
   nested?: MessagePart[]
-  /** Renders that transcript — supplied by MessageParts so this file needn't import it. */
-  renderNested?: (parts: MessagePart[]) => ReactNode
+  /**
+   * Renders that transcript — supplied by MessageParts so this file needn't
+   * import it. Takes the card's own liveness so the callback itself can stay
+   * referentially stable across a streaming turn (a per-card closure would
+   * change identity on every delta and defeat this component's memo).
+   */
+  renderNested?: (parts: MessagePart[], live: boolean) => ReactNode
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const Icon = TOOL_ICON[tool] ?? Wrench
@@ -258,7 +263,7 @@ export function ToolCall({
           {/* The subagent's own transcript, indented under a rail so it reads as a
               separate agent's work rather than more of the parent's. */}
           <Scroller className="max-h-[28rem] overflow-auto px-3 py-2">
-            <div className="border-l-2 border-border pl-3">{renderNested!(nested!)}</div>
+            <div className="border-l-2 border-border pl-3">{renderNested!(nested!, live)}</div>
             <div ref={tailRef} />
           </Scroller>
           {body && !live && (
@@ -294,4 +299,4 @@ export function ToolCall({
       )}
     </div>
   )
-}
+})

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -255,6 +255,100 @@ const chatRequests = new Map<string, string>()
 const modelCatalogCache = new Map<string, ModelInfo[]>()
 /** Set when a remote turn lands while a local send streams into the shared chat. */
 const remoteMirror = { deferred: false }
+
+/**
+ * Publish a session's live parts at most once per animation frame.
+ *
+ * All three streaming paths (a local send, a mirrored phone turn, a subagent's
+ * own session) used to write `streamingChats[id]` synchronously on every delta.
+ * A fast model emits those far quicker than the display can show them, so the
+ * transcript re-rendered several hundred times a second — re-parsing the turn's
+ * markdown and re-measuring the scroll column each time — and every render past
+ * the first in a frame was discarded without ever being painted. That was the
+ * bulk of the "the app is laggy while it streams" problem.
+ *
+ * Coalescing is lossless here because the parts array is CUMULATIVE: each delta
+ * produces a complete new snapshot of the turn, so the newest one already
+ * contains every skipped update.
+ *
+ * `null` (turn over) is published synchronously and cancels anything pending.
+ * It's the one update whose ordering matters: the persisted message is appended
+ * right after, and a frame landing later would resurrect the live bubble on top
+ * of it — a visibly duplicated reply.
+ */
+interface StreamPublisher {
+  (parts: MessagePart[] | null): void
+  /** Drop a scheduled frame without publishing it (the chat went away). */
+  cancel(): void
+}
+
+function createStreamPublisher(chatId: string): StreamPublisher {
+  let pending: MessagePart[] | null = null
+  let frame = 0
+  const publish = (parts: MessagePart[] | null): void =>
+    useRoxyStore.setState((s) => {
+      const next = { ...s.streamingChats }
+      if (parts === null) delete next[chatId]
+      else next[chatId] = parts
+      return { streamingChats: next }
+    })
+  const cancel = (): void => {
+    if (frame) cancelAnimationFrame(frame)
+    frame = 0
+    pending = null
+  }
+  const publisher = (parts: MessagePart[] | null): void => {
+    if (parts === null) {
+      cancel()
+      publish(null)
+      return
+    }
+    // Only the payload is replaced; the already-scheduled frame picks up
+    // whichever snapshot was last. Re-scheduling would land on the same frame
+    // boundary anyway, so this is a rate limit rather than a debounce — the
+    // first delta of a turn still paints on the very next frame.
+    pending = parts
+    if (frame) return
+    frame = requestAnimationFrame(() => {
+      frame = 0
+      if (pending) publish(pending)
+      pending = null
+    })
+  }
+  publisher.cancel = cancel
+  return publisher
+}
+
+/**
+ * One publisher per streaming session. Coalescing only works if consecutive
+ * deltas reach the SAME publisher, and two of the three paths (remote mirror,
+ * subagent) run as event handlers that are re-entered per delta and so cannot
+ * hold one in a local.
+ *
+ * Registering them centrally also gives `deleteChat` something to cancel: a
+ * frame scheduled just before a session is removed would otherwise land after
+ * the cleanup and write a live bubble back for a chat that no longer exists.
+ */
+const streamPublishers = new Map<string, StreamPublisher>()
+
+function publishStream(chatId: string, parts: MessagePart[] | null): void {
+  let publisher = streamPublishers.get(chatId)
+  if (!publisher) {
+    publisher = createStreamPublisher(chatId)
+    streamPublishers.set(chatId, publisher)
+  }
+  publisher(parts)
+  // Turn over and nothing pending — drop it rather than accumulating one
+  // closure per session ever streamed.
+  if (parts === null) streamPublishers.delete(chatId)
+}
+
+/** Forget a session's publisher, dropping any frame it had scheduled. */
+function cancelStream(chatId: string): void {
+  streamPublishers.get(chatId)?.cancel()
+  streamPublishers.delete(chatId)
+}
+
 /**
  * Live parts for the in-flight *phone-driven* turn per session, so the desktop
  * mirrors a remote reply token-by-token (the twin of a local send's `parts`).
@@ -350,12 +444,7 @@ function applyRemoteDelta(payload: RemoteDelta): void {
     // Never clobber a local send streaming into the same chat — its own handler
     // owns `streamingChats[sessionId]` until finishTurn reconciles.
     if (useRoxyStore.getState().sendingChats[sessionId]) return
-    useRoxyStore.setState((s) => {
-      const next = { ...s.streamingChats }
-      if (parts === null) delete next[sessionId]
-      else next[sessionId] = parts
-      return { streamingChats: next }
-    })
+    publishStream(sessionId, parts)
   }
 
   if (payload.kind === 'turn') {
@@ -436,12 +525,7 @@ function applySubagentDelta(payload: SubagentDelta): void {
   const { subChatId } = payload
   const reflect = (parts: MessagePart[] | null): void => {
     if (useRoxyStore.getState().activeChatId !== subChatId) return
-    useRoxyStore.setState((s) => {
-      const next = { ...s.streamingChats }
-      if (parts === null) delete next[subChatId]
-      else next[subChatId] = parts
-      return { streamingChats: next }
-    })
+    publishStream(subChatId, parts)
   }
 
   if (payload.kind === 'run') {
@@ -1160,6 +1244,10 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   deleteChat: async (id) => {
     await api.chats.remove(id)
     await get().refreshChats()
+    // Before clearing the live state, drop any frame this chat had scheduled —
+    // it would otherwise land after the cleanup and write a streaming bubble
+    // back for a session that no longer exists.
+    cancelStream(id)
     set((s) => {
       const sendingChats = { ...s.sendingChats }
       const streamingChats = { ...s.streamingChats }
@@ -1264,13 +1352,10 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     // sessions at once) never crosses the streams or drops a reply.
     const setSending = (v: boolean): void =>
       set((s) => ({ sendingChats: { ...s.sendingChats, [chatId]: v } }))
-    const setStreaming = (parts: MessagePart[] | null): void =>
-      set((s) => {
-        const next = { ...s.streamingChats }
-        if (parts === null) delete next[chatId]
-        else next[chatId] = parts
-        return { streamingChats: next }
-      })
+
+    // Streamed parts are published at most once per animation frame — see
+    // `createStreamPublisher` for why that matters.
+    const setStreaming = (parts: MessagePart[] | null): void => publishStream(chatId, parts)
     const clearStop = (): void =>
       set((s) => {
         const next = { ...s.stopChats }


### PR DESCRIPTION
Two separate bugs that fed each other.

## Switching a session left you at the top

The switch effect reset `scrollTop = 0` by hand, after paint, in a `useEffect`. That is a race it lost every time. A session's transcript arrives a commit LATER than the switch, so the ordering was:

  switch -> tail effect pins to the bottom -> reset stomps it back to 0

and the scroll event that write produced then landed in `onScroll`, which read it as "the user scrolled to the top" and cleared `stickToBottom` -- so nothing ever pinned again. At offset 0 it also tripped the paginate-up branch, quietly loading another 30 messages into a session you had not even looked at yet.

The reset is gone. A switch now marks the session "not arrived" and the tail effect owns the offset outright, landing it whenever the content actually shows up, in whatever order the effects happen to run. Scroll events are ignored until that first pin, because until then every one of them is our own doing (unmounting the outgoing column collapses scrollHeight and the browser clamps to 0). `onScroll` also treats the exact offset we last wrote as "still following", so a delta that grows the turn between the write and the event is not misread as the user scrolling away.

Simulated against a fake scroller in React's real effect order: 13 checks covering switching between long sessions, switching to a session shorter than the viewport, reading history mid-stream, scrolling back to resume, and paging in older turns. The old logic fails 3 of them, including a late clamp event stranding the pane at the top.

## Streaming re-rendered the whole transcript per token

Nothing in the transcript was memoized, so every delta re-rendered all 30 visible bubbles and re-parsed each one's markdown through Streamdown. The cost grew with the length of the reply, which is why long answers got progressively choppier.

- Publish streamed parts at most once per animation frame. All three paths (local send, mirrored phone turn, subagent session) wrote the store synchronously per delta; renders past the first in a frame were never painted. Lossless, because each delta carries a complete cumulative snapshot. `null` still publishes synchronously -- it is the one update whose ordering matters against the persisted message.
- Memoize MessageBubble, ToolCall, ReasoningBlock, and each markdown block. A settled message's `parts` is a stable reference, so a shallow compare is both correct and sufficient.
- Hoist `renderNested` to a stable callback. It closed over each card's own `state`, giving every card a fresh identity per delta, which alone would have defeated the memo. The card passes its liveness in instead.
- Build the ResizeObserver once via a ref callback instead of inside an effect keyed on `streaming` -- that tore down and rebuilt an observer on every token, each rebuild forcing a layout.

Also cancels a session's pending frame in `deleteChat`, so a frame scheduled just before removal cannot write a live bubble back for a chat that no longer exists.