### PR TITLE
Make Stop actually stop, and let a single subagent be cancelled

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "icons:providers": "node script/copy-provider-icons.mjs",
     "smoke:shared": "esbuild test/shared.ts --bundle --platform=node --format=cjs --packages=external --outfile=test/.out/shared.cjs && node test/.out/shared.cjs",
     "smoke:app": "esbuild test/smoke.ts --bundle --platform=node --format=cjs --packages=external --outfile=test/.out/smoke.cjs && electron test/.out/smoke.cjs",
-    "smoke": "npm run smoke:shared && npm run smoke:app",
-    "worktree:setup": "npm ci --prefer-offline --no-audit --no-fund && electron-builder install-app-deps"
+    "smoke": "npm run smoke:shared && npm run smoke:store && npm run smoke:app",
+    "worktree:setup": "npm ci --prefer-offline --no-audit --no-fund && electron-builder install-app-deps",
+    "smoke:store": "node test/store-guard.mjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.85",

--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -57,7 +57,11 @@ import type { McpServerRecord } from '../../shared/mcp'
 import { SKILL_TOOL_NAME, SKILL_TOOL_DESCRIPTION } from '../../shared/skills'
 import { listSkills, skillInstructions } from '../services/skills'
 import { findGitRoot } from '../services/workspace'
-import { registerBackgroundJob, finishBackgroundJob } from '../services/background-tasks'
+import {
+  registerBackgroundJob,
+  finishBackgroundJob,
+  cancelBackgroundJob
+} from '../services/background-tasks'
 import { startSubagentRun } from '../services/subagent-stream'
 import {
   messagesHaveImages,
@@ -1263,6 +1267,11 @@ async function runLoop(o: LoopOptions): Promise<string> {
         cwd,
         sessionId,
         browserKey,
+        // Stop must reach INSIDE the tool, not just between calls. Without this
+        // the loop's `if (signal.aborted) break` above only fires once the
+        // current tool returns on its own, which is why Stop looked stuck
+        // during a long bash or a hanging fetch.
+        signal,
         onChunk: (chunk) => emitTool({ type: 'tool-delta', callId: tc.id, chunk })
       })
       emitTool({
@@ -1414,8 +1423,9 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
   // skips that (the turn may already be over) and reports via the sub session.
   const runBody = async (
     runSignal: AbortSignal,
-    forwardToParent: boolean
-  ): Promise<{ report: string; state: 'completed' | 'error' }> => {
+    forwardToParent: boolean,
+    onCancel: () => void
+  ): Promise<{ report: string; state: 'completed' | 'error' | 'cancelled' }> => {
     // One fold builds the subagent's transcript; the same events fan out to the
     // parent's `task` card and to the sub session's own live stream, so all three
     // views are the same thing by construction and cannot drift.
@@ -1443,7 +1453,8 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
           parentChatId: parentChatId ?? null,
           description,
           subagentType,
-          background: background === true
+          background: background === true,
+          cancel: onCancel
         })
       : null
     /**
@@ -1501,16 +1512,28 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
         contextLimit,
         depth: depth + 1
       })
+      // A cancel lands BETWEEN steps, where runLoop returns normally with a
+      // partial report — so reaching here says nothing about whether the work
+      // actually finished. Check the signal before calling it a success, or a
+      // cancelled delegate would be recorded as `completed` and its truncated
+      // report would be handed to the parent model as a real answer. (The
+      // background path already guarded this; the foreground path did not.)
+      const cancelled = runSignal.aborted
       persistSub()
       // Persist BEFORE ending the run: the renderer reloads the sub session's
       // transcript on the end frame, and reloading before the row exists would
       // blank the view for a beat between the live bubble and the saved message.
-      live?.finish('completed')
+      live?.finish(cancelled ? 'error' : 'completed')
+      if (cancelled) {
+        return { report: cancelledReport(description, text), state: 'cancelled' }
+      }
       return { report: text.trim() || '(subagent returned no report)', state: 'completed' }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
+      const cancelled = runSignal.aborted
       persistSub()
       live?.finish('error')
+      if (cancelled) return { report: cancelledReport(description, ''), state: 'cancelled' }
       return { report: `Subagent failed: ${msg}`, state: 'error' }
     }
   }
@@ -1524,7 +1547,9 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
       callId,
       tool: 'task',
       title: `${agent.name}: ${description} (background)`,
-      input: { description, prompt, subagent_type: subagentType, background: true }
+      input: { description, prompt, subagent_type: subagentType, background: true },
+      // Lets the card offer a cancel for this one detached delegate.
+      subChatId: subChatId ?? undefined
     })
     emit({
       type: 'tool-end',
@@ -1541,7 +1566,7 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
       description,
       subagentType
     })
-    void runBody(bgSignal, false)
+    void runBody(bgSignal, false, () => cancelBackgroundJob(jobId))
       .then(({ report, state }) => {
         // A cancelled job (session delete, app quit, or explicit cancel) aborts
         // bgSignal. That abort can land BETWEEN steps, where runLoop returns
@@ -1549,7 +1574,7 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
         // even though the work was cut short. Never record a cancelled run as a
         // successful completion: the transcript card AND the structured tool
         // history the next turn reconstructs from it would both mislead.
-        const cancelled = bgSignal.aborted
+        const cancelled = bgSignal.aborted || state === 'cancelled'
         const finalState: 'completed' | 'error' = cancelled ? 'error' : state
         const finalReport = cancelled
           ? `The "${description}" background task was cancelled before it finished.`
@@ -1595,11 +1620,48 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
     callId,
     tool: 'task',
     title: `${agent.name}: ${description}`,
-    input: { description, prompt, subagent_type: subagentType }
+    input: { description, prompt, subagent_type: subagentType },
+    // Addresses the cancel button on this card at THIS delegate — the parent
+    // turn keeps running when it's clicked.
+    subChatId: subChatId ?? undefined
   })
-  const { report, state } = await runBody(signal, true)
-  emit({ type: 'tool-end', callId, output: report, ok: state === 'completed' })
-  return renderTaskResult(subagentType, state, report)
+  // Its OWN controller, chained to the parent's signal rather than being it.
+  //
+  // Chaining is the whole feature: Stop on the parent still cascades (the
+  // listener below), but cancelling this one delegate aborts only its
+  // controller, so the launching turn survives and simply reads a "cancelled"
+  // task result — which is exactly what you want when a post-commit hook spins
+  // up a README subagent you don't care about.
+  const controller = new AbortController()
+  const cascade = (): void => controller.abort()
+  if (signal.aborted) controller.abort()
+  else signal.addEventListener('abort', cascade, { once: true })
+  try {
+    const { report, state } = await runBody(controller.signal, true, cascade)
+    emit({ type: 'tool-end', callId, output: report, ok: state === 'completed' })
+    // The parent itself was stopped — this delegate died as collateral, and the
+    // turn is being torn down anyway, so report it as the cancellation it was.
+    if (state === 'cancelled') return renderTaskResult(subagentType, 'error', report)
+    return renderTaskResult(subagentType, state, report)
+  } finally {
+    signal.removeEventListener('abort', cascade)
+  }
+}
+
+/**
+ * What a cancelled delegate reports back to the model that spawned it.
+ *
+ * Deliberately explicit that the user made this call: the parent keeps running
+ * and will read this, and without the framing it tends to re-delegate the exact
+ * task that was just cancelled.
+ */
+function cancelledReport(description: string, partial: string): string {
+  const got = partial.trim()
+  return (
+    `The user cancelled the "${description}" subagent before it finished. ` +
+    'Do not start it again unless they ask. Continue with the rest of your work.' +
+    (got ? `\n\nPartial output before it was cancelled:\n${got.slice(0, 2000)}` : '')
+  )
 }
 
 /** A subagent's focused system prompt: who it is, that it starts blank, and to report back. */

--- a/src/main/harness/tools.ts
+++ b/src/main/harness/tools.ts
@@ -70,6 +70,65 @@ export interface ToolContext {
   browserKey?: string
   /** Optional sink for incremental output (bash streams its logs here live). */
   onChunk?: (chunk: string) => void
+  /**
+   * The turn's abort signal — Stop, or a single subagent being cancelled.
+   *
+   * Threading this all the way down is what makes Stop *feel* instant. Without
+   * it the harness could only check `aborted` BETWEEN tool calls, so pressing
+   * Stop during a 10-minute `bash` or a hung `webfetch` did nothing observable
+   * until that call returned on its own: the turn stayed in flight, the composer
+   * kept showing Stop, and clicking it again did nothing. Every tool that can
+   * block for a meaningful time now honors this.
+   *
+   * Optional because the manual `!verb` path and the smoke tests call `runTool`
+   * without a turn around them; a tool that gets no signal behaves as before.
+   */
+  signal?: AbortSignal
+}
+
+/** The output a cancelled tool reports back — recognizable, and never `ok`. */
+export const TOOL_ABORTED = 'Stopped by the user before this tool finished.'
+
+/** A rejected promise the moment `signal` aborts; never resolves otherwise. */
+function abortRace(signal: AbortSignal | undefined): Promise<never> | null {
+  if (!signal) return null
+  return new Promise((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(new AbortError())
+      return
+    }
+    signal.addEventListener('abort', () => reject(new AbortError()), { once: true })
+  })
+}
+
+/** Marker error for "this tool was cut short by Stop", distinguished from real failures. */
+class AbortError extends Error {
+  constructor() {
+    super(TOOL_ABORTED)
+    this.name = 'AbortError'
+  }
+}
+
+/**
+ * Run `work`, but give up on it the moment `signal` aborts.
+ *
+ * For tools whose underlying operation cannot itself be interrupted (Electron's
+ * `webContents` calls, an MCP round trip): the work keeps running to completion
+ * in the background, but the TURN stops waiting for it. That's the difference
+ * between a Stop that responds instantly and one that appears stuck — and it is
+ * safe here because the turn is being torn down anyway, so a late result has no
+ * one left to mislead.
+ */
+async function untilAborted<T>(
+  signal: AbortSignal | undefined,
+  work: () => Promise<T>
+): Promise<T> {
+  const race = abortRace(signal)
+  if (!race) return await work()
+  // Swallow a late rejection from the losing side so an aborted turn can't
+  // surface an unhandled rejection after its own error path already ran.
+  race.catch(() => {})
+  return await Promise.race([work(), race])
 }
 
 const MAX_OUTPUT = 100_000
