### PR TITLE
Keep the activity graph when sessions and folders are deleted

### DIFF
--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -40,6 +40,10 @@ export function addColumnIfMissing(
  * ahead of what they actually contain.
  */
 const REPAIR_SCHEMA_SQL = /* sql */ `
+  CREATE TABLE IF NOT EXISTS activity (
+        day   TEXT PRIMARY KEY,
+        turns INTEGER NOT NULL DEFAULT 0
+      );
   CREATE TABLE IF NOT EXISTS chats (
         id          TEXT PRIMARY KEY,
         title       TEXT NOT NULL,
@@ -367,7 +371,34 @@ export const MIGRATIONS: Migration[] = [
     addColumnIfMissing(db, 'chats', 'agent_id', 'TEXT')
     addColumnIfMissing(db, 'chats', 'reasoning_effort', 'TEXT')
     addColumnIfMissing(db, 'chats', 'context_limit', 'INTEGER')
-  }
+  },
+
+  // ---- v18: durable activity ledger (the contribution graph's own memory) ----
+  // The graph used to COUNT assistant messages live. But messages are ON DELETE
+  // CASCADE from chats, so deleting a session - or removing a folder, which
+  // deletes every session under it - silently erased months of green squares.
+  // Activity is a record of what you DID, not a view over what you still keep,
+  // and the two must not share a lifetime.
+  //
+  // So: one append-only row per local calendar day, incremented as turns happen
+  // and never cascaded from anything. Tiny (365 rows/year), independent of
+  // session retention, and the only history that has to survive a cleanup.
+  //
+  // The backfill re-derives the ledger from the messages still present, using
+  // SQLite's 'localtime' so the buckets match `localDay` in the renderer. Turns
+  // already deleted before this upgrade are gone for good - nothing recorded
+  // them - but everything still on disk is preserved on the way in.
+  /* sql */ `
+    CREATE TABLE IF NOT EXISTS activity (
+      day   TEXT PRIMARY KEY,
+      turns INTEGER NOT NULL DEFAULT 0
+    );
+    INSERT OR IGNORE INTO activity(day, turns)
+      SELECT date(created_at / 1000, 'unixepoch', 'localtime') AS day, COUNT(*)
+      FROM messages
+      WHERE role = 'assistant'
+      GROUP BY day;
+  `
 ]
 
 /**
@@ -417,6 +448,20 @@ export function repairSchema(db: Database): void {
         FROM chats
         WHERE workspace_path IS NOT NULL
         GROUP BY workspace_path;
+    `)
+  }
+  // The activity ledger is append-only and CANNOT be rebuilt once its source
+  // messages are deleted, so it is only ever seeded (never reconciled) - and
+  // only when completely empty, which means the table itself was just restored
+  // by the DDL above. A ledger with any row in it is the record of record.
+  const led = db.prepare('SELECT COUNT(*) AS n FROM activity').get() as { n: number }
+  if (led.n === 0) {
+    db.exec(`
+      INSERT OR IGNORE INTO activity(day, turns)
+        SELECT date(created_at / 1000, 'unixepoch', 'localtime') AS day, COUNT(*)
+        FROM messages
+        WHERE role = 'assistant'
+        GROUP BY day;
     `)
   }
 }

--- a/src/main/db/repo.ts
+++ b/src/main/db/repo.ts
@@ -31,6 +31,7 @@ import {
   seedSessionConfig,
   type SessionConfigPatch
 } from '../../shared/session-config'
+import { localDay } from '../../shared/cost'
 import { getDb } from './database'
 import { decryptSecret, encryptSecret } from '../services/secure'
 
