### PR TITLE
Open the OAuth callback listener before sending the user to the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",

--- a/src/main/services/cliproxy.ts
+++ b/src/main/services/cliproxy.ts
@@ -104,6 +104,9 @@ const LOGIN_POLL_MS = 1_000
 /** Codex's OAuth callback listener, opened by the sidecar for the login flow. */
 const CODEX_CALLBACK_PORT = 1455
 
+/** How long to wait for the sidecar to bind that port before calling it a failure. */
+const CALLBACK_BIND_TIMEOUT_MS = 5_000
+
 // ---- Paths -------------------------------------------------------------------
 
 /** Root for everything this service owns, under Electron's userData. */
@@ -822,11 +825,68 @@ export async function startLogin(): Promise<CliProxyLoginStart> {
         'Close any running Codex CLI or proxy and try again.'
     )
   }
+
+  // `is_webui=true` is what makes the sidecar OPEN the callback listener on
+  // :1455 and wait for the browser to come back.
+  //
+  // Without it the endpoint still returns a perfectly valid authorization URL,
+  // but nothing ever binds the port - that mode expects the CALLER to host the
+  // redirect, which is right for its own terminal flow and wrong for ours. The
+  // failure lands at the worst possible moment: the user signs in, approves
+  // consent, and only then gets ERR_CONNECTION_REFUSED, with the authorization
+  // code stranded in the address bar.
   const body = await management<{ status?: string; url?: string; state?: string; error?: string }>(
-    '/codex-auth-url'
+    '/codex-auth-url?is_webui=true'
   )
   if (!body.url || !body.state) throw new Error(body.error || 'Sign-in could not be started.')
+
+  // Confirm the listener is actually up before sending anyone to the browser.
+  // The endpoint returning 200 is not evidence that the port got bound, and this
+  // is the last moment we can fail cheaply.
+  if (!(await waitForCallbackListener())) {
+    throw new Error(
+      'The sign-in listener could not start. Something may be blocking port ' +
+        `${CODEX_CALLBACK_PORT} on this machine.`
+    )
+  }
   return { url: body.url, state: body.state }
+}
+
+/**
+ * Wait for the sidecar to bind the OAuth callback port.
+ *
+ * It binds asynchronously after the auth-url call returns, so a naive check
+ * races it. Polling briefly turns "signed in, then refused" into a clear error
+ * raised before the browser is ever opened.
+ *
+ * This CONNECTS rather than reusing isPortFree, which tests availability by
+ * binding. Binding here would be actively harmful: polling every 100ms while the
+ * sidecar is trying to bind the same port means we eventually win the race and
+ * take it ourselves, causing the exact failure this function exists to detect.
+ */
+function waitForCallbackListener(): Promise<boolean> {
+  const deadline = Date.now() + CALLBACK_BIND_TIMEOUT_MS
+  const attempt = (): Promise<boolean> =>
+    new Promise((resolve) => {
+      const socket = new net.Socket()
+      const done = (ok: boolean): void => {
+        socket.destroy()
+        resolve(ok)
+      }
+      socket.setTimeout(500)
+      socket.once('connect', () => done(true))
+      socket.once('timeout', () => done(false))
+      socket.once('error', () => done(false))
+      socket.connect(CODEX_CALLBACK_PORT, HOST)
+    })
+
+  return (async () => {
+    while (Date.now() < deadline) {
+      if (await attempt()) return true
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    return false
+  })()
 }
 
 /**

--- a/test/cliproxy.ts
+++ b/test/cliproxy.ts
@@ -15,6 +15,7 @@
  * authorization URL, which is the last step Roxy controls.
  */
 import { createHash } from 'node:crypto'
+import net from 'node:net'
 import { createReadStream, mkdtempSync, promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -125,6 +126,27 @@ async function main(): Promise<void> {
   check('the auth URL uses PKCE', login.url.includes('code_challenge_method=S256'))
   check('startLogin returns a state token', login.state.length > 0)
   check('the auth URL carries that state', login.url.includes(`state=${login.state}`))
+
+  // The bug this guards against: the endpoint happily returns a valid URL while
+  // nothing binds :1455, so the user completes consent and *then* gets
+  // ERR_CONNECTION_REFUSED with the authorization code stranded in the address
+  // bar. A 200 from the management API is not evidence that a listener exists -
+  // only a connection is.
+  const callbackBound = await new Promise<boolean>((resolve) => {
+    const socket = new net.Socket()
+    socket.setTimeout(2000)
+    socket.once('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once('timeout', () => {
+      socket.destroy()
+      resolve(false)
+    })
+    socket.once('error', () => resolve(false))
+    socket.connect(1455, '127.0.0.1')
+  })
+  check('the OAuth callback listener is accepting connections', callbackBound)
 
   // ---- teardown leaves the install (and would-be tokens) in place ----
   const stopped = await stop()


### PR DESCRIPTION
The download now works - that part of #41 landed. This fixes the next step: sign-in completes, then the browser hits `http://localhost:1455/auth/callback?code=...` and gets `ERR_CONNECTION_REFUSED`, with the authorization code stranded in the address bar.

Nothing was listening on 1455. **Two independent causes, both reproduced against the real binary.**

## 1. The management call needs `is_webui=true`

Without it, `/codex-auth-url` still returns a perfectly valid authorization URL - but never binds the callback port. That mode expects the *caller* to host the redirect, which suits CLIProxyAPI's own terminal flow and not ours.

Measured directly:

```
plain /codex-auth-url          1455 = REFUSED at +0s +3s +8s +15s +25s +40s
with  ?is_webui=true           1455 = LISTENING at +2s +10s +25s +45s +70s
```

The listener also survives our 1s status polling, which was the other thing worth ruling out.

This is why my earlier probe "worked" - I happened to use `is_webui=true` when exploring the API, then shipped the call without it. The endpoint returning `200` with a well-formed URL made it look correct.

## 2. My first readiness check made it worse

I added a guard that waits for the listener before opening the browser. It used the existing `isPortFree()`, which tests a port **by binding it** - so polling every 100ms while the sidecar is trying to bind the *same* port means we eventually win the race and take it ourselves, manufacturing the exact failure the check exists to catch.

It now connects instead of binding. **The integration test caught this on the first run**, which is the only reason it did not ship; the symptom would have been indistinguishable from the original bug.

## The behavioural change

`startLogin` now confirms the listener is actually accepting connections before returning. If something is genuinely blocking 1455, the error appears **before the browser opens** - not after the user has signed in and approved consent, which is the worst possible moment to discover it.

## Testing

`smoke:cliproxy` 56 ? **57 checks**. The new one opens a real socket to 1455 after `startLogin`, because a 200 from the management API is not evidence a listener exists - only a connection is.

`typecheck`, `smoke:shared` (706) pass.

## Note on the conflict you saw

`src/features/settings/ux/components/SettingsTabs.tsx` is not from any of my branches - there is no `src/features/` tree on main, and none of #39/#40/#41 touched it. That conflict belongs to a different PR.