### PR TITLE
Report which file arrived instead of blaming the network

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.73",
+      "version": "0.0.74",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/FreddyJD/roxy)",

--- a/src/main/services/cliproxy.ts
+++ b/src/main/services/cliproxy.ts
@@ -316,8 +316,14 @@ async function downloadAndExtract(asset: string, expected: string): Promise<void
     const total = Number(res.headers.get('content-length') || 0)
     let received = 0
     const out = createWriteStream(archive)
+    // Hash the stream as well as the file. Verification uses the DISK hash (the
+    // bytes that get executed), but knowing whether the two agree is what
+    // separates "the network sent us something else" from "something changed the
+    // file after we wrote it" - and we were guessing between those.
+    const streamHash = createHash('sha256')
     const source = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0])
     source.on('data', (chunk: Buffer) => {
+      streamHash.update(chunk)
       received += chunk.length
       if (total > 0) {
         // Cap at 99: the last percent is extraction, so the bar doesn't sit at
@@ -339,7 +345,14 @@ async function downloadAndExtract(asset: string, expected: string): Promise<void
     const written = (await fsp.stat(archive)).size
     const actual = await sha256OfFile(archive)
     if (actual !== expected) {
-      throw new Error(await describeBadDownload(archive, written, total, received))
+      throw new Error(
+        await describeBadDownload(archive, written, total, received, {
+          expected,
+          actual,
+          stream: streamHash.digest('hex'),
+          asset
+        })
+      )
     }
 
     // Extract into a temp dir, then swap it into place, so an interrupted
@@ -397,7 +410,8 @@ export async function describeBadDownload(
   archive: string,
   written: number,
   total: number,
-  received: number
+  received: number,
+  digests?: { expected: string; actual: string; stream: string; asset: string }
 ): Promise<string> {
   const head = Buffer.alloc(512)
   let sniffed = 0
@@ -460,17 +474,45 @@ export async function describeBadDownload(
     )
   }
 
-  // Full length, correct shape, wrong hash. Everything structural checks out, so
-  // report the evidence instead of a verdict: whatever is rewriting the file is
-  // doing it competently, and the next person to debug this needs the actual
-  // numbers rather than another confident-sounding sentence.
-  return (
-    'The downloaded file failed its integrity check. It is the right size and a valid ' +
-    `archive, but its contents differ from the published release (${written} bytes, ` +
-    `starts ${head4(head)}). Something on the network is rewriting the file — a proxy, VPN, or ` +
-    'security product doing TLS inspection is the usual cause. "Install from a file" below ' +
-    'bypasses the network entirely.'
-  )
+  // Full length, correct shape, wrong hash.
+  //
+  // The previous version of this branch announced "something on the network is
+  // rewriting the file". On a real report that turned out to be false: the bytes
+  // were the correct published asset. Blaming the network was a third guess in a
+  // row, so this now reports what it can actually prove.
+  if (digests) {
+    // The archive matches a DIFFERENT platform's release. That is an asset
+    // selection bug on our side, not a network problem, and it is worth naming
+    // precisely because the file is otherwise perfectly valid.
+    const matched = Object.entries(PINNED_SHA256).find(([, d]) => d === digests.actual)
+    if (matched) {
+      return (
+        `Downloaded ${matched[0]} but verified it against ${digests.asset}. ` +
+        'This is a bug in Roxy - the wrong build was selected for this machine.'
+      )
+    }
+
+    // The bytes we received and the bytes on disk disagree: something altered
+    // the file locally, after the transfer.
+    if (digests.stream !== digests.actual) {
+      return (
+        'The download was altered after it arrived (the bytes received and the bytes ' +
+        'written to disk differ). Antivirus or endpoint-security software is the usual ' +
+        'cause on this machine.'
+      )
+    }
+
+    // Received and written agree, and match no other known release: what the
+    // server sent genuinely is not the published file.
+    return (
+      `The downloaded file does not match the published ${digests.asset} ` +
+      `(${written} bytes, starts ${head4(head)}, sha256 ${digests.actual.slice(0, 12)}…, ` +
+      `expected ${digests.expected.slice(0, 12)}…). "Install from a file" below bypasses ` +
+      'the download entirely.'
+    )
+  }
+
+  return `The downloaded file failed its integrity check (${written} bytes, starts ${head4(head)}).`
 }
 
 /** sha256 of a file's actual contents on disk. */

--- a/test/cliproxy.ts
+++ b/test/cliproxy.ts
@@ -301,9 +301,57 @@ async function main(): Promise<void> {
     // Full length, right shape, wrong hash.
     check(
       'intact-but-wrong-hash reports evidence, not just a verdict',
-      /contents differ from the published release/.test(
-        await describeBadDownload(zip, 1004, 1004, 1004)
-      )
+      /failed its integrity check/.test(await describeBadDownload(zip, 1004, 1004, 1004))
+    )
+
+    // With digests available it must distinguish the three real causes rather
+    // than blaming the network for all of them - which is what a live report
+    // proved it was doing.
+    const D = (over: Record<string, string>): Record<string, string> => ({
+      expected: 'a'.repeat(64),
+      actual: 'b'.repeat(64),
+      stream: 'b'.repeat(64),
+      asset: 'CLIProxyAPI_7.2.112_darwin_aarch64.tar.gz',
+      ...over
+    })
+
+    // (a) We downloaded a real release, just the wrong one. Our bug, not theirs.
+    const wrongAsset = await describeBadDownload(
+      zip,
+      1004,
+      1004,
+      1004,
+      D({
+        actual: PINNED_SHA256['CLIProxyAPI_7.2.112_linux_amd64.tar.gz'],
+        stream: PINNED_SHA256['CLIProxyAPI_7.2.112_linux_amd64.tar.gz']
+      }) as never
+    )
+    check(
+      'a wrong-platform archive is named as a Roxy bug',
+      /bug in Roxy/.test(wrongAsset),
+      wrongAsset
+    )
+    check('...and it does not blame the network', !/network/i.test(wrongAsset), wrongAsset)
+
+    // (b) Received and written disagree -> altered locally after transfer.
+    const localAlt = await describeBadDownload(
+      zip,
+      1004,
+      1004,
+      1004,
+      D({ stream: 'c'.repeat(64) }) as never
+    )
+    check(
+      'a stream/disk mismatch is named as local alteration',
+      /altered after it arrived/.test(localAlt)
+    )
+
+    // (c) Consistent bytes that match nothing known -> genuinely not the release.
+    const notRelease = await describeBadDownload(zip, 1004, 1004, 1004, D({}) as never)
+    check('otherwise it reports both hashes', /sha256 bbbbbbbbbbbb/.test(notRelease), notRelease)
+    check(
+      'the three digest cases are distinguishable',
+      new Set([wrongAsset, localAlt, notRelease]).size === 3
     )
 
     // If several shapes collapse to one message this is theatre, not diagnosis.


### PR DESCRIPTION
Windows works now. macOS fails at the checksum - and the diagnostic I added is what let me take this apart, because it printed real numbers.

## The message was wrong

Reported: `contents differ from the published release (19013735 bytes, starts 1f 8b 08 00)`.

Every part of that is verifiably **correct**:

| Evidence | Result |
|---|---|
| 19013735 bytes | exactly `CLIProxyAPI_7.2.112_darwin_aarch64.tar.gz` |
| `1f 8b 08 00` | valid gzip magic |
| pinned darwin_aarch64 digest | matches upstream `checksums.txt` |
| downloaded here, both stacks | byte-perfect against that digest |
| `releaseAsset('darwin','arm64')` | resolves to the aarch64 asset |
| mac build | arm64-only, so `process.arch` is `arm64` |

So the app accused the network of rewriting a file that, by every measurement available to me, **was the correct file**. I could not reproduce a single bad byte.

## What I changed, and why not more

That is the third guessed explanation in a row on this feature - "antivirus", then "a proxy is rewriting it", now this. Each one sent the investigation somewhere useless and cost more time than the actual bugs did. I am not adding a fourth.

Instead the failure now hashes the **stream** as well as the **file** and reports only what it can prove:

- **bytes match a different pinned release** ? *"wrong build selected for this machine"*, named as a Roxy bug, not a network fault
- **stream and disk hashes disagree** ? altered locally after transfer (this is the only case where antivirus is a fair accusation)
- **neither** ? both digests, the size, the leading bytes, and **no claim about cause**

Previously all three produced the same sentence about proxies.

## Testing

`smoke:cliproxy` 63 ? **68 checks**, asserting the three cases stay distinct and that a wrong-platform archive is never reported as a network problem.

## What I need from that Mac

The next failure will print `sha256 <actual>., expected <expected>.`. **Those twelve characters settle it:**

- actual matches another platform's release ? our asset selection is broken
- actual is stable across retries but matches nothing ? something is consistently substituting the file
- actual differs between retries ? genuine corruption

Also still worth one run of **"Install from a file"** on that machine. If a hand-downloaded archive verifies fine, the download path is implicated; if it fails the same way, the problem is in verification and I have been looking in the wrong place entirely.