@@ -232,6 +233,7 @@ export function resetAll(): void {
        DELETE FROM providers;
        DELETE FROM integrations;
        DELETE FROM mcp_servers;
+       DELETE FROM activity;
        DELETE FROM settings;`
     )
   })
@@ -945,6 +947,12 @@ export function addMessage(input: AddMessageInput): Message {
       'INSERT INTO messages(id, chat_id, role, content, parts, created_at) VALUES(?, ?, ?, ?, ?, ?)'
     ).run(id, input.chatId, input.role, input.content, partsJson, now)
     db.prepare('UPDATE chats SET updated_at = ? WHERE id = ?').run(now, input.chatId)
+    // One assistant message = one agent turn. Credited to the durable ledger in
+    // the SAME transaction as the message, so the graph can never disagree with
+    // what was actually persisted - and, unlike the message, the credit stays
+    // when the session is later deleted. Counts sub and loop sessions too, which
+    // is what the previous message-counting query did.
+    if (input.role === 'assistant') recordActivityTurn(localDay(now))
   })
   tx()
   return {
@@ -1405,16 +1413,30 @@ export function insertBackfilledUsage(input: {
 // ---- Activity (contribution graph) -------------------------------------------
 
 /**
- * Timestamps (epoch ms) of every agent turn — one per assistant message — at or
- * after `since`, across all sessions (main, sub, and loop). Feeds the Settings
- * contribution graph's per-day counts. Uses the existing (chat_id, created_at)
- * index for a cheap scan.
+ * Credit one agent turn to a local calendar day.
+ *
+ * The graph is deliberately NOT a query over `messages`: those cascade away with
+ * their chat, so deleting a session (or a whole project folder) used to erase the
+ * history of having worked. This ledger is append-only, keyed by day, and owned
+ * by nothing - the only table whose rows outlive everything they describe.
+ *
+ * `day` must be the LOCAL calendar day (`localDay`), matching how the renderer
+ * lays the grid out, so a turn lands in the square the user watched it happen in.
  */
-export function listAgentTurnTimestamps(since: number): number[] {
-  const rows = getDb()
+export function recordActivityTurn(day: string, turns = 1): void {
+  if (!day || turns <= 0) return
+  getDb()
     .prepare(
-      "SELECT created_at FROM messages WHERE role = 'assistant' AND created_at >= ? ORDER BY created_at ASC"
+      `INSERT INTO activity(day, turns) VALUES(?, ?)
+       ON CONFLICT(day) DO UPDATE SET turns = turns + excluded.turns`
     )
-    .all(since) as { created_at: number }[]
-  return rows.map((r) => r.created_at)
+    .run(day, Math.floor(turns))
+}
+
+/** Per-day turn counts from `fromDay` (inclusive, local YYYY-MM-DD) onward. */
+export function listActivityDays(fromDay: string): Map<string, number> {
+  const rows = getDb()
+    .prepare('SELECT day, turns FROM activity WHERE day >= ? ORDER BY day ASC')
+    .all(fromDay) as { day: string; turns: number }[]
+  return new Map(rows.map((r) => [r.day, r.turns]))
 }

--- a/src/main/services/activity.ts
+++ b/src/main/services/activity.ts
@@ -1,14 +1,20 @@
 /**
- * The activity dashboard service — turns the messages table into the
+ * The activity dashboard service — turns the durable activity ledger into the
  * `ActivityStats` payload the Settings contribution graph renders.
  *
- * One agent turn = one assistant message. We count them per local calendar day
- * over a rolling window (default ~53 weeks, so the GitHub-style grid fills), then
- * hand the raw timestamps to the pure `aggregateActivity` (shared with the tests)
- * for zero-filling, level bucketing, and streak math.
+ * One agent turn = one assistant message, credited to a local calendar day as it
+ * happens (see `repo.recordActivityTurn`). Reading the LEDGER rather than the
+ * messages table is the whole point: messages cascade away with their chat, so a
+ * graph derived from them lost months of history the moment a session or a
+ * project folder was removed. Your record of having worked shouldn't depend on
+ * whether you kept the transcript.
+ *
+ * The per-day counts go to the pure `aggregateActivityDays` (shared with the
+ * tests) for zero-filling, level bucketing, and streak math.
  */
 import * as repo from '../db/repo'
-import { aggregateActivity } from '../../shared/activity'
+import { aggregateActivityDays } from '../../shared/activity'
+import { localDay } from '../../shared/cost'
 import type { ActivityStats } from '../../shared/types'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -19,9 +25,8 @@ export const ACTIVITY_DAYS = 371
 /** Build the contribution-graph payload for the last `days` days (inclusive of today). */
 export function getActivityStats(days = ACTIVITY_DAYS): ActivityStats {
   const now = Date.now()
-  // Start-of-day `days-1` back, so a turn early on the first day still counts.
-  const start = new Date(now - (days - 1) * DAY_MS)
-  start.setHours(0, 0, 0, 0)
-  const timestamps = repo.listAgentTurnTimestamps(start.getTime())
-  return aggregateActivity(timestamps, now, days)
+  // The oldest day the window shows. Compared as a YYYY-MM-DD string, which sorts
+  // chronologically, so the ledger scan is a cheap range over its primary key.
+  const from = localDay(now - (days - 1) * DAY_MS)
+  return aggregateActivityDays(repo.listActivityDays(from), now, days)
 }

--- a/src/shared/activity.ts
+++ b/src/shared/activity.ts
@@ -34,12 +34,26 @@ export function activityLevel(count: number, max: number): ActivityDay['level'] 
  * deterministic. `days` is the window length (e.g. 182 ≈ 26 weeks).
  */
 export function aggregateActivity(timestamps: number[], now: number, days = 182): ActivityStats {
-  const span = Math.max(1, Math.floor(days))
   const byDay = new Map<string, number>()
   for (const ts of timestamps) {
     const key = localDay(ts)
     byDay.set(key, (byDay.get(key) ?? 0) + 1)
   }
+  return aggregateActivityDays(byDay, now, days)
+}
+
+/**
+ * The same aggregation, but from per-day counts tallied ELSEWHERE - the
+ * `activity` ledger, which outlives the sessions those turns happened in and so
+ * has no timestamps left to re-bucket. Keys are local YYYY-MM-DD, exactly what
+ * `localDay` produces, so both entry points describe the same calendar.
+ */
+export function aggregateActivityDays(
+  byDay: ReadonlyMap<string, number>,
+  now: number,
+  days = 182
+): ActivityStats {
+  const span = Math.max(1, Math.floor(days))
 
   // The window runs [now - (span-1) days .. now], oldest → newest, so the last
   // cell is always today and the grid fills left-to-right like GitHub's.

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -95,7 +95,7 @@ import {
   aggregateUsage
 } from '../src/shared/cost'
 import type { TokenUsage, UsageRecord } from '../src/shared/types'
-import { aggregateActivity, activityLevel } from '../src/shared/activity'
+import { aggregateActivity, activityLevel, aggregateActivityDays } from '../src/shared/activity'
 import {
   estimateTokens,
   countLines,
@@ -2978,6 +2978,29 @@ async function main(): Promise<void> {
   check(
     'activity: idle today → current streak 0',
     aggregateActivity([aNow - 5 * DAYMS], aNow, 182).currentStreak === 0
+  )
+
+  // The ledger path: per-day counts recorded as turns happened, with no
+  // timestamps left to re-bucket (the sessions may be long deleted). It must
+  // produce exactly what the timestamp path does for the same days, or the graph
+  // would visibly shift the moment the data source changed under it.
+  const ledger = new Map([
+    [localDay(aNow), 3],
+    [localDay(aNow - DAYMS), 2],
+    [localDay(aNow - 3 * DAYMS), 1]
+  ])
+  const fromLedger = aggregateActivityDays(ledger, aNow, 182)
+  check(
+    'activity: ledger counts match the timestamp path exactly',
+    JSON.stringify(fromLedger) === JSON.stringify(act)
+  )
+  check(
+    'activity: days outside the window are ignored',
+    aggregateActivityDays(new Map([[localDay(aNow - 400 * DAYMS), 9]]), aNow, 182).total === 0
+  )
+  check(
+    'activity: an empty ledger is a blank grid',
+    aggregateActivityDays(new Map(), aNow, 7).total === 0
   )
 
   // ---- forge: remote URL parsing ------------------------------------------

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -13,6 +13,8 @@ import { pathToFileURL } from 'node:url'
 import { app } from 'electron'
 
 import * as repo from '../src/main/db/repo'
+import { getActivityStats } from '../src/main/services/activity'
+import { localDay } from '../src/shared/cost'
 import { closeDb } from '../src/main/db/database'
 import {
   runTool,
@@ -854,6 +856,59 @@ async function main(): Promise<void> {
     repo.removeChat(sessB.id)
   }
 
+  // ---- activity survives deletion (the whole point of the ledger) ----
+  // The contribution graph used to COUNT assistant messages, which cascade away
+  // with their chat - so deleting a session, or removing a project folder (which
+  // deletes every session under it), silently erased months of history. These
+  // pin the property that broke: the record of having worked outlives the
+  // transcript it came from.
+  {
+    const before = getActivityStats().total
+    const today = localDay(Date.now())
+
+    const keep = repo.createChat({ title: 'activity keep', kind: 'main', workspacePath: ws })
+    const doomed = repo.createChat({ title: 'activity doomed', kind: 'main', workspacePath: ws })
+    const sub = repo.createChat({
+      title: 'activity sub',
+      kind: 'sub',
+      workspacePath: ws,
+      parentId: doomed.id
+    })
+
+    repo.addMessage({ chatId: keep.id, role: 'user', content: 'hi' })
+    repo.addMessage({ chatId: keep.id, role: 'assistant', content: 'one' })
+    repo.addMessage({ chatId: doomed.id, role: 'assistant', content: 'two' })
+    repo.addMessage({ chatId: sub.id, role: 'assistant', content: 'three' })
+
+    // 4 messages went in, 3 of them assistant: user prompts are not turns.
+    const after = getActivityStats()
+    check('activity: assistant messages are recorded as turns', after.total === before + 3)
+    const todayCell = after.days[after.days.length - 1]
+    check(
+      'activity: turns land on today, in local time',
+      todayCell.date === today && todayCell.count >= 3
+    )
+
+    // Deleting the session cascades its messages AND its subagent's - the graph
+    // must not move.
+    repo.removeChat(doomed.id)
+    check(
+      "activity: deleting a session doesn't erase its history",
+      getActivityStats().total === before + 3
+    )
+    check(
+      'activity: the messages really were deleted',
+      repo.listMessages(doomed.id).length === 0 && repo.listMessages(sub.id).length === 0
+    )
+
+    // ...and removing the last session in a folder (what "remove folder" does)
+    // must not either.
+    repo.removeChat(keep.id)
+    const end = getActivityStats()
+    check('activity: emptying a project folder keeps the graph', end.total === before + 3)
+    check('activity: today is still an active day', end.currentStreak >= 1)
+  }
+
   // ---- migration repair (two branches, two different "v14"s) ----
   // The schema version is an ARRAY POSITION, so when the usage-dashboard branch
   // and the worktree branch each shipped a migration numbered v14, a database
@@ -899,6 +954,58 @@ async function main(): Promise<void> {
          VALUES('mig1','pre-existing','main','/proj',1,1,1)`
       ).run()
       return db