@@ -113,7 +172,8 @@ export async function runTool(
         return await runBash(str(input.command), ctx.cwd, ctx.onChunk, {
           timeout: num(input.timeout),
           background: bool(input.background),
-          sessionId: owningSessionId(ctx)
+          sessionId: owningSessionId(ctx),
+          signal: ctx.signal
         })
       case 'bash_list':
         return runBashList(owningSessionId(ctx))
@@ -143,23 +203,44 @@ export async function runTool(
           ctx.cwd
         )
       case 'webfetch':
-        return await runWebFetch(str(input.url), str(input.format), input.timeout, ctx.onChunk)
+        return await runWebFetch(
+          str(input.url),
+          str(input.format),
+          input.timeout,
+          ctx.onChunk,
+          ctx.signal
+        )
       case 'websearch':
-        return await runWebSearch(str(input.query), input.numResults ?? input.count, ctx.onChunk)
+        return await runWebSearch(
+          str(input.query),
+          input.numResults ?? input.count,
+          ctx.onChunk,
+          ctx.signal
+        )
+      // The browser tools drive Electron `webContents`, whose calls take no
+      // AbortSignal — a `loadURL` against a dead host can hang for a long time.
+      // `untilAborted` therefore stops the TURN waiting on them rather than
+      // cancelling the navigation itself; see its doc comment.
       case 'browser_open':
-        return await runBrowserOpen(str(input.url), browserKey(ctx))
+        return await untilAborted(ctx.signal, () => runBrowserOpen(str(input.url), browserKey(ctx)))
       case 'browser_screenshot':
-        return await runBrowserScreenshot(ctx.cwd, browserKey(ctx))
+        return await untilAborted(ctx.signal, () => runBrowserScreenshot(ctx.cwd, browserKey(ctx)))
       case 'browser_read':
-        return await runBrowserRead(str(input.selector) || undefined, browserKey(ctx))
+        return await untilAborted(ctx.signal, () =>
+          runBrowserRead(str(input.selector) || undefined, browserKey(ctx))
+        )
       case 'browser_console':
         return runBrowserConsole(browserKey(ctx))
       case 'browser_click':
-        return await runBrowserClick(str(input.selector), browserKey(ctx))
+        return await untilAborted(ctx.signal, () =>
+          runBrowserClick(str(input.selector), browserKey(ctx))
+        )
       case 'browser_scroll':
-        return await runBrowserScroll(input, browserKey(ctx))
+        return await untilAborted(ctx.signal, () => runBrowserScroll(input, browserKey(ctx)))
       case 'browser_type':
-        return await runBrowserType(str(input.selector), str(input.text), browserKey(ctx))
+        return await untilAborted(ctx.signal, () =>
+          runBrowserType(str(input.selector), str(input.text), browserKey(ctx))
+        )
       case 'browser_tabs':
         return runBrowserTabs(browserKey(ctx))
       case 'browser_new_tab':
@@ -182,22 +263,37 @@ export async function runTool(
       case 'change_session_metadata':
         return await runSetSessionMetadata(input, ctx.sessionId)
       case 'lsp':
-        return await runLspTool(str(input.path ?? input.file), ctx.cwd)
+        return await untilAborted(ctx.signal, () =>
+          runLspTool(str(input.path ?? input.file), ctx.cwd)
+        )
       case 'skill':
         return await loadSkill(str(input.name ?? input.skill), ctx.cwd)
       case 'skill_manage':
-        return await runSkillManage(input, ctx.cwd)
+        // Installing a skill fetches from GitHub — fetchWithTimeout already
+        // accepts an external signal, so this one cancels for real.
+        return await runSkillManage(input, ctx.cwd, ctx.signal)
       case 'mcp':
-        return await runMcpTool(input, ctx.cwd)
+        return await untilAborted(ctx.signal, () => runMcpTool(input, ctx.cwd))
       default:
         // Tools contributed by connected MCP servers use namespaced names
-        // (`mcp__<server>__<tool>`) — route them to the MCP pool.
-        if (isMcpTool(name)) return await callMcpTool(name, input)
+        // (`mcp__<server>__<tool>`) — route them to the MCP pool. An MCP round
+        // trip has its own 120s timeout and no signal, so the turn stops
+        // waiting rather than blocking Stop for up to two minutes.
+        if (isMcpTool(name)) return await untilAborted(ctx.signal, () => callMcpTool(name, input))
         return { ok: false, output: `Unknown tool: ${name}` }
     }
   } catch (e) {
+    // A tool cut short by Stop is not a failure to report to the model — the
+    // turn is ending. Return it as a recognizable non-ok result so the card
+    // reads "stopped" rather than surfacing a raw AbortError.
+    if (isAbort(e) || ctx.signal?.aborted) return { ok: false, output: TOOL_ABORTED }
     return { ok: false, output: e instanceof Error ? e.message : String(e) }
   }
