### PR TITLE
Trust the checksum compiled into the app over the one fetched at runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.72",
+      "version": "0.0.73",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",

--- a/src/main/services/cliproxy.ts
+++ b/src/main/services/cliproxy.ts
@@ -71,7 +71,10 @@ const PORT_RANGE_END = 8399
  * the offline case: when github.com is unreachable, a manual install still has
  * something to verify against instead of being waved through.
  */
-const PINNED_SHA256: Record<string, string> = {
+// Exported so the integration test can assert it against upstream. Now that we
+// trust this over the network, a wrong entry breaks every install - it has to be
+// checkable.
+export const PINNED_SHA256: Record<string, string> = {
   'CLIProxyAPI_7.2.112_windows_amd64.zip':
     'e2a59965f73e5e32c00cb711a09412f8a7898ca8c10a4e682bb963dafde764f4',
   'CLIProxyAPI_7.2.112_windows_aarch64.zip':
@@ -260,12 +263,24 @@ async function install(): Promise<void> {
 
   update({ status: 'downloading', progress: 0, error: undefined })
 
-  // Fetched once: it describes the pinned release, so it cannot change between
-  // attempts.
-  const sumsRes = await fetchWithFallback(checksumsUrl())
-  if (!sumsRes.ok) throw new Error(`Couldn't fetch checksums (${sumsRes.status}).`)
-  const expected = sha256For(await sumsRes.text(), asset)
-  if (!expected) throw new Error(`The release doesn't list a checksum for ${asset}.`)
+  // Prefer the digest compiled into this build over anything fetched.
+  //
+  // checksums.txt is ~1KB of plain text on the same host as the archive, so any
+  // proxy able to corrupt the download can trivially rewrite it too - and then
+  // we would verify a perfectly good archive against a bad expectation and tell
+  // the user their download was "modified in transit". Blaming the 20MB file for
+  // the corruption of the 1KB one.
+  //
+  // PINNED_SHA256 was recorded when CLIPROXY_VERSION was set and ships inside the
+  // application. It cannot be altered in flight, which makes it strictly more
+  // trustworthy than the network. Fetch only when we have no pin for this asset.
+  let expected: string | null = PINNED_SHA256[asset] ?? null
+  if (!expected) {
+    const sumsRes = await fetchWithFallback(checksumsUrl())
+    if (!sumsRes.ok) throw new Error(`Couldn't fetch checksums (${sumsRes.status}).`)
+    expected = sha256For(await sumsRes.text(), asset)
+  }
+  if (!expected) throw new Error(`Couldn't determine the expected checksum for ${asset}.`)
 
   let lastError: Error | null = null
   for (let attempt = 1; attempt <= DOWNLOAD_ATTEMPTS; attempt++) {
@@ -360,6 +375,13 @@ async function downloadAndExtract(asset: string, expected: string): Promise<void
   }
 }
 
+/** First bytes as hex, for identifying what a rewritten file actually is. */
+function head4(buf: Buffer): string {
+  return Array.from(buf.subarray(0, 4))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ')
+}
+
 /**
  * Explain a failed integrity check by INSPECTING the file, rather than asserting
  * a cause we never checked.
@@ -438,10 +460,16 @@ export async function describeBadDownload(
     )
   }
 
-  // Full length, correct shape, wrong hash: genuinely different bytes.
+  // Full length, correct shape, wrong hash. Everything structural checks out, so
+  // report the evidence instead of a verdict: whatever is rewriting the file is
+  // doing it competently, and the next person to debug this needs the actual
+  // numbers rather than another confident-sounding sentence.
   return (
-    'The downloaded file failed its integrity check. The bytes arrived intact but do not ' +
-    'match the published checksum, so it was modified in transit.'
+    'The downloaded file failed its integrity check. It is the right size and a valid ' +
+    `archive, but its contents differ from the published release (${written} bytes, ` +
+    `starts ${head4(head)}). Something on the network is rewriting the file — a proxy, VPN, or ` +
+    'security product doing TLS inspection is the usual cause. "Install from a file" below ' +
+    'bypasses the network entirely.'
   )
 }
 
@@ -992,13 +1020,14 @@ export async function installFromFile(archivePath: string): Promise<CliProxyStat
 
     update({ status: 'downloading', progress: 50, error: undefined })
     try {
-      const sumsRes = await fetchWithFallback(checksumsUrl())
-      let expected: string | null = null
-      if (sumsRes.ok) expected = sha256For(await sumsRes.text(), asset)
-
-      // The checksums file lives on the same host that may be blocked. Fall back
-      // to the digest recorded at pin time so an offline install still verifies.
-      const want = expected ?? PINNED_SHA256[asset]
+      // Same ordering as the download path: the compiled-in digest wins. Anyone
+      // installing by hand is usually doing so BECAUSE the network is hostile,
+      // which is the worst case in which to trust it for the expected value.
+      let want: string | null = PINNED_SHA256[asset] ?? null
+      if (!want) {
+        const sumsRes = await fetchWithFallback(checksumsUrl())
+        if (sumsRes.ok) want = sha256For(await sumsRes.text(), asset)
+      }
       if (!want) {
         throw new Error("Couldn't determine the expected checksum for this platform.")
       }

--- a/test/cliproxy.ts
+++ b/test/cliproxy.ts
@@ -23,6 +23,7 @@ import { pipeline } from 'node:stream/promises'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { app } from 'electron'
+import { checksumsUrl, releaseAsset, sha256For } from '../src/shared/cliproxy'
 import {
   baseUrl,
   disconnect,
@@ -32,6 +33,7 @@ import {
   extract,
   listProxyModels,
   localApiKey,
+  PINNED_SHA256,
   shutdownCliProxy,
   startLogin,
   status,
@@ -298,13 +300,50 @@ async function main(): Promise<void> {
 
     // Full length, right shape, wrong hash.
     check(
-      'intact-but-wrong-hash is named as modification in transit',
-      /modified in transit/.test(await describeBadDownload(zip, 1004, 1004, 1004))
+      'intact-but-wrong-hash reports evidence, not just a verdict',
+      /contents differ from the published release/.test(
+        await describeBadDownload(zip, 1004, 1004, 1004)
+      )
     )
 
     // If several shapes collapse to one message this is theatre, not diagnosis.
     const messages = new Set([mPortal, mShort, mNoLen, mWrite])
     check('the failure modes stay distinguishable', messages.size === 4, `${messages.size}/4`)
+  }
+
+  // ---- the pinned digest must be right, because we now trust it over the network ----
+  //
+  // install() prefers PINNED_SHA256 to whatever checksums.txt says, since a
+  // proxy that can corrupt a 20MB archive can trivially rewrite 1KB of text.
+  // That inverts the risk: a WRONG pin now breaks every install instead of
+  // being silently corrected by the network. So verify it against upstream.
+  {
+    const asset = releaseAsset(process.platform, process.arch)
+    check('this platform has a release asset', !!asset)
+    check('...and it has a pinned digest', !!asset && !!PINNED_SHA256[asset])
+
+    const res = await fetch(checksumsUrl())
+    check('upstream checksums.txt is reachable', res.ok, `status ${res.status}`)
+    if (res.ok && asset) {
+      const text = await res.text()
+      const upstream = sha256For(text, asset)
+      check('upstream publishes a digest for this asset', !!upstream)
+      check(
+        'the pinned digest matches upstream exactly',
+        upstream === PINNED_SHA256[asset],
+        `pinned=${PINNED_SHA256[asset]} upstream=${upstream}`
+      )
+      // Every pin, not just this platform's - a bad entry only breaks the
+      // machines that use it, which is exactly the bug that hides in review.
+      let allMatch = true
+      for (const [name, digest] of Object.entries(PINNED_SHA256)) {
+        if (sha256For(text, name) !== digest) {
+          allMatch = false
+          check(`pin for ${name} matches upstream`, false, digest)
+        }
+      }
+      check('every pinned digest matches upstream', allMatch)
+    }
   }
 
   // ---- manual install (the escape hatch for blocked networks) ----


### PR DESCRIPTION
Third attempt at the same machine's download failure, and this one found a hole in the verification itself rather than in the transfer.

## What the new message told us

"The bytes arrived intact but do not match the published checksum" is the branch where **length, ZIP header, and byte count all check out** - only the hash disagrees. That ruled out truncation, captive portals, and short writes, and pointed somewhere I had not looked: the expected value.

## The hole

`install()` fetched `checksums.txt` and trusted it completely.

But `checksums.txt` is **~1KB of plain text served from the same host as the archive**. Anything capable of corrupting a 20MB binary can rewrite it far more easily. When that happens we compare a perfectly good archive against a bad expectation - and blame the 20MB file for the corruption of the 1KB one.

`PINNED_SHA256` already existed for offline installs. It ships inside the application, where nothing in transit can touch it. **It was strictly more trustworthy than the network the entire time, and I asked the network anyway.** Both the download and manual-install paths now prefer it, falling back to `checksums.txt` only for assets with no pin.

## The risk that creates, and how it is covered

This inverts the failure mode: a *wrong* pin would now break every install instead of being silently corrected by the network. So the integration test fetches upstream and asserts every pinned digest matches - **all six, not just the current platform**, since a bad entry otherwise only breaks the machines that use it and passes review everywhere else.

```
? the pinned digest matches upstream exactly
? every pinned digest matches upstream
```

## Also: stopped asserting a cause

The final diagnosis branch claimed "modified in transit" as fact. When length, shape and size all check out, the honest output is the **evidence** - size, leading bytes - plus the likely culprit, not a verdict. Whatever rewrites the file is doing it competently, and the next person debugging this needs numbers rather than another confident sentence. That is now the third time a guessed explanation sent this investigation sideways.

## Contents

Carries the OAuth callback fix from #42 (not yet on main), plus this change. `smoke:cliproxy` 57 ? **63 checks**; `typecheck` and `smoke:shared` (706) pass.

## If it still fails

The next message will include the actual size and leading bytes of what arrived. That is enough to identify what is rewriting it. And "Install from a file" bypasses the network completely - worth trying regardless, since it will confirm the diagnosis in one step: if a hand-downloaded archive installs cleanly, the network is conclusively the culprit.