+    }
+
+    // v18's backfill: an existing install upgrading must not start from a blank
+    // graph. The ledger is seeded from the assistant messages still on disk,
+    // bucketed by LOCAL day so it agrees with what the renderer draws.
+    {
+      const db = await seeded('mig-activity', 17)
+      const mk = (id: string, at: number, role: string): void => {
+        db.prepare(
+          `INSERT INTO messages(id, chat_id, role, content, created_at)
+           VALUES(?, 'mig1', ?, 'x', ?)`
+        ).run(id, role, at)
+      }
+      const noon = new Date(2026, 0, 15, 12, 0, 0).getTime()
+      mk('m1', noon, 'assistant')
+      mk('m2', noon + 60_000, 'assistant')
+      mk('m3', noon - 24 * 60 * 60 * 1000, 'assistant')
+      mk('m4', noon, 'user') // not a turn
+      check('migration v18: ledger absent before the upgrade', !tablesOf(db).includes('activity'))
+
+      runLadder(db)
+      const led = db.prepare('SELECT day, turns FROM activity ORDER BY day').all() as {
+        day: string
+        turns: number
+      }[]
+      check(
+        'migration v18: backfills one row per active day',
+        led.length === 2,
+        JSON.stringify(led)
+      )
+      check(
+        'migration v18: backfills local-day counts, assistant only',
+        led[0].day === localDay(noon - 24 * 60 * 60 * 1000) &&
+          led[0].turns === 1 &&
+          led[1].day === localDay(noon) &&
+          led[1].turns === 2,
+        JSON.stringify(led)
+      )
+
+      // The ledger is the record of record: re-running must never re-seed on top
+      // of it, or every restart would double a day that still has its messages.
+      repairSchema(db)
+      repairSchema(db)
+      check(
+        'migration v18: repeated opens never double-count',
+        (
+          db.prepare('SELECT turns AS t FROM activity WHERE day = ?').get(localDay(noon)) as {
+            t: number
+          }
+        ).t === 2
+      )
+      db.close()
     }
 
     // Direction 1: took the usage v14, so the worktree columns were skipped.