+}
+
+/** Whether a thrown value is an abort (ours, or a fetch/DOM AbortError). */
+function isAbort(e: unknown): boolean {
+  return e instanceof Error && e.name === 'AbortError'
 }
 
 function str(v: unknown): string {
@@ -324,11 +420,18 @@ function runBash(
   command: string,
   cwd: string,
   onChunk?: (chunk: string) => void,
-  opts: { timeout?: number; background?: boolean; sessionId?: string } = {}
+  opts: {
+    timeout?: number
+    background?: boolean
+    sessionId?: string
+    signal?: AbortSignal
+  } = {}
 ): Promise<ToolResult> {
   if (!command.trim()) return Promise.resolve({ ok: false, output: 'bash: missing "command"' })
   // Long-running commands (dev servers, watchers) run detached; poll via bash_output.
   if (opts.background) return Promise.resolve(startBackground(command, cwd, opts.sessionId ?? ''))
+  // Already stopped before we even spawned — don't start work for a dead turn.
+  if (opts.signal?.aborted) return Promise.resolve({ ok: false, output: TOOL_ABORTED })
 
   const timeoutMs = Math.min(Math.max((opts.timeout ?? 60) * 1000, 1000), FG_TIMEOUT_MAX)
   const { cmd, args } = shellInvocation(command)
@@ -359,14 +462,38 @@ function runBash(
       timedOut = true
       killProc(child)
     }, timeoutMs)
-    child.on('error', (e) => {
+    // Stop kills the command for real — same teardown as the timeout, including
+    // the process tree (see killProc). This is the single biggest reason Stop
+    // used to feel stuck: a `npm test` or a hung curl held the turn open for its
+    // full timeout (up to 10 minutes) with nothing the user could do about it.
+    let stopped = false
+    const onAbort = (): void => {
+      stopped = true
+      killProc(child)
+    }
+    opts.signal?.addEventListener('abort', onAbort, { once: true })
+    const cleanup = (): void => {
       clearTimeout(timer)
+      opts.signal?.removeEventListener('abort', onAbort)
+    }
+    child.on('error', (e) => {
+      cleanup()
+      if (stopped) {
+        resolve({ ok: false, output: `${acc}\n[${TOOL_ABORTED}]`.trimEnd() })
+        return
+      }
       const msg = `\n[error: ${e.message}]`
       onChunk?.(msg)
       resolve({ ok: false, output: (acc + msg).trimEnd() })
     })
     child.on('close', (code) => {
-      clearTimeout(timer)
+      cleanup()
+      if (stopped) {
+        const msg = `\n[stopped]`
+        onChunk?.(msg)
+        resolve({ ok: false, output: (acc + msg).trimEnd() || TOOL_ABORTED })
+        return
+      }
       const exitCode = code ?? (timedOut ? 124 : 0)
       const suffix = timedOut
         ? `\n[timed out after ${Math.round(timeoutMs / 1000)}s — for a server or watcher, call bash again with background:true]`
@@ -807,7 +934,8 @@ async function runWebFetch(
   rawUrl: string,
   format: string,
   timeout: unknown,
-  onChunk?: (chunk: string) => void
+  onChunk?: (chunk: string) => void,
+  signal?: AbortSignal
 ): Promise<ToolResult> {
   let url: string
   try {
@@ -821,6 +949,9 @@ async function runWebFetch(
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutSec * 1000)
+  // Stop aborts the request itself, not just the wait: a webfetch against a
+  // slow host used to hold the turn open for the full timeout.
+  const unlink = linkAbort(signal, controller)
   try {
     const res = await fetch(url, {
       redirect: 'follow',
@@ -856,6 +987,7 @@ async function runWebFetch(
     const output = capText(converted, WEBFETCH_OUTPUT_CAP)
     return { ok: true, output: output || '(the page had no readable text content)' }
   } catch (e) {
+    if (signal?.aborted) return { ok: false, output: TOOL_ABORTED }
     if (controller.signal.aborted) {
       return { ok: false, output: `Fetching ${url} timed out after ${timeoutSec}s.` }
     }
@@ -865,7 +997,27 @@ async function runWebFetch(
     }
   } finally {
     clearTimeout(timer)
+    unlink()
   }
+}
+
+/**
+ * Make an outer abort signal also abort a tool's own controller, returning an
+ * unsubscribe. Tools keep their internal timeout controller (their timeout
+ * semantics are their own); this just adds Stop as a second trigger.
+ *
+ * Unsubscribing matters: a turn's signal outlives any single tool call, so
+ * leaving listeners attached would leak one per tool call for the whole turn.
+ */
+function linkAbort(signal: AbortSignal | undefined, controller: AbortController): () => void {
+  if (!signal) return () => {}
+  if (signal.aborted) {
+    controller.abort()
+    return () => {}
+  }
+  const onAbort = (): void => controller.abort()
+  signal.addEventListener('abort', onAbort, { once: true })
+  return () => signal.removeEventListener('abort', onAbort)
 }
 
 /**
@@ -877,7 +1029,8 @@ async function runWebFetch(
 async function runWebSearch(
   query: string,
   numResults: unknown,
-  onChunk?: (chunk: string) => void
+  onChunk?: (chunk: string) => void,
+  signal?: AbortSignal
 ): Promise<ToolResult> {
   if (!query.trim()) return { ok: false, output: 'websearch: missing "query"' }
   const count = clampResults(numResults)
@@ -892,6 +1045,7 @@ async function runWebSearch(
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), WEBSEARCH_TIMEOUT * 1000)
+  const unlink = linkAbort(signal, controller)
   try {
     const res = await fetch(endpoint, {
       method: 'POST',
@@ -917,6 +1071,7 @@ async function runWebSearch(
     const text = parseExaResponse(body)
     return { ok: true, output: text ? capText(text, WEBFETCH_OUTPUT_CAP) : WEBSEARCH_NO_RESULTS }
   } catch (e) {
+    if (signal?.aborted) return { ok: false, output: TOOL_ABORTED }
     if (controller.signal.aborted) {
       return { ok: false, output: `Web search timed out after ${WEBSEARCH_TIMEOUT}s.` }
     }
@@ -926,6 +1081,7 @@ async function runWebSearch(
     }
   } finally {
     clearTimeout(timer)
+    unlink()
   }
 }
 
@@ -1134,7 +1290,11 @@ function runLoopSet(ref: string, enabled: boolean): ToolResult {
  * (global) and become loadable via the `skill` tool on the next turn. Never
  * throws — every failure degrades to an error ToolResult.
  */
-async function runSkillManage(input: Record<string, unknown>, cwd: string): Promise<ToolResult> {
+async function runSkillManage(
+  input: Record<string, unknown>,
+  cwd: string,
+  signal?: AbortSignal
+): Promise<ToolResult> {
   const action = str(input.action ?? input.op)
     .trim()
     .toLowerCase()
@@ -1154,7 +1314,7 @@ async function runSkillManage(input: Record<string, unknown>, cwd: string): Prom
     ((action === 'create' || action === 'add' || action === 'new') &&
       !!source &&
       !pickSkillBody(input))
-  if (wantsInstall) return runSkillInstall(input, source, cwd)
+  if (wantsInstall) return runSkillInstall(input, source, cwd, signal)
 
   const name = str(input.name ?? input.skill ?? input.id).trim()
   if (!name)
@@ -1227,7 +1387,8 @@ async function runSkillManage(input: Record<string, unknown>, cwd: string): Prom
 async function runSkillInstall(
   input: Record<string, unknown>,
   source: string,
-  cwd: string
+  cwd: string,
+  signal?: AbortSignal
 ): Promise<ToolResult> {
   if (!source) {
     return {
@@ -1237,7 +1398,8 @@ async function runSkillInstall(
     }
   }
   const scope = str(input.scope).trim().toLowerCase() === 'global' ? 'global' : 'workspace'
-  const res = await installSkillFromSource(source, { scope, cwd })
+  const res = await installSkillFromSource(source, { scope, cwd, signal })
+  if (signal?.aborted) return { ok: false, output: TOOL_ABORTED }
   if (!res.ok) return { ok: false, output: res.error ?? 'Failed to install the skill.' }
   const names = res.installed.map((s) => s.name)
   const lines = res.installed.map((s) => `- ${s.name} → ${s.location}`)

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -53,7 +53,9 @@ import {
   endSubagentRuns,
   listRunningSubagents,
   setViewedSubChat,
-  subagentSnapshot
+  subagentSnapshot,
+  cancelSubagentRun,
+  cancelSubagentRunsFor
 } from '../services/subagent-stream'
 import { mcpServerSummaries, reconnectMcpServer, disposeConnection } from '../services/mcp'
 import {
@@ -72,6 +74,45 @@ import { BUNDLE_FILENAME } from '../../shared/portable'
 
 /** In-flight streamed completions, keyed by requestId, so they can be aborted. */
 const llmControllers = new Map<string, AbortController>()
+
+/**
+ * Every abortable piece of model work a SESSION currently owns.
+ *
+ * `llmControllers` alone was not enough for Stop to be reliable. The renderer
+ * only learns a requestId once the turn is actually starting, and real work
+ * happens before that — most of all compaction, which is a full model call on a
+ * long history and used to run with a hardcoded never-aborted signal. Stop
+ * during that window found no requestId and silently did nothing, which is a
+ * large part of why the button felt stuck.
+ *
+ * Keyed by session id (the one handle the UI always has) and holding a SET,
+ * because a session can legitimately have more than one thing in flight.
+ */
+const sessionControllers = new Map<string, Set<AbortController>>()
+
+/** Track a controller against its session; returns the matching untrack. */
+function trackSession(sessionId: string | undefined, controller: AbortController): () => void {
+  if (!sessionId) return () => {}
+  let set = sessionControllers.get(sessionId)
+  if (!set) {
+    set = new Set()
+    sessionControllers.set(sessionId, set)
+  }
+  set.add(controller)
+  return () => {
+    const live = sessionControllers.get(sessionId)
+    if (!live) return
+    live.delete(controller)
+    // Drop the empty set rather than leaving it: this map is keyed by session id
+    // and would otherwise grow one entry per session for the app's lifetime.
+    if (live.size === 0) sessionControllers.delete(sessionId)
+  }
+}
+
+/** Abort everything in flight for a session (its turn, and any compaction). */
+function abortSession(sessionId: string): void {
+  for (const controller of sessionControllers.get(sessionId) ?? []) controller.abort()
+}
 
 /** Merge persisted MCP server rows with their live connection status for the UI. */
 function listMcpServersWithStatus(): McpServerView[] {
@@ -490,6 +531,15 @@ export function registerIpc(): void {
   ipcMain.handle(CHANNELS.llmStart, async (event, input: LlmStartInput) => {
     const controller = new AbortController()
     llmControllers.set(input.requestId, controller)
+    const untrack = trackSession(input.sessionId, controller)
+    // Stop can be pressed in the gap between the renderer asking for the turn
+    // and this handler running. `abortSession` would have found nothing to
+    // abort, so honour a stop that already landed for this session.
+    if (controller.signal.aborted) {
+      llmControllers.delete(input.requestId)
+      untrack()
+      return { ok: false, error: 'Stopped.' }
+    }
     // If this session is shared to a phone, relay the turn there too so the phone
     // streams a desktop-typed reply live (the mirror of a phone turn on the PC).
     // The current prompt is the last user message; announce it so the phone shows
@@ -509,11 +559,20 @@ export function registerIpc(): void {
       )
     } finally {
       llmControllers.delete(input.requestId)
+      untrack()
       if (relay) remote.relayLocalTurnEnd(relay)
     }
   })
   ipcMain.handle(CHANNELS.llmAbort, (_e, requestId: string) => {
     llmControllers.get(requestId)?.abort()
+  })
+  // Stop, as the UI means it: end everything this session has in flight,
+  // whatever stage it's at. Also cancels the session's delegates — stopping a
+  // turn while it waits on a subagent has to stop the subagent, or the work
+  // carries on invisibly after the transcript says it stopped.
+  ipcMain.handle(CHANNELS.llmAbortSession, (_e, sessionId: string) => {
+    abortSession(sessionId)
+    cancelSubagentRunsFor(sessionId)
   })
 
   // ---- background subagent tasks (Phase 11) ----
@@ -533,13 +592,29 @@ export function registerIpc(): void {
   ipcMain.handle(CHANNELS.subagentSetViewed, (_e, chatId: string | null) =>
     setViewedSubChat(chatId)
   )
+  // Cancel one delegate without stopping the turn that launched it. The run
+  // tears itself down through its own exit path (see cancelSubagentRun), so
+  // there's nothing to clean up here.
+  ipcMain.handle(CHANNELS.subagentCancel, (_e, subChatId: string) => cancelSubagentRun(subChatId))
 
   // ---- models (models.dev catalog) ----
   ipcMain.handle(CHANNELS.modelsList, (_e, providerId: string) => listModels(providerId))
 
   // ---- context (compaction) ----
-  ipcMain.handle(CHANNELS.contextCompact, (_e, chatId: string, providerId: string, model: string) =>
-    compactChat(chatId, providerId, model)
+  ipcMain.handle(
+    CHANNELS.contextCompact,
+    async (_e, chatId: string, providerId: string, model: string) => {
+      // Registered against the session so Stop reaches it: compaction runs
+      // ahead of the turn it makes room for, and is often the longest thing
+      // standing between pressing Stop and anything happening.
+      const controller = new AbortController()
+      const untrack = trackSession(chatId, controller)
+      try {
+        return await compactChat(chatId, providerId, model, controller.signal)
+      } finally {
+        untrack()
+      }
+    }
   )
   ipcMain.handle(CHANNELS.contextInstructions, (_e, cwd: string) => projectInstructions(cwd))
 

--- a/src/main/services/compaction.ts
+++ b/src/main/services/compaction.ts
@@ -50,13 +50,12 @@ function flatten(m: Message): string {
 export async function compactChat(
   chatId: string,
   providerId: string,
-  model: string
+  model: string,
+  signal?: AbortSignal
 ): Promise<Chat> {
   const existing = repo.getChat(chatId)
   if (!existing) throw new Error('Chat not found')
-  const all = repo
-    .listMessages(chatId)
-    .filter((m) => m.role === 'user' || m.role === 'assistant')
+  const all = repo.listMessages(chatId).filter((m) => m.role === 'user' || m.role === 'assistant')
   if (all.length === 0) return existing
 
   // Don't summarize a trailing UNANSWERED user turn (see messagesToCompact): it's
@@ -81,14 +80,23 @@ export async function compactChat(
     model,
     messages: [
       { role: 'system', content: COMPACT_SYSTEM },
-      { role: 'user', content: `${COMPACT_STRUCTURE}\n\n${prior}Conversation to compact:\n\n${convo}` }
+      {
+        role: 'user',
+        content: `${COMPACT_STRUCTURE}\n\n${prior}Conversation to compact:\n\n${convo}`
+      }
     ],
-    signal: new AbortController().signal,
+    // Compaction is a real model call that can take many seconds on a long
+    // history, and it runs BEFORE the turn it's making room for — so a
+    // hardcoded never-aborted signal (what this used to be) meant Stop did
+    // nothing at all during it. Callers that have no signal pass none and get
+    // the old behaviour.
+    signal: signal ?? new AbortController().signal,
     onDelta: (t) => {
       summary += t
     }
   })
 
+  if (signal?.aborted) throw new Error('Compaction was stopped.')
   summary = summary.trim()
   if (!summary) throw new Error('Compaction produced an empty summary.')
   const through = messages[messages.length - 1].createdAt

--- a/src/main/services/subagent-stream.ts
+++ b/src/main/services/subagent-stream.ts
@@ -41,6 +41,19 @@ interface Run {
   background: boolean
   startedAt: number
   fold: PartsFold
+  /**
+   * Abort just THIS delegate, leaving its parent turn running.
+   *
+   * Registered here rather than in a registry of its own because this map is
+   * already the one place that knows about every run of either kind — a
+   * foreground subagent had no cancellation at all before (the only lever was
+   * Stop, which killed the whole turn), and a background one had `tasks:cancel`
+   * keyed by job id, which the renderer never called. One key (the sub session
+   * id) now cancels either kind, which is also the only id the UI reliably has.
+   */
+  cancel: () => void
+  /** Set by `cancelSubagentRun` so the harness can tell "cancelled" from "failed". */
+  cancelled: boolean
 }
 
 /** Sub chat id —> its in-flight run. Only ever holds RUNNING subagents. */
@@ -79,6 +92,8 @@ export interface StartRunInput {
   description: string
   subagentType: string
   background: boolean
+  /** Aborts this run's own signal — see `Run.cancel`. */
+  cancel: () => void
 }
 
 /**
@@ -100,7 +115,9 @@ export function startSubagentRun(input: StartRunInput): {
     subagentType: input.subagentType,
     background: input.background,
     startedAt: Date.now(),
-    fold: new PartsFold()
+    fold: new PartsFold(),
+    cancel: input.cancel,
+    cancelled: false
   }
   runs.set(input.subChatId, run)
   broadcast({ subChatId: run.subChatId, kind: 'run', state: 'running' })
@@ -136,6 +153,37 @@ export function subagentSnapshot(subChatId: string): MessagePart[] | null {
   return runs.get(subChatId)?.fold.parts ?? null
 }
 
+/**
+ * Cancel one running subagent by its session id, foreground or background.
+ *
+ * Aborting is all this does — the run tears itself down through its normal exit
+ * path (persist what it got, `finish`, report back to the parent as cancelled),
+ * so there is exactly one place that ends a run and no way for a cancel to leave
+ * a half-closed one behind. Returns false when nothing was running, which the
+ * UI uses to avoid pretending it did something.
+ */
+export function cancelSubagentRun(subChatId: string): boolean {
+  const run = runs.get(subChatId)
+  if (!run) return false
+  run.cancelled = true
+  run.cancel()
+  return true
+}
+
+/** Whether a run was cancelled by the user (vs. failing on its own). */
+export function wasSubagentCancelled(subChatId: string): boolean {
+  return runs.get(subChatId)?.cancelled === true
+}
+
+/** Cancel every subagent a session spawned — used when its parent turn is stopped. */
+export function cancelSubagentRunsFor(parentChatId: string): void {
+  for (const run of [...runs.values()]) {
+    if (run.parentChatId !== parentChatId) continue
+    run.cancelled = true
+    run.cancel()
+  }
+}
+
 /** Every subagent currently running, so a fresh window can restore its spinners. */
 export function listRunningSubagents(): SubagentRunView[] {
   return [...runs.values()].map((r) => ({
@@ -160,6 +208,15 @@ export function listRunningSubagents(): SubagentRunView[] {
 export function endSubagentRuns(chatId: string): void {
   for (const run of [...runs.values()]) {
     if (run.subChatId !== chatId && run.parentChatId !== chatId) continue
+    // Now that runs carry a cancel, stop the WORK too rather than only clearing
+    // the registry: a foreground delegate whose session was deleted mid-run used
+    // to keep burning tokens with nowhere left to report.
+    run.cancelled = true
+    try {
+      run.cancel()
+    } catch {
+      // a cancel must never break the teardown loop
+    }
     runs.delete(run.subChatId)
     broadcast({ subChatId: run.subChatId, kind: 'run', state: 'error' })
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -136,6 +136,7 @@ const roxy: RoxyApi = {
   llm: {
     start: (input) => ipcRenderer.invoke(CHANNELS.llmStart, input),
     abort: (requestId) => ipcRenderer.invoke(CHANNELS.llmAbort, requestId),
+    abortSession: (sessionId) => ipcRenderer.invoke(CHANNELS.llmAbortSession, sessionId),
     onDelta: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, payload: LlmDelta): void =>
         callback(payload)
@@ -157,6 +158,7 @@ const roxy: RoxyApi = {
     snapshot: (subChatId) => ipcRenderer.invoke(CHANNELS.subagentSnapshot, subChatId),
     listRunning: () => ipcRenderer.invoke(CHANNELS.subagentListRunning),
     setViewed: (chatId) => ipcRenderer.invoke(CHANNELS.subagentSetViewed, chatId),
+    cancel: (subChatId) => ipcRenderer.invoke(CHANNELS.subagentCancel, subChatId),
     onDelta: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, payload: SubagentDelta): void =>
         callback(payload)

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -9,7 +9,8 @@ import {
   Loader2,
   Repeat,
   RotateCw,
-  Settings
+  Settings,
+  Square
 } from 'lucide-react'
 import type { Chat } from '@shared/types'
 import { useRoxyStore } from '../lib/store'
@@ -75,6 +76,11 @@ export function ChatView(): JSX.Element {
   // the parent agent delegated it — so the only signal is the live run itself.
   const subagentRunning = useRoxyStore((s) =>
     s.activeChatId ? !!s.runningSubagents[s.activeChatId] : false
+  )
+  const cancelSubagent = useRoxyStore((s) => s.cancelSubagent)
+  const cancelBackgroundTask = useRoxyStore((s) => s.cancelBackgroundTask)
+  const runningTasks = useRoxyStore((s) =>
+    s.activeChatId ? (s.runningTasks[s.activeChatId] ?? []) : []
   )
 
   const hasContent = messages.length > 0 || (streaming !== null && streaming.length > 0)
@@ -328,14 +334,22 @@ export function ChatView(): JSX.Element {
             ) : (
               <WorkspacePath chat={activeChat} />
             )}
-            {subagentRunning && (
-              <span
-                title="This subagent is working"
-                className="flex shrink-0 items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[11px] text-accent"
+            {subagentRunning && activeChatId && (
+              // Clickable, because this used to be the one running thing in the
+              // app with no way to stop it: a subagent's turn is driven by its
+              // parent, so the composer's Stop was deliberately withheld here
+              // (it had no request of its own to abort) and the session was
+              // simply uninterruptible from its own view.
+              <button
+                onClick={() => void cancelSubagent(activeChatId)}
+                title="Cancel this subagent"
+                className="press-scale group flex shrink-0 items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[11px] text-accent transition-colors hover:bg-accent/20"
               >
-                <Loader2 className="h-3 w-3 animate-spin" />
-                working
-              </span>
+                <Loader2 className="h-3 w-3 animate-spin group-hover:hidden" />
+                <Square className="hidden h-2.5 w-2.5 fill-current group-hover:block" />
+                <span className="group-hover:hidden">working</span>
+                <span className="hidden group-hover:inline">cancel</span>
+              </button>
             )}
             {hasSessionInfo && (
               <button
@@ -362,14 +376,25 @@ export function ChatView(): JSX.Element {
                 />
               </button>
             )}
-            {backgroundTaskCount > 0 && (
-              <span
-                title={`${backgroundTaskCount} background subagent${backgroundTaskCount === 1 ? '' : 's'} running`}
-                className="flex shrink-0 items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[11px] text-accent"
+            {backgroundTaskCount > 0 && activeChatId && (
+              // Detached tasks were cancellable in main from day one
+              // (`tasks:cancel`) but nothing ever called it — this badge counted
+              // them and offered no way out. Cancels them all: they're detached
+              // by definition, so "stop the thing I didn't ask for" is the whole
+              // interaction, and per-task control lives on the task card.
+              <button
+                onClick={() => {
+                  for (const t of runningTasks) void cancelBackgroundTask(activeChatId, t.jobId)
+                }}
+                title={`Cancel ${backgroundTaskCount} background subagent${
+                  backgroundTaskCount === 1 ? '' : 's'
+                }`}
+                className="press-scale group flex shrink-0 items-center gap-1 rounded-md bg-accent/10 px-1.5 py-0.5 text-[11px] text-accent transition-colors hover:bg-accent/20"
               >
-                <Loader2 className="h-3 w-3 animate-spin" />
+                <Loader2 className="h-3 w-3 animate-spin group-hover:hidden" />
+                <Square className="hidden h-2.5 w-2.5 fill-current group-hover:block" />
                 <span className="tabular-nums">{backgroundTaskCount}</span>
-              </span>
+              </button>
             )}
           </div>
         )}
@@ -518,10 +543,13 @@ export function ChatView(): JSX.Element {
         </div>
       )}
 
+      {/* A subagent's session can now be stopped from its own composer: the Stop
+          cancels the DELEGATE (there is no local request here to abort), which
+          is what the button visibly means in this view. */}
       <Composer
         onSend={submit}
         sending={sending || subagentRunning}
-        onStop={subagentRunning ? undefined : stop}
+        onStop={subagentRunning && activeChatId ? () => void cancelSubagent(activeChatId) : stop}
       />
 
       <WorkstreamStrip />

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -554,7 +554,9 @@ export function ChatView(): JSX.Element {
       <Composer
         onSend={submit}
         sending={sending || subagentRunning}
-        onStop={subagentRunning && activeChatId ? () => void cancelSubagent(activeChatId) : stop}
+        onStop={
+          subagentRunning && activeChatId ? () => void cancelSubagent(activeChatId) : () => stop()
+        }
       />
 
       <WorkstreamStrip />

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -68,9 +68,15 @@ export function ChatView(): JSX.Element {
   const activeChatId = useRoxyStore((s) => s.activeChatId)
   const chats = useRoxyStore((s) => s.chats)
   const loops = useRoxyStore((s) => s.loops)
-  const backgroundTaskCount = useRoxyStore((s) =>
-    s.activeChatId ? (s.runningTasks[s.activeChatId]?.length ?? 0) : 0
+  // Subscribe to the STORED array, not a defaulted copy. A selector returning
+  // `?? []` builds a new array every call, so zustand's Object.is check never
+  // matches and the component re-renders forever ("getSnapshot should be
+  // cached" -> "Maximum update depth exceeded"). undefined is a stable value;
+  // the empty-array default belongs below, outside the subscription.
+  const runningTasks = useRoxyStore((s) =>
+    s.activeChatId ? s.runningTasks[s.activeChatId] : undefined
   )
+  const backgroundTaskCount = runningTasks?.length ?? 0
   // A subagent working in ITS OWN session. Tracked separately from `sending`
   // (which is per-chat local-send state): nobody "sent" this turn from the UI —
   // the parent agent delegated it — so the only signal is the live run itself.
@@ -79,9 +85,6 @@ export function ChatView(): JSX.Element {
   )
   const cancelSubagent = useRoxyStore((s) => s.cancelSubagent)
   const cancelBackgroundTask = useRoxyStore((s) => s.cancelBackgroundTask)
-  const runningTasks = useRoxyStore((s) =>
-    s.activeChatId ? (s.runningTasks[s.activeChatId] ?? []) : []
-  )
 
   const hasContent = messages.length > 0 || (streaming !== null && streaming.length > 0)
   // `messages` is cleared the instant you click a session and refilled only after
@@ -384,7 +387,9 @@ export function ChatView(): JSX.Element {
               // interaction, and per-task control lives on the task card.
               <button
                 onClick={() => {
-                  for (const t of runningTasks) void cancelBackgroundTask(activeChatId, t.jobId)
+                  for (const t of runningTasks ?? []) {
+                    void cancelBackgroundTask(activeChatId, t.jobId)
+                  }
                 }}
                 title={`Cancel ${backgroundTaskCount} background subagent${
                   backgroundTaskCount === 1 ? '' : 's'

--- a/src/renderer/src/components/Composer.tsx
+++ b/src/renderer/src/components/Composer.tsx
@@ -39,6 +39,15 @@ export function Composer({
   }
 
   const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+    // Escape stops the turn. The button alone was not enough: it hides as soon
+    // as you type (the composer switches to "add to queue"), so drafting a
+    // follow-up while a turn ran left no visible way to stop it — you had to
+    // clear the box first to get the button back. The draft is preserved.
+    if (event.key === 'Escape' && sending && onStop) {
+      event.preventDefault()
+      onStop()
+      return
+    }
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
       submit()
@@ -125,7 +134,13 @@ export function Composer({
           ref={ref}
           value={value}
           rows={1}
-          placeholder={sending ? 'Queue a follow-up…' : 'Ask Roxy anything… (paste or drop images)'}
+          placeholder={
+            sending
+              ? onStop
+                ? 'Queue a follow-up… (Esc to stop)'
+                : 'Queue a follow-up…'
+              : 'Ask Roxy anything… (paste or drop images)'
+          }
           onChange={(e) => {
             setValue(e.target.value)
             autoGrow()
@@ -158,7 +173,7 @@ export function Composer({
           {showStop ? (
             <button
               onClick={onStop}
-              title="Stop"
+              title="Stop (Esc)"
               className="press-scale flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white text-black hover:bg-white/90"
             >
               <Square className="h-3 w-3 fill-current" />

--- a/src/renderer/src/components/MessageParts.tsx
+++ b/src/renderer/src/components/MessageParts.tsx
@@ -5,6 +5,7 @@ import type { MessagePart } from '@shared/types'
 import { streamSignature } from '@shared/parts'
 import { ToolCall } from './ToolCall'
 import { ThinkingIndicator } from './ThinkingIndicator'
+import { useRoxyStore } from '../lib/store'
 import { cn } from '../lib/cn'
 
 // Fade streamed markdown in as it arrives. `stagger: 0` is deliberate: the
@@ -79,11 +80,22 @@ export function MessageParts({
     [streaming]
   )
 
+  // Selected (not called through `getState()`) so the identity is stable and the
+  // per-card callbacks below stay memo-friendly.
+  const cancelSubagent = useRoxyStore((s) => s.cancelSubagent)
+
   return (
     <div className="flex flex-col gap-1 text-sm leading-relaxed text-text">
       {parts.map((part, i) => {
         const isLast = i === parts.length - 1
         if (part.type === 'tool') {
+          // Only a live `task` card that knows its delegate's session can offer a
+          // cancel. Everything else gets undefined, and ToolCall draws nothing.
+          const subChatId = part.subChatId
+          const cancel =
+            part.tool === 'task' && part.state === 'running' && subChatId
+              ? () => void cancelSubagent(subChatId)
+              : undefined
           return (
             <ToolCall
               key={i}
@@ -93,6 +105,7 @@ export function MessageParts({
               output={part.output}
               image={part.image}
               diff={part.diff}
+              onCancel={cancel}
               nested={part.children}
               // A subagent's transcript renders through this same component, so a
               // nested tool card looks and behaves exactly like a top-level one.

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Plus,
   Repeat,
   Settings as SettingsIcon,
+  Square,
   SquarePen,
   Trash2
 } from 'lucide-react'
@@ -98,6 +99,8 @@ export function Sidebar(): JSX.Element {
   const forkChat = useRoxyStore((s) => s.forkChat)
   const renameChat = useRoxyStore((s) => s.renameChat)
   const sendingChats = useRoxyStore((s) => s.sendingChats)
+  const stop = useRoxyStore((s) => s.stop)
+  const cancelSubagent = useRoxyStore((s) => s.cancelSubagent)
   const loops = useRoxyStore((s) => s.loops)
   const removeLoop = useRoxyStore((s) => s.removeLoop)
   const reorderSessions = useRoxyStore((s) => s.reorderSessions)
@@ -714,7 +717,19 @@ export function Sidebar(): JSX.Element {
                                   )}
                                 >
                                   {sending ? (
-                                    <BrailleSpinner className="shrink-0 text-sm text-accent" />
+                                    // Click the spinner to stop THAT session.
+                                    // `store.stop()` only ever knew the active
+                                    // chat, so a session streaming in the
+                                    // background could not be stopped at all
+                                    // without switching to it first.
+                                    <button
+                                      onClick={() => stop(chat.id)}
+                                      title="Stop this session"
+                                      className="group/stop flex h-4 w-4 shrink-0 items-center justify-center rounded text-accent transition-colors hover:bg-white/10"
+                                    >
+                                      <BrailleSpinner className="text-sm group-hover/stop:hidden" />
+                                      <Square className="hidden h-2 w-2 fill-current group-hover/stop:block" />
+                                    </button>
                                   ) : (
                                     <span
                                       className={cn(
@@ -845,7 +860,19 @@ export function Sidebar(): JSX.Element {
                                           )}
                                         >
                                           {runningSubagents[sub.id] ? (
-                                            <BrailleSpinner className="shrink-0 text-xs text-accent" />
+                                            // Skip one delegate from the sidebar
+                                            // — the fastest path for the "a
+                                            // commit hook spawned a README
+                                            // subagent I don't want" case, with
+                                            // no need to open anything.
+                                            <button
+                                              onClick={() => void cancelSubagent(sub.id)}
+                                              title="Cancel this subagent"
+                                              className="group/cancel flex h-4 w-4 shrink-0 items-center justify-center rounded text-accent transition-colors hover:bg-white/10"
+                                            >
+                                              <BrailleSpinner className="text-xs group-hover/cancel:hidden" />
+                                              <Square className="hidden h-2 w-2 fill-current group-hover/cancel:block" />
+                                            </button>
                                           ) : (
                                             <Hammer className="h-3 w-3 shrink-0 opacity-70" />
                                           )}

--- a/src/renderer/src/components/ToolCall.tsx
+++ b/src/renderer/src/components/ToolCall.tsx
@@ -13,6 +13,7 @@ import {
   Repeat,
   ScanText,
   Search,
+  Square,
   Terminal,
   TriangleAlert,
   Wrench
@@ -140,7 +141,8 @@ export const ToolCall = memo(function ToolCall({
   image,
   diff,
   nested: nestedParts,
-  renderNested
+  renderNested,
+  onCancel
 }: {
   tool: string
   state: 'running' | 'done' | 'error'
@@ -148,6 +150,12 @@ export const ToolCall = memo(function ToolCall({
   output?: string
   image?: string
   diff?: ToolDiff
+  /**
+   * Cancel just this call — supplied only for a running `task` card whose
+   * delegate we can address. Absent means there is nothing honest to offer, and
+   * no button is drawn (a Stop that does nothing is worse than no Stop).
+   */
+  onCancel?: () => void
   /** A subagent's live transcript, for a `task` card. */
   nested?: MessagePart[]
   /**
@@ -224,6 +232,32 @@ export const ToolCall = memo(function ToolCall({
           {showNested && !live && stepCount > 0 && (
             <span className="font-mono text-[10px] tabular-nums text-text-subtle">
               {stepCount} {stepCount === 1 ? 'step' : 'steps'}
+            </span>
+          )}
+          {/* Skip this delegate without stopping the turn — the answer to "a hook
+              spun up a README subagent and I just want it gone". Rendered as a
+              nested <span role="button">, not a <button>: the header is itself a
+              button (expand/collapse) and nesting one is invalid HTML that React
+              warns about and browsers un-nest. Stops propagation so cancelling
+              doesn't also toggle the card open. */}
+          {live && onCancel && (
+            <span
+              role="button"
+              tabIndex={0}
+              title="Cancel this subagent"
+              onClick={(e) => {
+                e.stopPropagation()
+                onCancel()
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter' && e.key !== ' ') return
+                e.preventDefault()
+                e.stopPropagation()
+                onCancel()
+              }}
+              className="press-scale flex h-5 w-5 items-center justify-center rounded text-text-subtle transition-colors hover:bg-white/10 hover:text-text"
+            >
+              <Square className="h-2.5 w-2.5 fill-current" />
             </span>
           )}
           {state === 'running' && <Loader2 className="h-3.5 w-3.5 animate-spin text-text-subtle" />}

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -15,6 +15,7 @@ import type {
   ChatMessage,
   CreateLoopInput,
   LlmEvent,
+  LlmResult,
   ModelInfo,
   RemoteDelta,
   RemoteState,
@@ -186,7 +187,16 @@ interface RoxyStore {
   editQueued: (id: string, content: string, images?: ComposerImage[]) => Promise<void>
   /** Refresh the usage/cost dashboard (called on turn end + when the pill opens). */
   refreshUsage: () => Promise<void>
-  stop: () => void
+  /**
+   * Stop a session's turn. Defaults to the active chat; pass an id to stop a
+   * session that isn't on screen (a background turn used to be unstoppable —
+   * the only Stop button was the composer's, which only ever knew the open one).
+   */
+  stop: (targetChatId?: string) => void
+  /** Cancel ONE running subagent by its session id, leaving its parent turn alive. */
+  cancelSubagent: (subChatId: string) => Promise<void>
+  /** Cancel one detached background task launched by a session. */
+  cancelBackgroundTask: (sessionId: string, jobId: string) => Promise<void>
   /** Start sharing the active session to a phone via the roxy.gg relay. */
   startRemote: () => Promise<void>
   /** Stop sharing + revoke the room/token (Stop sharing). */
@@ -1591,19 +1601,41 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
         setStreaming(parts)
       })
       chatRequests.set(chatId, requestId)
-      const result = await api.llm.start({
-        requestId,
-        sessionId: chatId,
-        providerId: provider.id,
-        model,
-        messages: chatMessages,
-        agentId,
-        reasoning: info?.reasoning ?? false,
-        reasoningEffort: config.reasoningEffort,
-        contextLimit: contextBudget
-      })
-      deltaHandlers.delete(requestId)
-      chatRequests.delete(chatId)
+      // Stop can land during the pre-flight above (ensureModels, token estimate,
+      // compaction, buildChatMessages — all awaited, all before a requestId
+      // exists). Starting the turn anyway is exactly the "I pressed cancel and
+      // it ran regardless" case, so bail here instead.
+      if (stopped()) {
+        deltaHandlers.delete(requestId)
+        chatRequests.delete(chatId)
+        await finishTurn()
+        return
+      }
+      // Every exit from here on must clear the send state. Without the
+      // try/finally a rejected `llm.start` (a main-process throw, a window
+      // race) left `sendingChats[chatId]` true forever: the composer showed a
+      // Stop button for a turn that no longer existed, and clicking it aborted
+      // a requestId that had already been deleted. That is the OTHER half of
+      // the stuck-cancel bug, and it could only be cleared by restarting.
+      let result: LlmResult
+      try {
+        result = await api.llm.start({
+          requestId,
+          sessionId: chatId,
+          providerId: provider.id,
+          model,
+          messages: chatMessages,
+          agentId,
+          reasoning: info?.reasoning ?? false,
+          reasoningEffort: config.reasoningEffort,
+          contextLimit: contextBudget
+        })
+      } catch (e) {
+        result = { ok: false, error: e instanceof Error ? e.message : String(e) }
+      } finally {
+        deltaHandlers.delete(requestId)
+        chatRequests.delete(chatId)
+      }
       if (!result.ok && !stopped()) {
         parts = [
           ...parts,
@@ -1680,12 +1712,44 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     }
   },
 
-  stop: () => {
-    const id = get().activeChatId
+  stop: (targetChatId) => {
+    const id = targetChatId ?? get().activeChatId
     if (!id) return
     set((s) => ({ stopChats: { ...s.stopChats, [id]: true } }))
     const requestId = chatRequests.get(id)
     if (requestId) void api.llm.abort(requestId)
+    // Abort by SESSION as well as by request.
+    //
+    // `chatRequests` is only populated once the turn is actually starting, and a
+    // turn does real work before that — most of all compaction, a full model
+    // call on a long history. Stop pressed in that window used to find no
+    // requestId, do nothing at all, and then have its own flag wiped by
+    // `clearStop` when the turn it failed to stop finished. That is the "cancel
+    // gets stuck" bug. This path always has something to abort, and also
+    // cancels the session's subagents.
+    void api.llm.abortSession(id)
+  },
+
+  cancelSubagent: async (subChatId) => {
+    // Optimistic: the spinner has to go the instant you click, or the button
+    // reads as broken while the run tears itself down. Main is the source of
+    // truth and will broadcast the real end state a moment later.
+    set((s) => {
+      const next = { ...s.runningSubagents }
+      delete next[subChatId]
+      return { runningSubagents: next }
+    })
+    await api.subagents.cancel(subChatId)
+  },
+
+  cancelBackgroundTask: async (sessionId, jobId) => {
+    set((s) => ({
+      runningTasks: {
+        ...s.runningTasks,
+        [sessionId]: (s.runningTasks[sessionId] ?? []).filter((t) => t.jobId !== jobId)
+      }
+    }))
+    await api.tasks.cancel(jobId)
   },
 
   compactConversation: async (targetChatId) => {

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -250,6 +250,24 @@ interface RoxyStore {
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
+/**
+ * Accept a session id only if it really is one.
+ *
+ * Actions shaped `(chatId?: string) => …` are the natural thing to hand
+ * straight to an onClick — and React then calls them with the SyntheticEvent,
+ * which silently becomes the "session" to act on. TypeScript does not catch it:
+ * `(id?: string) => void` is assignable to `() => void`, so `onClick={stop}`
+ * compiles clean. The failure mode is ugly and remote from the cause — the event
+ * keys state as "[object Object]", matches no session, and blows up as
+ * "An object could not be cloned" when it reaches an IPC boundary, leaving the
+ * button looking stuck.
+ *
+ * So every such action funnels its argument through here: anything that is not a
+ * string means "the active session".
+ */
+const asChatId = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
 let loopTickSubscribed = false
 let llmDeltaSubscribed = false
 let taskUpdateSubscribed = false
@@ -1713,7 +1731,8 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   },
 
   stop: (targetChatId) => {
-    const id = targetChatId ?? get().activeChatId
+    // Guarded: a bare `onClick={stop}` hands this the click event. See asChatId.
+    const id = asChatId(targetChatId) ?? get().activeChatId
     if (!id) return
     set((s) => ({ stopChats: { ...s.stopChats, [id]: true } }))
     const requestId = chatRequests.get(id)
@@ -1753,7 +1772,9 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   },
 
   compactConversation: async (targetChatId) => {
-    const chatId = targetChatId ?? get().activeChatId
+    // Same guard as `stop`: this shape is one bare onClick away from sending a
+    // SyntheticEvent over IPC to api.context.compact.
+    const chatId = asChatId(targetChatId) ?? get().activeChatId
     if (!chatId || get().compactingChats[chatId]) return
     const { settings, providers } = get()
     // Compact with the SESSION's own model: compacting must not route a

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -268,6 +268,16 @@ export type LlmEvent =
       tool: string
       title?: string
       input?: Record<string, unknown>
+      /**
+       * For a `task` call: the delegate's own session id.
+       *
+       * Carried beside `input` rather than inside it on purpose — `input` is
+       * replayed verbatim as the model's `tool_calls` arguments on later turns
+       * (see reconstructTurn), and an id the model never passed has no business
+       * in its history. This is UI addressing: it's what lets the card's cancel
+       * button name the one delegate to stop.
+       */
+      subChatId?: string
     }
   | { type: 'tool-delta'; callId: string; chunk: string }
   | {
@@ -665,6 +675,12 @@ export interface RoxyApi {
     /** Stream a completion; text deltas arrive via onDelta. Resolves when done. */
     start(input: LlmStartInput): Promise<LlmResult>
     abort(requestId: string): Promise<void>
+    /**
+     * Stop everything in flight for a session — the streaming turn, any
+     * compaction running ahead of it, and every subagent it spawned. Works even
+     * before a requestId exists, which `abort` cannot.
+     */
+    abortSession(sessionId: string): Promise<void>
     onDelta(callback: (payload: LlmDelta) => void): () => void
   }
   tasks: {
@@ -689,6 +705,12 @@ export interface RoxyApi {
      * session the user is reading. Pass null when the open chat isn't a sub.
      */
     setViewed(chatId: string | null): Promise<void>
+    /**
+     * Cancel ONE running subagent, foreground or background, without touching
+     * the turn that spawned it. Resolves false when nothing was running for that
+     * id (it finished between the click and the call).
+     */
+    cancel(subChatId: string): Promise<boolean>
     /**
      * Subscribe to a subagent's own live stream, keyed by ITS session id, so its
      * individual chat view streams like any other. Returns an unsubscribe fn.

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -91,6 +91,15 @@ export const CHANNELS = {
 
   llmStart: 'llm:start',
   llmAbort: 'llm:abort',
+  /**
+   * renderer -> main: stop EVERYTHING in flight for a session.
+   *
+   * llm:abort needs a requestId, which the renderer only has once the turn is
+   * already streaming — so it cannot cancel the pre-flight work (compaction
+   * above all) that runs first. This is Stop as the user means it, keyed by the
+   * one id the UI always has.
+   */
+  llmAbortSession: 'llm:abortSession',
   /** main -> renderer event carrying a streamed completion chunk */
   llmDelta: 'llm:delta',
 
@@ -109,6 +118,14 @@ export const CHANNELS = {
   subagentListRunning: 'subagent:listRunning',
   /** renderer -> main: which chat is on screen, so a viewed sub session isn't pruned */
   subagentSetViewed: 'subagent:setViewed',
+  /**
+   * renderer -> main: cancel ONE running subagent by its session id.
+   *
+   * Keyed by sub chat id rather than the background job id `tasks:cancel` uses,
+   * because that is the only handle the UI has for a FOREGROUND delegate (which
+   * has no job at all) — and it's the id every subagent surface already knows.
+   */
+  subagentCancel: 'subagent:cancel',
 
   modelsList: 'models:list',
 

--- a/src/shared/parallel.ts
+++ b/src/shared/parallel.ts
@@ -93,9 +93,9 @@ export function partitionTasksByWriteCapability<T>(
  * The returned promise is meant to be held and awaited later, so a caller can
  * run its other (sequential) tools while these are in flight.
  *
- * `aborted()` is polled between writers: once the turn is cancelled we stop
- * LAUNCHING new ones, but results already produced are kept so the caller can
- * still pair every tool_call with a tool result.
+ * `aborted()` is polled between BOTH writers and readers: once the turn is
+ * cancelled we stop LAUNCHING new ones, but results already produced are kept so
+ * the caller can still pair every tool_call with a tool result.
  */
 export async function runTasksByWriteCapability<T, R>(
   tasks: readonly T[],
@@ -108,10 +108,16 @@ export async function runTasksByWriteCapability<T, R>(
 ): Promise<{ task: T; result: R }[]> {
   const { readers, writers } = partitionTasksByWriteCapability(tasks, opts.isWriteCapable)
 
-  const readerWork = mapWithConcurrency(readers, opts.limit, async (t) => ({
-    task: t,
-    result: await opts.run(t)
-  }))
+  // Readers honor the abort too. They used to be launched unconditionally, so
+  // stopping a turn that had fanned out (say) eight explore subagents still
+  // started every one that hadn't been picked up yet — work the user had just
+  // asked to cancel, spending tokens on a turn that was already over.
+  const readerWork = mapWithConcurrency(
+    readers,
+    opts.limit,
+    async (t) => ({ task: t, result: await opts.run(t) }),
+    opts.aborted
+  )
 
   const writerWork = (async (): Promise<{ task: T; result: R }[]> => {
     const out: { task: T; result: R }[] = []
@@ -123,7 +129,10 @@ export async function runTasksByWriteCapability<T, R>(
   })()
 
   const [a, b] = await Promise.all([readerWork, writerWork])
-  return [...a, ...b]
+  // A reader that was never launched (abort) leaves a HOLE in the pool's result
+  // array, since it preserves input positions. Drop those: callers pair results
+  // by id and would otherwise dereference `undefined`.
+  return [...a.filter((r) => r !== undefined), ...b]
 }
 
 /** Coerce an unknown JSON value to a trimmed string, or '' when absent. */
@@ -169,11 +178,16 @@ export function parseTaskInput(rawArgs: string): TaskInput {
  * This is the bounded worker pool behind parallel subagents: it keeps the
  * machine from being swamped when a model fans out many `task` calls, while
  * still overlapping their (mostly network-bound) work.
+ *
+ * `aborted` is polled before each item is picked up. Items never started are
+ * left as holes in the result array (the caller supplies their own placeholder),
+ * which is the same shape as the writer loop's early `break`.
  */
 export async function mapWithConcurrency<T, R>(
   items: readonly T[],
   limit: number,
-  fn: (item: T, index: number) => Promise<R>
+  fn: (item: T, index: number) => Promise<R>,
+  aborted?: () => boolean
 ): Promise<R[]> {
   const n = items.length
   const results = new Array<R>(n)
@@ -182,6 +196,7 @@ export async function mapWithConcurrency<T, R>(
   let next = 0
   async function worker(): Promise<void> {
     for (;;) {
+      if (aborted?.()) return
       const i = next++
       if (i >= n) return
       results[i] = await fn(items[i], i)

--- a/src/shared/parts.ts
+++ b/src/shared/parts.ts
@@ -77,7 +77,8 @@ function foldInto(
         state: 'running',
         title: event.title,
         callId: event.callId,
-        input: event.input
+        input: event.input,
+        subChatId: event.subChatId
       }
     ]
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -202,6 +202,12 @@ export type MessagePart =
       input?: Record<string, unknown>
       /** One-line summary shown on the tool card (e.g. the command run). */
       title?: string
+      /**
+       * For a `task` card: the subagent session it spawned, so the card can
+       * offer to cancel that one delegate (and link to its transcript). Absent
+       * on every other tool, and on task cards from before this existed.
+       */
+      subChatId?: string
       /** Result body, shown when the card is expanded. */
       output?: string
       /** Optional inline image (data URL), e.g. a browser screenshot. */

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -1017,6 +1017,49 @@ check('renderBackgroundStarted warns against polling', /DO NOT poll/i.test(start
 }
 
 {
+  // A `task` card carries its delegate's session id, which is what addresses the
+  // per-subagent cancel button. It must survive the fold, and must NOT be
+  // invented for tools that don't have one.
+  const fold = new PartsFold()
+  fold.apply({
+    type: 'tool-start',
+    callId: 't9',
+    tool: 'task',
+    title: 'Explore: map it',
+    input: { description: 'map it' },
+    subChatId: 'sub-42'
+  })
+  const card = fold.parts[0]
+  check(
+    'fold: a task card keeps its subChatId',
+    card.type === 'tool' && card.subChatId === 'sub-42'
+  )
+  // It is UI addressing, not model history: it must stay OUT of `input`, which
+  // is replayed verbatim as the model's tool_calls arguments next turn.
+  check(
+    'fold: subChatId is not smuggled into the model-facing input',
+    card.type === 'tool' && !('subChatId' in (card.input ?? {}))
+  )
+
+  fold.apply({ type: 'tool-start', callId: 'b1', tool: 'bash', title: 'ls' })
+  const plain = fold.parts[1]
+  check(
+    'fold: a non-task card has no subChatId',
+    plain.type === 'tool' && plain.subChatId === undefined
+  )
+
+  // Resuming a run (opening a subagent session mid-flight) must not lose it.
+  const resumed = new PartsFold()
+  resumed.seed(fold.parts)
+  resumed.apply({ type: 'tool-end', callId: 't9', output: 'done', ok: true })
+  const after = resumed.parts[0]
+  check(
+    'fold: subChatId survives a seed + later tool-end',
+    after.type === 'tool' && after.subChatId === 'sub-42' && after.state === 'done'
+  )
+}
+
+{
   // The point of the feature: a subagent's steps nest INSIDE its task card and
   // never leak into the parent's top-level parts.
   const fold = new PartsFold()
@@ -2277,6 +2320,42 @@ async function main(): Promise<void> {
       })
       check('abort stops launching further writers', ran === 1, String(ran))
       check('...but keeps the result that already completed', out.length === 1)
+    }
+
+    // Readers honor the abort too. They used to be launched unconditionally, so
+    // stopping a fanned-out turn still started every explore subagent that had
+    // not been picked up yet.
+    {
+      let ran = 0
+      let abort = false
+      const out = await runTasksByWriteCapability(['explore', 'explore', 'explore', 'explore'], {
+        isWriteCapable: () => false,
+        limit: 1, // one at a time, so the abort lands between items
+        aborted: () => abort,
+        run: async () => {
+          ran++
+          abort = true
+          return ran
+        }
+      })
+      check('abort stops launching further readers', ran === 1, String(ran))
+      check('...and leaves no undefined holes in the results', out.length === 1)
+      check(
+        '...with the completed result intact',
+        out.every((r) => r !== undefined && r.result !== undefined)
+      )
+    }
+
+    // A reader batch that is aborted before ANY item starts yields nothing at
+    // all rather than an array of holes.
+    {
+      const out = await runTasksByWriteCapability(['explore', 'explore'], {
+        isWriteCapable: () => false,
+        limit: 4,
+        aborted: () => true,
+        run: async () => 1
+      })
+      check('an already-aborted turn launches no readers', out.length === 0)
     }
 
     check(

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -776,6 +776,82 @@ async function main(): Promise<void> {
   check('bash_kill stops the process', bgKill.ok, bgKill.output)
   check('bash_output rejects an unknown id', !(await run('bash_output', { id: 'bg_nope' })).ok)
 
+  // ---- Stop actually interrupts a running tool ----
+  // The turn signal now reaches INSIDE runTool. Before this, the harness could
+  // only check `aborted` BETWEEN tool calls, so pressing Stop during a long
+  // bash did nothing until that command finished on its own (up to 10 minutes)
+  // — the "cancel button gets stuck" bug.
+  {
+    const sleepCmd = process.platform === 'win32' ? 'Start-Sleep -Seconds 30' : 'sleep 30'
+
+    // Aborting mid-flight kills the child and returns promptly.
+    const controller = new AbortController()
+    const startedAt = Date.now()
+    const pending = runTool(
+      'bash',
+      { command: sleepCmd, timeout: 30 },
+      { cwd: ws, signal: controller.signal }
+    )
+    setTimeout(() => controller.abort(), 300)
+    const stoppedRes = await pending
+    const elapsed = Date.now() - startedAt
+    check('bash: an aborted command returns promptly', elapsed < 10_000, `${elapsed}ms`)
+    check('bash: an aborted command is not ok', !stoppedRes.ok, stoppedRes.output)
+    check(
+      'bash: an aborted command reads as stopped, not as a timeout',
+      /stopped/i.test(stoppedRes.output) && !/timed out/i.test(stoppedRes.output),
+      stoppedRes.output
+    )
+
+    // An already-aborted signal must not spawn anything at all.
+    const dead = new AbortController()
+    dead.abort()
+    const skipped = await runTool('bash', { command: bashCmd }, { cwd: ws, signal: dead.signal })
+    check(
+      'bash: an already-stopped turn never spawns the command',
+      !skipped.ok && !skipped.output.includes('roxy-bash-ok'),
+      skipped.output
+    )
+
+    // A signal that never aborts must not change ordinary behaviour.
+    const live = new AbortController()
+    const normal = await runTool('bash', { command: bashCmd }, { cwd: ws, signal: live.signal })
+    check(
+      'bash: a live signal leaves a normal command untouched',
+      normal.ok && normal.output.includes('roxy-bash-ok'),
+      normal.output
+    )
+
+    // Every tool call attaches an abort listener to the SAME turn signal, so a
+    // long turn would leak one per call if they were never removed.
+    const shared = new AbortController()
+    for (let i = 0; i < 12; i++) {
+      await runTool('bash', { command: bashCmd }, { cwd: ws, signal: shared.signal })
+    }
+    const listeners = (
+      shared.signal as AbortSignal & { listenerCount?: (t: string) => number }
+    ).listenerCount?.('abort')
+    check(
+      'bash: abort listeners are cleaned up between calls',
+      listeners === undefined || listeners <= 1,
+      String(listeners)
+    )
+
+    // A cancelled fetch reports as stopped rather than as a network failure.
+    const fetchCtl = new AbortController()
+    fetchCtl.abort()
+    const fetchRes = await runTool(
+      'webfetch',
+      { url: 'https://example.com' },
+      { cwd: ws, signal: fetchCtl.signal }
+    )
+    check(
+      'webfetch: an already-stopped turn reports as stopped',
+      !fetchRes.ok && /stopped/i.test(fetchRes.output),
+      fetchRes.output
+    )
+  }
+
   // ---- background procs are owned per SESSION, not per cwd ----
   // Two sessions open on the SAME folder must not see or kill each other's dev
   // servers, and a subagent's processes must be owned by its parent session.

--- a/test/store-guard.mjs
+++ b/test/store-guard.mjs
@@ -1,0 +1,97 @@
+/**
+ * Regression guard: a store action shaped `(chatId?: string) => …` must survive
+ * being handed a React SyntheticEvent.
+ *
+ * `onStop={stop}` compiled clean — TypeScript lets `(id?: string) => void` be
+ * assigned to `() => void` — and React then called it with the click event,
+ * which became the "session" to stop. That keyed state as "[object Object]",
+ * matched no in-flight request, and threw "An object could not be cloned" when
+ * it hit the IPC boundary, so the turn was never aborted and Stop looked stuck.
+ *
+ * Run: node test/store-guard.mjs
+ */
+import { globSync, readFileSync } from 'node:fs'
+
+// Normalize CRLF up front: this repo checks out with Windows line endings and
+// every multiline pattern below would otherwise silently never match.
+const src = readFileSync(
+  new URL('../src/renderer/src/lib/store.ts', import.meta.url),
+  'utf8'
+).replace(/\r\n/g, '\n')
+
+let failures = 0
+const check = (name, ok, detail = '') => {
+  if (ok) {
+    console.log(`  \u2713 ${name}`)
+  } else {
+    failures++
+    console.log(`  \u2717 ${name}${detail ? ` \u2014 ${detail}` : ''}`)
+  }
+}
+
+console.log('store: event-as-argument guards')
+
+// 1. The guard exists and rejects non-strings.
+check(
+  'asChatId helper is present in the store',
+  /const asChatId = \(value: unknown\): string \| undefined =>/.test(src)
+)
+
+const asChatId = (value) => (typeof value === 'string' ? value : undefined)
+const fakeClickEvent = { nativeEvent: {}, target: {}, currentTarget: {}, type: 'click' }
+check('a SyntheticEvent is rejected', asChatId(fakeClickEvent) === undefined)
+check('a real chat id passes through', asChatId('chat_123') === 'chat_123')
+check('undefined stays undefined', asChatId(undefined) === undefined)
+
+// 2. Both at-risk actions route their argument through the guard. These are the
+//    only two store actions with an optional FIRST parameter — i.e. the only two
+//    a bare handler can poison. Match the IMPLEMENTATION (`name: (arg) => {` or
+//    `name: async (arg) => {`), not the interface declaration above it.
+for (const action of ['stop', 'compactConversation']) {
+  const impl = new RegExp(
+    `^  ${action}: (?:async )?\\([^)]*\\) => \\{\\n([\\s\\S]*?)\\n  \\},`,
+    'm'
+  )
+  const body = src.match(impl)?.[1]
+  check(`${action}: implementation found`, body !== undefined)
+  check(
+    `${action} funnels its argument through asChatId`,
+    body !== undefined && body.includes('asChatId('),
+    'an unguarded optional-id action can swallow a click event'
+  )
+}
+
+// 3. No .tsx passes either action bare into a handler prop. This is the actual
+//    call-site bug; the runtime guard is the safety net behind it.
+//
+//    The real bug lived in a TERNARY BRANCH (`onStop={cond ? () => … : stop}`),
+//    so matching only `on…={stop}` missed it entirely — the first version of
+//    this test passed against the unfixed code. Instead: capture the whole
+//    handler expression, then look for the action name used as a BARE reference
+//    (not `stop(`, not `.stop`, not `stopChats`) anywhere inside it.
+const RISKY = ['stop', 'compactConversation']
+const offenders = []
+for (const file of globSync('src/renderer/src/**/*.tsx')) {
+  const text = readFileSync(file, 'utf8').replace(/\r\n/g, '\n')
+  // Handler prop up to its balancing brace, tolerating newlines and one level
+  // of nested braces (enough for the arrow bodies these expressions contain).
+  for (const m of text.matchAll(/\bon[A-Z]\w*=\{((?:[^{}]|\{[^{}]*\})*)\}/g)) {
+    const expr = m[1]
+    for (const name of RISKY) {
+      // Bare use: the identifier NOT followed by `(` and NOT preceded by `.`
+      // or a word character. `() => stop()` is a call — safe. `: stop` is not.
+      const bare = new RegExp(`(?<![.\\w])${name}(?!\\s*\\()(?![\\w])`)
+      if (bare.test(expr)) {
+        offenders.push(`${file}: on…={…${name}…}`)
+      }
+    }
+  }
+}
+check(
+  'no component passes stop/compactConversation bare to a handler',
+  offenders.length === 0,
+  offenders.join(', ')
+)
+
+console.log(failures === 0 ? '\nSTORE GUARD OK' : `\nSTORE GUARD FAILED \u2014 ${failures} failing`)
+process.exit(failures === 0 ? 0 : 1)


### PR DESCRIPTION
Two related complaints: the cancel button sometimes did nothing, and a subagent spun up by a commit hook couldn't be skipped without killing the whole turn.

## Stop was stuck for four independent reasons

**1. The turn's `AbortSignal` never reached a tool.** `ToolContext` had no `signal` field at all, so the harness could only check `aborted` *between* tool calls — pressing Stop during a 10-minute `bash` or a hung `webfetch` did nothing observable until that call returned on its own. The signal now threads into `runTool`: `bash` kills its process tree, `webfetch`/`websearch`/skill-install abort their requests, and browser/MCP/lsp calls (which take no signal) stop being *waited on* so the turn can end.

**2. Compaction ran on a never-aborted signal** — literally `new AbortController().signal` — and it runs *ahead* of the turn it makes room for.

**3. The renderer only learned a `requestId` after that pre-flight.** Stop pressed during it found nothing to abort, then had its own flag wiped by `clearStop()` when the turn it failed to stop finished. Added `llm:abortSession`, keyed by session id, which always has something to abort.

**4. `await api.llm.start(...)` had no try/catch.** A rejected invoke left `sendingChats[chatId]` true *forever*: a permanent Stop button aborting an already-deleted requestId, clearable only by restarting.

## Cancelling one subagent

Each delegate now gets its own `AbortController` chained to its parent's signal, so cancelling one leaves the turn running and reports back a "cancelled, don't retry" result. Cancel buttons on the task card, the sidebar spinner, the sub session's own header/composer (which previously had **no** Stop at all), and the background-task badge — `tasks:cancel` existed in main but nothing ever called it.

`Esc` now stops too, since the button hides as soon as you type a follow-up.

## Also fixed along the way

- An aborted **foreground** subagent was recorded as `completed`, and its truncated report handed to the parent model as a real answer. The background path already guarded this; the more common path didn't.
- Deleting a session mid-run cleared the registry without stopping the work.
- Aborting a fanned-out turn still launched every queued reader subagent.
- Stop only ever worked on the *active* chat, so a background session couldn't be stopped without switching to it.

## Two self-inflicted bugs, caught and fixed in follow-up commits

Both were introduced by the first commit here and are worth calling out:

- **Infinite render loop** (`c9653d8`) — the new badge selector returned `s.runningTasks[id] ?? []`, allocating a fresh array on every call. zustand compares with `Object.is`, so it never matched: *"getSnapshot should be cached"* → *"Maximum update depth exceeded"*, taking down the chat pane.
- **Stop swallowed the click event** (`ca787ed`) — `onStop={... : stop}` passed the action bare into a handler, so React called it with the `SyntheticEvent`. Once `stop` took an optional `targetChatId`, that event *became* the session: state keyed as `"[object Object]"`, no request matched, and `abortSession(event)` threw **"An object could not be cloned"** at the IPC boundary. TypeScript couldn't catch it — `(id?: string) => void` is assignable to `() => void`.

The second is fixed at both ends: the call site wraps (`() => stop()`), and both store actions with an optional first parameter (`stop`, `compactConversation`) funnel through an `asChatId` guard.

## Testing

- `test/smoke.ts` — 7 new checks proving an aborted `bash` dies in <10s rather than 30, never spawns when already stopped, reports as *stopped* rather than *timed out*, and doesn't leak abort listeners across calls.
- `test/shared.ts` — reader-abort behaviour and `subChatId` surviving the parts fold. 687 checks pass.
- `test/store-guard.mjs` (new, `npm run smoke:store`) — asserts both at-risk actions use the guard and that no `.tsx` passes either bare to a handler.

One note on that last file: its **first version passed against the unfixed code**, because it only matched `on…={stop}` and the real bug lived in a ternary branch. It now scans the whole handler expression for a bare reference, and is verified to fail when the original line is reintroduced.

Both typechecks and the full build pass. `smoke:app` has one pre-existing failure (`a session without a port does not set PORT`) that also fails on `main` — the dev machine has a `PORT` env var set.
