### PR TITLE
Download through Chromium's network stack, and allow a manual install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.70",
+      "version": "0.0.71",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -443,6 +443,17 @@ export function registerIpc(): void {
     return cliproxy.status()
   })
   ipcMain.handle(CHANNELS.cliproxyStop, () => cliproxy.stop())
+  ipcMain.handle(CHANNELS.cliproxyInstallFile, async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    const filters = [
+      { name: 'CLIProxyAPI release', extensions: process.platform === 'win32' ? ['zip'] : ['gz'] }
+    ]
+    const result = win
+      ? await dialog.showOpenDialog(win, { properties: ['openFile'], filters })
+      : await dialog.showOpenDialog({ properties: ['openFile'], filters })
+    if (result.canceled || result.filePaths.length === 0) return cliproxy.status()
+    return cliproxy.installFromFile(result.filePaths[0])
+  })
 
   // ---- dialogs ----
   ipcMain.handle(CHANNELS.dialogOpenWorkspace, async (event) => {

--- a/src/main/services/cliproxy.ts
+++ b/src/main/services/cliproxy.ts
@@ -248,30 +248,18 @@ async function downloadAndExtract(asset: string, expected: string): Promise<void
     })
     await pipeline(source, out)
 
-    // Length check first: nearly free, and it names the actual problem
-    // ("stopped early") instead of the generic checksum failure that a short
-    // file would otherwise produce.
-    const written = (await fsp.stat(archive)).size
-    if (total > 0 && written !== total) {
-      throw new Error(
-        `The download stopped early (${written} of ${total} bytes) — usually a network blip.`
-      )
-    }
-
     // Verify the FILE ON DISK, not the bytes that streamed past on the way in.
     //
     // Hashing the stream was a real bug: it attests to what was RECEIVED, while
     // tar extracts what was WRITTEN. Anything that corrupts the file after the
-    // socket — a short write, a full disk, an antivirus scanner rewriting the
-    // temp file — sails straight through a stream hash and then explodes inside
-    // tar as "ZIP decompression failed (-5)", which reads like a broken release
-    // rather than a broken download. Hash what we are about to execute.
+    // socket — a short write, a full disk, a scanner rewriting the temp file —
+    // sails straight through a stream hash and then explodes inside tar as
+    // "ZIP decompression failed (-5)", which reads like a broken release rather
+    // than a broken download. Hash what we are about to execute.
+    const written = (await fsp.stat(archive)).size
     const actual = await sha256OfFile(archive)
     if (actual !== expected) {
-      throw new Error(
-        'The downloaded file is corrupt (checksum mismatch). This is usually a network or ' +
-          'antivirus problem rather than a bad release.'
-      )
+      throw new Error(await describeBadDownload(archive, written, total, received))
     }
 
     // Extract into a temp dir, then swap it into place, so an interrupted
@@ -305,6 +293,91 @@ async function downloadAndExtract(asset: string, expected: string): Promise<void
   } finally {
     await fsp.rm(staging, { recursive: true, force: true }).catch(() => undefined)
   }