@@ -1026,7 +1133,7 @@ async function main(): Promise<void> {
 
     // Every table the app depends on must come back, not just the ones a
     // previously-reported bug happened to name.
-    for (const table of ['projects', 'usage', 'queue', 'mcp_servers', 'settings']) {
+    for (const table of ['projects', 'usage', 'queue', 'mcp_servers', 'settings', 'activity']) {
       const db = healthy()
       db.exec(`DROP TABLE ${table}`)
       check(`self-heal: ${table} is missing before repair`, !tablesOf(db).includes(table))


### PR DESCRIPTION
The contribution graph counted assistant messages live. Messages are ON DELETE CASCADE from chats, so deleting a session -- or removing a project folder, which deletes every session under it -- silently erased months of green squares along with the transcripts.

Activity is a record of what you did, not a view over what you still keep. The two should not share a lifetime.

Add an append-only `activity` ledger: one row per local calendar day, credited inside the same transaction that writes the assistant message, and referenced by nothing, so no cascade can reach it. ~365 rows a year.

- v18 backfills it from the assistant messages still on disk, bucketing with SQLite's 'localtime' so the squares match `localDay` in the renderer. Turns whose sessions were already deleted are unrecoverable, but nothing currently on disk is lost on the way in.
- repairSchema restores the table and seeds it only when it is completely empty. It never reconciles: re-seeding a live ledger would double every day that still has its messages, on every open.
- The aggregation splits into `aggregateActivityDays`, taking per-day counts; the timestamp entry point funnels into it, so the ledger and the old path are provably identical (pinned by a test).
- Factory reset still clears it -- that is an explicit erase-everything, unlike deleting one session.

Covered by smoke checks that deleting a session, its subagent, and the last session in a folder all leave the graph untouched, plus the v18 backfill, double-count safety, and self-heal.