+}
+
+/**
+ * Explain a failed integrity check by INSPECTING the file, rather than asserting
+ * a cause we never checked.
+ *
+ * The first version of this message blamed "network or antivirus" unconditionally.
+ * That was a guess dressed as a diagnosis: it sent people to disable their AV for
+ * what is usually a captive portal or a TLS-inspecting proxy handing back an HTML
+ * error page. The bytes on disk already say which it was, so read them.
+ */
+// Exported for the integration test: the whole point of this function is the
+// message it produces, so that message needs to be assertable.
+export async function describeBadDownload(
+  archive: string,
+  written: number,
+  total: number,
+  received: number
+): Promise<string> {
+  const head = Buffer.alloc(512)
+  let sniffed = 0
+  try {
+    const fh = await fsp.open(archive, 'r')
+    try {
+      sniffed = (await fh.read(head, 0, head.length, 0)).bytesRead
+    } finally {
+      await fh.close()
+    }
+  } catch {
+    // Unreadable is itself informative, but not worth failing over here.
+  }
+  const text = head.subarray(0, sniffed).toString('utf8')
+
+  // An intercepting proxy or captive portal returns a page, not an archive.
+  if (/^\s*(<!doctype|<html|\{|<\?xml)/i.test(text)) {
+    return (
+      'The download returned a web page instead of the release file. A proxy, VPN, or ' +
+      'network sign-in page is intercepting the request to github.com.'
+    )
+  }
+
+  // Archives have stable magic bytes; a wrong one means substituted content.
+  const isZip = head[0] === 0x50 && head[1] === 0x4b
+  const isGzip = head[0] === 0x1f && head[1] === 0x8b
+  const wantsZip = archive.endsWith('.zip')
+  if (sniffed > 0 && ((wantsZip && !isZip) || (!wantsZip && !isGzip))) {
+    return (
+      'The downloaded file is not a valid archive — something replaced its contents ' +
+      'in transit (usually a proxy or content filter).'
+    )
+  }
+
+  // Order matters here: these overlap, and the most specific cause has to be
+  // tested first or it can never be reported.
+  //
+  // A short write (we received N bytes but only M reached the file) is the one
+  // case that genuinely implicates local software - antivirus holding the handle,
+  // or a full disk. Check it before the length comparison, which would otherwise
+  // absorb it and blame the network.
+  if (written !== received) {
+    return (
+      `The file was damaged while being written (${received} bytes downloaded, ${written} on disk). ` +
+      'Antivirus software or a full disk is the usual cause.'
+    )
+  }
+
+  // The transfer itself ended early.
+  if (total > 0 && written !== total) {
+    return `The download stopped early (${written} of ${total} bytes). This is usually a network drop.`
+  }
+
+  // No content-length to compare against - typically a proxy that re-chunked the
+  // response. Say exactly that rather than asserting a cause we cannot see.
+  if (total === 0) {
+    return (
+      `The download is incomplete or damaged (${written} bytes received, and the server ` +
+      'sent no length to check against). This usually means a proxy altered the response.'
+    )
+  }
+
+  // Full length, correct shape, wrong hash: genuinely different bytes.
+  return (
+    'The downloaded file failed its integrity check. The bytes arrived intact but do not ' +
+    'match the published checksum, so it was modified in transit.'
+  )
 }
 
 /** sha256 of a file's actual contents on disk. */

--- a/src/main/services/cliproxy.ts
+++ b/src/main/services/cliproxy.ts
@@ -39,7 +39,7 @@ import { pipeline } from 'node:stream/promises'
 import { Readable } from 'node:stream'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, net as electronNet } from 'electron'
 import { CHANNELS } from '../../shared/ipc'
 import {
   CLIPROXY_VERSION,
@@ -63,6 +63,28 @@ const HOST = '127.0.0.1'
 /** Port window for the sidecar, above Roxy's per-session dev-server range (3100-3999). */
 const PORT_RANGE_START = 8317
 const PORT_RANGE_END = 8399
+
+/**
+ * sha256 of each pinned release asset, recorded when CLIPROXY_VERSION was set.
+ *
+ * Normally the digest comes from the release's checksums.txt. These exist for
+ * the offline case: when github.com is unreachable, a manual install still has
+ * something to verify against instead of being waved through.
+ */
+const PINNED_SHA256: Record<string, string> = {
+  'CLIProxyAPI_7.2.112_windows_amd64.zip':
+    'e2a59965f73e5e32c00cb711a09412f8a7898ca8c10a4e682bb963dafde764f4',
+  'CLIProxyAPI_7.2.112_windows_aarch64.zip':
+    '23225aecfcdd4c680e6c3eda8e74f9bee16457bd4249d6b30e9f70185e14b550',
+  'CLIProxyAPI_7.2.112_darwin_aarch64.tar.gz':
+    'd8e41dd24f7f1ab68ed57d1637a928a13e7d217268093aa7d2177cf95010feff',
+  'CLIProxyAPI_7.2.112_darwin_amd64.tar.gz':
+    'c9c1c36e7f134bb43e4155321d3c75037a4ba6c3173e8c6cfa70caff49903a55',
+  'CLIProxyAPI_7.2.112_linux_amd64.tar.gz':
+    'a64de846ac2920b82cfbdfac988a3ae4f637eae9d2ff2fe00e4022cd451ca6e7',
+  'CLIProxyAPI_7.2.112_linux_aarch64.tar.gz':
+    '254bb551ac71eb54720a6ee848ca8de559cdee5feb2dc1e44dbda59a03233220'
+}
 
 /**
  * Download attempts before giving up. A corrupt archive is usually transient
@@ -175,6 +197,46 @@ async function isInstalled(): Promise<boolean> {
 }
 
 /**
+ * Fetch through Chromium's network stack instead of Node's.
+ *
+ * Node's global `fetch` knows nothing about the machine's proxy configuration or
+ * the enterprise root certificates in the OS trust store. On a corporate network,
+ * a VPN, or behind TLS inspection, that is the difference between a working
+ * download and a mangled one — which is precisely the failure this whole code
+ * path keeps tripping over.
+ *
+ * Electron's `net` module uses Chromium, so it picks up system proxy settings
+ * (including PAC scripts) and the OS certificate store for free.
+ */
+async function netFetch(url: string): Promise<Response> {
+  // net.fetch is only usable once the app is ready; every caller here is well
+  // past that, but guard rather than throw a confusing internal error.
+  if (!app.isReady()) return fetch(url)
+  return electronNet.fetch(url)
+}
+
+/**
+ * Fetch a URL, falling back to the other network stack when the first fails.
+ *
+ * Neither stack is strictly better. Chromium handles proxies and enterprise
+ * roots; Node's is unaffected by Chromium's own policy quirks. Trying both turns
+ * "this environment is unsupported" into "one of them worked", which for a
+ * download that is otherwise a dead end is worth the extra round trip.
+ */
+async function fetchWithFallback(url: string): Promise<Response> {
+  try {
+    const res = await netFetch(url)
+    if (res.ok) return res
+    // A non-2xx from Chromium may be an intercepting proxy; Node might see past
+    // it. Fall through rather than accept the failure.
+    const viaNode = await fetch(url)
+    return viaNode.ok ? viaNode : res
+  } catch {
+    return fetch(url)
+  }
+}
+
+/**
  * Download + verify + extract the pinned release, retrying a bad download.
  *
  * Retrying matters more than it looks. What this guards against is a corrupt
@@ -197,7 +259,7 @@ async function install(): Promise<void> {
 
   // Fetched once: it describes the pinned release, so it cannot change between
   // attempts.
-  const sumsRes = await fetch(checksumsUrl())
+  const sumsRes = await fetchWithFallback(checksumsUrl())
   if (!sumsRes.ok) throw new Error(`Couldn't fetch checksums (${sumsRes.status}).`)
   const expected = sha256For(await sumsRes.text(), asset)
   if (!expected) throw new Error(`The release doesn't list a checksum for ${asset}.`)
@@ -231,7 +293,7 @@ async function downloadAndExtract(asset: string, expected: string): Promise<void
   const staging = await fsp.mkdtemp(join(tmpdir(), 'roxy-cliproxy-'))
   const archive = join(staging, asset)
   try {
-    const res = await fetch(releaseAssetUrl(asset))
+    const res = await fetchWithFallback(releaseAssetUrl(asset))
     if (!res.ok || !res.body) throw new Error(`Download failed (${res.status}).`)
     const total = Number(res.headers.get('content-length') || 0)
     let received = 0
@@ -850,6 +912,80 @@ export async function listProxyModels(): Promise<{ id: string; name?: string }[]
   } catch {
     return []
   }
+}
+
+/**
+ * Install from a file the user already has, bypassing the download entirely.
+ *
+ * The escape hatch. Some networks cannot be fixed from inside the app: a proxy
+ * that rewrites binaries, a filter that blocks github.com outright, an
+ * air-gapped machine. Retries and a second network stack do not help there, and
+ * without this the feature is simply unavailable — with no way out.
+ *
+ * The archive still has to match the pinned release's checksum. A local file is
+ * a different delivery route, not a reason to run unverified code.
+ */
+export async function installFromFile(archivePath: string): Promise<CliProxyState> {
+  return enqueue(async () => {
+    const asset = releaseAsset(process.platform, process.arch)
+    if (!asset) throw new Error('Codex sign-in is unavailable on this platform.')
+
+    update({ status: 'downloading', progress: 50, error: undefined })
+    try {
+      const sumsRes = await fetchWithFallback(checksumsUrl())
+      let expected: string | null = null
+      if (sumsRes.ok) expected = sha256For(await sumsRes.text(), asset)
+
+      // The checksums file lives on the same host that may be blocked. Fall back
+      // to the digest recorded at pin time so an offline install still verifies.
+      const want = expected ?? PINNED_SHA256[asset]
+      if (!want) {
+        throw new Error("Couldn't determine the expected checksum for this platform.")
+      }
+
+      const actual = await sha256OfFile(archivePath)
+      if (actual !== want) {
+        throw new Error(
+          `That file doesn't match the expected ${asset} for v${CLIPROXY_VERSION}. ` +
+            'Download it from the CLIProxyAPI releases page and try again.'
+        )
+      }
+
+      const staging = await fsp.mkdtemp(join(tmpdir(), 'roxy-cliproxy-local-'))
+      try {
+        const extracted = join(staging, 'x')
+        await fsp.mkdir(extracted, { recursive: true })
+        await extract(archivePath, extracted)
+
+        const staged = join(
+          extracted,
+          process.platform === 'win32' ? 'cli-proxy-api.exe' : 'cli-proxy-api'
+        )
+        try {
+          await fsp.access(staged)
+        } catch {
+          throw new Error("That archive didn't contain the expected cli-proxy-api binary.")
+        }
+
+        const dest = installDir()
+        await fsp.rm(dest, { recursive: true, force: true })
+        await fsp.mkdir(join(dest, '..'), { recursive: true })
+        await fsp.rename(extracted, dest)
+        if (process.platform !== 'win32') {
+          await fsp.chmod(binPath(), 0o755).catch(() => undefined)
+        }
+      } finally {
+        await fsp.rm(staging, { recursive: true, force: true }).catch(() => undefined)
+      }
+
+      update({ status: 'stopped', progress: 100 })
+      return state
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      update({ status: 'not-installed', progress: 0, error: message })
+      throw e
+    }
+  })
 }
 
 /** Kill the sidecar on app quit. Best-effort and synchronous — quit won't wait. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -104,6 +104,7 @@ const roxy: RoxyApi = {
     login: () => ipcRenderer.invoke(CHANNELS.cliproxyLogin),
     signOut: (file) => ipcRenderer.invoke(CHANNELS.cliproxySignOut, file),
     stop: () => ipcRenderer.invoke(CHANNELS.cliproxyStop),
+    installFromFile: () => ipcRenderer.invoke(CHANNELS.cliproxyInstallFile),
     onState: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, state: CliProxyState): void =>
         callback(state)

--- a/src/renderer/src/components/CodexSetup.tsx
+++ b/src/renderer/src/components/CodexSetup.tsx
@@ -58,6 +58,28 @@ export function CodexSetup({ onConnected }: { onConnected: () => void }): JSX.El
     }
   }
 
+  /**
+   * Escape hatch for networks that block or rewrite the download: the user
+   * supplies the archive themselves, then sign-in continues as normal.
+   */
+  const installManually = async (): Promise<void> => {
+    setBusy(true)
+    setError(null)
+    try {
+      const next = await api.cliproxy.installFromFile()
+      // A cancelled picker leaves the state untouched - don't claim success.
+      if (next.status === 'not-installed') {
+        if (next.error) setError(next.error)
+        return
+      }
+      await signIn()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const connected = state.accounts.length > 0
 
   return (
@@ -83,7 +105,22 @@ export function CodexSetup({ onConnected }: { onConnected: () => void }): JSX.El
 
       {busy && <Progress state={state} />}
 
-      {error && <p className="text-xs text-danger">{error}</p>}
+      {error && (
+        <div className="flex flex-col gap-2">
+          <p className="text-xs text-danger">{error}</p>
+          {/* Only offered after a failure. Some networks rewrite or block the
+              download outright, and retrying cannot fix that — but the user can
+              fetch the file another way. It is still checksum-verified. */}
+          <button
+            type="button"
+            onClick={installManually}
+            disabled={busy}
+            className="self-start text-xs text-text-subtle underline-offset-2 transition-colors hover:text-text hover:underline disabled:opacity-40"
+          >
+            Download blocked? Install from a file instead
+          </button>
+        </div>
+      )}
 
       <Button variant="primary" onClick={signIn} disabled={busy}>
         {busy ? (

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -653,6 +653,12 @@ export interface RoxyApi {
     signOut(file: string): Promise<CliProxyState>
     /** Stop the local proxy (keeps the install and the signed-in accounts). */
     stop(): Promise<CliProxyState>
+    /**
+     * Install from an archive the user downloaded themselves, for networks that
+     * block or rewrite the download. Opens a file picker; the archive still has
+     * to match the pinned release's checksum.
+     */
+    installFromFile(): Promise<CliProxyState>
     /** Subscribe to sidecar state pushes; returns an unsubscribe fn. */
     onState(callback: (state: CliProxyState) => void): () => void
   }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -68,6 +68,8 @@ export const CHANNELS = {
   cliproxyLogin: 'cliproxy:login',
   cliproxySignOut: 'cliproxy:signOut',
   cliproxyStop: 'cliproxy:stop',
+  /** install from a user-picked archive (blocked networks / air-gapped) */
+  cliproxyInstallFile: 'cliproxy:installFile',
   /** main -> renderer: sidecar install/run status changed */
   cliproxyState: 'cliproxy:state',
 

--- a/test/cliproxy.ts
+++ b/test/cliproxy.ts
@@ -25,6 +25,7 @@ import { app } from 'electron'
 import {
   baseUrl,
   disconnect,
+  describeBadDownload,
   ensureRunning,
   extract,
   listProxyModels,
@@ -215,6 +216,72 @@ async function main(): Promise<void> {
       friendly
     )
     check('extract() does not leak tar internals', !/-5|Unknown error/.test(friendly), friendly)
+  }
+
+  // ---- a failed integrity check must DIAGNOSE, not guess ----
+  //
+  // The first version of this message blamed "network or antivirus"
+  // unconditionally. That is a guess wearing a diagnosis's clothes: it sends
+  // people to disable their AV for what is usually a captive portal or a
+  // TLS-inspecting proxy. The bytes on disk already say which it was, so these
+  // assert that each distinct failure gets its own accurate explanation.
+  {
+    const d = path.join(tmp, 'diagnosis')
+    await fs.mkdir(d, { recursive: true })
+
+    // A captive portal / intercepting proxy answers with a web page.
+    const portal = path.join(d, 'portal.zip')
+    await fs.writeFile(portal, '<!DOCTYPE html>\n<html><body>Sign in</body></html>')
+    const mPortal = await describeBadDownload(portal, 48, 48, 48)
+    check('captive portal is named as interception', /proxy, VPN, or network sign-in/.test(mPortal))
+    check('captive portal does not blame antivirus', !/antivirus/i.test(mPortal), mPortal)
+
+    // Content replaced with something that is not an archive at all.
+    const junk = path.join(d, 'junk.zip')
+    await fs.writeFile(junk, Buffer.alloc(2048, 0x41))
+    check(
+      'substituted content is named as a replaced archive',
+      /not a valid archive/.test(await describeBadDownload(junk, 2048, 2048, 2048))
+    )
+
+    // A real zip header, but the transfer ended early.
+    const zip = path.join(d, 'short.zip')
+    await fs.writeFile(
+      zip,
+      Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.alloc(1000)])
+    )
+    const mShort = await describeBadDownload(zip, 1004, 20854695, 1004)
+    check('a truncated download reports both byte counts', /1004 of 20854695/.test(mShort))
+    check('a truncated download does not blame antivirus', !/antivirus/i.test(mShort), mShort)
+
+    // THE REPORTED CASE. With no content-length (a proxy that re-chunks the
+    // response) the length check cannot fire, and the old code fell through to
+    // a flat antivirus claim with nothing behind it.
+    const mNoLen = await describeBadDownload(zip, 1004, 0, 1004)
+    check(
+      'a missing content-length is admitted, not papered over',
+      /no length to check against/.test(mNoLen)
+    )
+    check('a missing content-length points at the proxy', /proxy/.test(mNoLen), mNoLen)
+
+    // Downloaded N but only M reached disk: the one case that really does
+    // implicate local software.
+    const mWrite = await describeBadDownload(zip, 1004, 20854695, 20854695)
+    check(
+      'a short write reports downloaded vs on-disk',
+      /20854695 bytes downloaded, 1004 on disk/.test(mWrite)
+    )
+    check('a short write is where antivirus is named', /Antivirus/.test(mWrite))
+
+    // Full length, right shape, wrong hash.
+    check(
+      'intact-but-wrong-hash is named as modification in transit',
+      /modified in transit/.test(await describeBadDownload(zip, 1004, 1004, 1004))
+    )
+
+    // If several shapes collapse to one message this is theatre, not diagnosis.
+    const messages = new Set([mPortal, mShort, mNoLen, mWrite])
+    check('the failure modes stay distinguishable', messages.size === 4, `${messages.size}/4`)
   }
 }
 

--- a/test/cliproxy.ts
+++ b/test/cliproxy.ts
@@ -27,6 +27,7 @@ import {
   disconnect,
   describeBadDownload,
   ensureRunning,
+  installFromFile,
   extract,
   listProxyModels,
   localApiKey,
@@ -282,6 +283,33 @@ async function main(): Promise<void> {
     // If several shapes collapse to one message this is theatre, not diagnosis.
     const messages = new Set([mPortal, mShort, mNoLen, mWrite])
     check('the failure modes stay distinguishable', messages.size === 4, `${messages.size}/4`)
+  }
+
+  // ---- manual install (the escape hatch for blocked networks) ----
+  //
+  // Retries and a second network stack cannot help a network that blocks
+  // github.com outright, so the user can supply the archive themselves. It must
+  // still be checksum-verified: a different delivery route is not a reason to
+  // run unverified code.
+  {
+    const d = path.join(tmp, 'manual')
+    await fs.mkdir(d, { recursive: true })
+
+    const bogus = path.join(d, 'bogus.zip')
+    await fs.writeFile(bogus, Buffer.alloc(4096, 0x42))
+    let rejected = ''
+    try {
+      await installFromFile(bogus)
+    } catch (e) {
+      rejected = e instanceof Error ? e.message : String(e)
+    }
+    check('a mismatched archive is refused', rejected.length > 0)
+    check(
+      '...and the message names what was expected',
+      /doesn't match the expected/.test(rejected),
+      rejected
+    )
+    check('...and nothing was installed from it', (await status()).status !== 'running')
   }
 }
 


### PR DESCRIPTION
Follow-up to #40 for the download failures hitting a real machine. **This is the one to test.**

## What I checked before changing anything

The transfer itself is fine. 5 runs through Node's `fetch`, 3 through Electron, plus the real `install()` - all byte-exact against the published checksum. So the problem is the *environment* between the app and github.com, and no amount of retrying fixes that.

## Two changes

**1. Fetch through Chromium instead of Node.** Node's `fetch` ignores the machine's proxy configuration and the enterprise root certificates in the OS trust store. Electron's `net` uses Chromium, which honours both (including PAC scripts) - on a corporate network, a VPN, or behind TLS inspection that is the whole difference. Neither stack strictly dominates, so both are tried before giving up.

Verified `net.fetch` downloads the real 20MB asset byte-identically to Node's, so the fallback can't swap a good download for a bad one.

**2. "Install from a file" escape hatch.** Some networks can't be fixed from inside the app at all - a filter that blocks github.com, a proxy that rewrites binaries, an air-gapped machine. The user downloads the archive however they like and points Roxy at it.

It is still checksum-verified. Supplying the file by hand is a different delivery route, not permission to run unverified code. When `checksums.txt` is itself unreachable, it falls back to digests recorded at pin time. The option only appears **after a failure**, so the normal path stays one button.

This branch also carries the diagnosis commit that missed the #40 merge - the error message now inspects the file rather than blaming "network or antivirus" unconditionally.

## On bundling the binary instead

It came up, and it is a reasonable instinct - but I would not. CLIProxyAPI ships roughly **daily** (12 releases in the last 6 days), so bundling means chasing their cadence with Roxy releases or shipping a stale proxy. It also adds ~20MB per installer and makes macOS notarization harder, since the binary is unsigned and would become a nested binary we have to sign ourselves.

And it would not have fixed this: the same network that mangles a GitHub download also affects the Roxy installer, auto-updates, and models.dev. Bundling hides one symptom of a broader problem. Worth revisiting if Roxy ever targets air-gapped environments, where it becomes the right call.

## Testing

`smoke:cliproxy` 42 ? **56 checks**, including the manual-install path and its rejection of a mismatched archive. `typecheck`, `smoke:shared` (706), and `smoke:store` pass.

## What to look for

If the Chromium stack fixes it, sign-in just works. If it does not, the error should now **name the actual cause** - a proxy, a captive portal, a short write - instead of guessing, and the "Download blocked? Install from a file instead" link appears underneath as a way through regardless.