### PR TITLE
Cancel one tool call without stopping the whole turn

### DIFF
--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -11,7 +11,8 @@
  * Wires without tool support yet (azure/bedrock) fall back to a plain answer.
  */
 import type { ChatMessage, LlmEvent } from '../../shared/api'
-import type { ReasoningEffort, TokenUsage } from '../../shared/types'
+import type { ReasoningEffort, TokenUsage, ToolResult } from '../../shared/types'
+import { isInterruptibleTool } from '../../shared/tools'
 import { PartsFold, partsToContent } from '../../shared/parts'
 import {
   getAgent,
@@ -63,6 +64,7 @@ import {
   cancelBackgroundJob
 } from '../services/background-tasks'
 import { startSubagentRun } from '../services/subagent-stream'
+import { startToolRun } from '../services/tool-runs'
 import {
   messagesHaveImages,
   openAiContent,
@@ -1261,19 +1263,51 @@ async function runLoop(o: LoopOptions): Promise<string> {
         callId: tc.id,
         tool: tc.name,
         title: toolTitle(tc.name, input),
-        input
+        input,
+        // Whether this card gets a cancel button. Resolved here, in the one place
+        // that knows the tool's real name (MCP names are only known at runtime),
+        // rather than re-derived in the renderer from a list that would drift.
+        cancellable: isInterruptibleTool(tc.name)
       })
-      const result = await runTool(tc.name, input, {
-        cwd,
-        sessionId,
-        browserKey,
-        // Stop must reach INSIDE the tool, not just between calls. Without this
-        // the loop's `if (signal.aborted) break` above only fires once the
-        // current tool returns on its own, which is why Stop looked stuck
-        // during a long bash or a hanging fetch.
-        signal,
-        onChunk: (chunk) => emitTool({ type: 'tool-delta', callId: tc.id, chunk })
+      // Its OWN controller, chained to the turn's signal rather than being it —
+      // the same shape a subagent gets, and for the same reason. Stop still
+      // cascades (the listener below), but cancelling this ONE call aborts only
+      // this controller, so the turn survives, the model reads a cancelled result
+      // for this call, and every other tool result in the step is preserved.
+      const callController = new AbortController()
+      const cascade = (): void => callController.abort()
+      if (signal.aborted) callController.abort()
+      else signal.addEventListener('abort', cascade, { once: true })
+      const run = startToolRun({
+        callId: tc.id,
+        tool: tc.name,
+        sessionId: sessionId ?? '',
+        cancel: cascade
       })
+      let result: ToolResult
+      try {
+        result = await runTool(tc.name, input, {
+          cwd,
+          sessionId,
+          browserKey,
+          // Stop must reach INSIDE the tool, not just between calls. Without this
+          // the loop's `if (signal.aborted) break` above only fires once the
+          // current tool returns on its own, which is why Stop looked stuck
+          // during a long bash or a hanging fetch.
+          signal: callController.signal,
+          onChunk: (chunk) => emitTool({ type: 'tool-delta', callId: tc.id, chunk })
+        })
+        // Distinguish "the user cancelled this one call" from "Stop killed the
+        // turn". Both abort the same signal, so the tool can't tell them apart —
+        // only the registry knows which lever was pulled. The wording matters:
+        // the turn CONTINUES after a per-call cancel, and the model is about to
+        // read this, so it has to understand not to immediately retry.
+        if (run.wasCancelled())
+          result = { ...result, ok: false, output: cancelledToolReport(result.output) }
+      } finally {
+        run.end()
+        signal.removeEventListener('abort', cascade)
+      }
       emitTool({
         type: 'tool-end',
         callId: tc.id,
@@ -1646,6 +1680,22 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
   } finally {
     signal.removeEventListener('abort', cascade)
   }
+}
+
+/**
+ * What a cancelled TOOL CALL reports back to the model that made it.
+ *
+ * Deliberately explicit that the user did this and that the turn is still
+ * running — the model reads this result and keeps going, and without the framing
+ * it reliably re-runs the exact command that was just killed. Any partial output
+ * is kept: half a test run is often the whole reason you stopped it.
+ */
+function cancelledToolReport(partial: string): string {
+  const got = partial.trim()
+  const note =
+    'The user cancelled this tool call. Do not run it again unless they ask — ' +
+    'continue with the rest of your work, or ask them how to proceed.'
+  return got ? `${note}\n\nPartial output before it was cancelled:\n${got.slice(0, 4000)}` : note
 }
 
 /**

--- a/src/main/harness/tools.ts
+++ b/src/main/harness/tools.ts
@@ -195,12 +195,16 @@ export async function runTool(
       case 'list':
         return await runList(str(input.path) || '.', ctx.cwd)
       case 'glob':
-        return await runGlob(str(input.pattern), ctx.cwd)
+        // tinyglobby takes no signal, so the walk itself runs to completion — but
+        // a glob over a monorepo or a network drive is slow enough to be worth
+        // cancelling, and the turn need not wait for it.
+        return await untilAborted(ctx.signal, () => runGlob(str(input.pattern), ctx.cwd))
       case 'grep':
         return await runGrep(
           str(input.pattern),
           str(input.include ?? input.glob) || '**/*',
-          ctx.cwd
+          ctx.cwd,
+          ctx.signal
         )
       case 'webfetch':
         return await runWebFetch(
@@ -895,7 +899,12 @@ async function runGlob(pattern: string, cwd: string): Promise<ToolResult> {
   return { ok: true, output: shown.join('\n') + more }
 }
 
-async function runGrep(pattern: string, include: string, cwd: string): Promise<ToolResult> {
+async function runGrep(
+  pattern: string,
+  include: string,
+  cwd: string,
+  signal?: AbortSignal
+): Promise<ToolResult> {
   if (!pattern) return { ok: false, output: 'grep: missing "pattern"' }
   let re: RegExp
   try {
@@ -903,9 +912,16 @@ async function runGrep(pattern: string, include: string, cwd: string): Promise<T
   } catch {
     return { ok: false, output: `grep: invalid regex: ${pattern}` }
   }
-  const files = await glob(include, { cwd, onlyFiles: true, ignore: IGNORE })
+  // The glob can't be interrupted; the scan below can, and on a big tree that's
+  // where nearly all the time goes.
+  const files = await untilAborted(signal, () =>
+    glob(include, { cwd, onlyFiles: true, ignore: IGNORE })
+  )
   const results: string[] = []
   for (const rel of files.slice(0, 2000)) {
+    // Checked per file rather than per line: 2000 file reads is the slow part,
+    // and a per-line check would cost more than the responsiveness it buys.
+    if (signal?.aborted) throw new AbortError()
     let content: string
     try {
       content = await fs.readFile(path.join(cwd, rel), 'utf8')

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -62,6 +62,7 @@ import {
   cancelSubagentRun,
   cancelSubagentRunsFor
 } from '../services/subagent-stream'
+import { cancelToolCall, cancelToolCallsFor } from '../services/tool-runs'
 import { mcpServerSummaries, reconnectMcpServer, disposeConnection } from '../services/mcp'
 import {
   listSkills,
@@ -587,6 +588,11 @@ export function registerIpc(): void {
       return runTool(name, input ?? {}, { cwd: cwd ?? '', sessionId })
     }
   )
+  // Cancel one in-flight tool call without touching the turn around it. The call
+  // unwinds through its own exit path (see cancelToolCall), which is what keeps
+  // the model's tool_calls -> role:'tool' pairing intact, so there is nothing to
+  // clean up here.
+  ipcMain.handle(CHANNELS.toolsCancel, (_e, callId: string) => cancelToolCall(callId))
 
   // ---- queue ----
   // Each mutation re-mirrors the shared queue to any paired phone (remote is a
@@ -669,6 +675,11 @@ export function registerIpc(): void {
   ipcMain.handle(CHANNELS.llmAbortSession, (_e, sessionId: string) => {
     abortSession(sessionId)
     cancelSubagentRunsFor(sessionId)
+    // Belt and braces: the turn's own signal already cascades into every call's
+    // controller, so this is normally a no-op. It matters for a call registered
+    // by work that ISN'T the tracked turn (compaction, a loop tick), which would
+    // otherwise keep running with nobody left to read its result.
+    cancelToolCallsFor(sessionId)
   })
 
   // ---- background subagent tasks (Phase 11) ----

--- a/src/main/services/tool-runs.ts
+++ b/src/main/services/tool-runs.ts
@@ -1,0 +1,143 @@
+/**
+ * Registry of tool calls that are executing RIGHT NOW, so one of them can be
+ * cancelled on its own.
+ *
+ * Stop was all-or-nothing before this. A turn that fired `bash npm test` on a
+ * wedged suite, or a `webfetch` at a host that never answers, left exactly one
+ * lever: kill the entire turn — throwing away the model's reasoning and every
+ * other tool result alongside the one call you actually wanted gone. This is the
+ * missing granularity, and it's deliberately the same shape as the subagent
+ * registry next door (`subagent-stream.ts`): a map from a public id to a
+ * `cancel`, an explicit `cancelled` flag so the harness can tell "the user did
+ * this" from "it failed", and a handle-based API so a finished run can't be
+ * resurrected by a late call.
+ *
+ * Keyed by the model's tool-call id, which is the id a tool card already carries
+ * to the renderer and the only one that names a single call inside a turn.
+ *
+ * Not persisted and not broadcast: unlike a subagent run, a tool call cannot
+ * outlive the turn that started it, so the requestId-keyed `llm:delta` stream
+ * the card already rides is enough to reflect the outcome. The renderer only
+ * ever needs to ASK (an invoke), never to be told out-of-band.
+ */
+
+interface ToolRun {
+  callId: string
+  tool: string
+  /** The session whose turn is running this call — scopes a session-wide sweep. */
+  sessionId: string
+  /** Aborts this call's own signal, leaving the rest of the turn alone. */
+  cancel: () => void
+  /**
+   * Set ONLY by `cancelToolCall` — i.e. the user cancelled this ONE call and the
+   * turn is still running.
+   *
+   * Deliberately not set by the session-wide sweep, which aborts the identical
+   * signal: the harness swaps in a "you cancelled this, carry on with the rest
+   * of your work" result when it sees this flag, and that sentence is a lie in a
+   * transcript whose whole turn just stopped. A full Stop leaves the flag false
+   * and the tool's own `TOOL_ABORTED` wording stands.
+   */
+  cancelled: boolean
+  startedAt: number
+}
+
+/** Call id -> the in-flight call. Only ever holds RUNNING calls. */
+const runs = new Map<string, ToolRun>()
+
+export interface StartToolRunInput {
+  callId: string
+  tool: string
+  sessionId: string
+  cancel: () => void
+}
+
+/**
+ * Register a running tool call. Returns `end` to deregister it, plus
+ * `wasCancelled` so the caller can classify its own outcome AFTER the work
+ * unwinds but BEFORE the entry is dropped.
+ *
+ * A handle rather than free functions keyed by id, for the same reason
+ * `startSubagentRun` is one: the caller can only end the run it started, and an
+ * `end` that races a cancel can't reopen anything.
+ */
+export function startToolRun(input: StartToolRunInput): {
+  end: () => void
+  wasCancelled: () => boolean
+} {
+  const run: ToolRun = {
+    callId: input.callId,
+    tool: input.tool,
+    sessionId: input.sessionId,
+    cancel: input.cancel,
+    cancelled: false,
+    startedAt: Date.now()
+  }
+  // Last writer wins on a duplicate id. Providers do occasionally repeat a
+  // tool-call id across steps of one turn, and the newer call is the live one —
+  // the alternative (refusing to register) would silently make it uncancellable.
+  runs.set(input.callId, run)
+  let ended = false
+  return {
+    end: () => {
+      if (ended) return
+      ended = true
+      // Only drop OUR entry: a later call that reused this id has already
+      // replaced us in the map and must keep its own cancellability.
+      if (runs.get(input.callId) === run) runs.delete(input.callId)
+    },
+    wasCancelled: () => run.cancelled
+  }
+}
+
+/**
+ * Cancel one running tool call by its id.
+ *
+ * Aborting is all this does — the call tears itself down through its normal exit
+ * path (the tool observes the signal, returns a cancelled result, the harness
+ * emits `tool-end` and feeds the model a result for that call id). That matters
+ * more here than anywhere else: the provider REQUIRES a `role:'tool'` result for
+ * every `tool_calls` entry, so a cancel that skipped the normal path would leave
+ * a dangling call and 400 the next request.
+ *
+ * Returns false when nothing was running for that id.
+ */
+export function cancelToolCall(callId: string): boolean {
+  const run = runs.get(callId)
+  if (!run) return false
+  run.cancelled = true
+  try {
+    run.cancel()
+  } catch {
+    // A cancel must never throw back into the IPC handler.
+  }
+  return true
+}
+
+/** Whether a call was cancelled by the user (vs. failing or finishing on its own). */
+export function wasToolCallCancelled(callId: string): boolean {
+  return runs.get(callId)?.cancelled === true
+}
+
+/**
+ * Abort every tool call a session has in flight — part of a session-wide Stop.
+ *
+ * Note what this does NOT do: set `cancelled`. That flag means "the user
+ * cancelled this single call and the turn continues", which is exactly what a
+ * Stop is not. See the field's doc comment.
+ */
+export function cancelToolCallsFor(sessionId: string): void {
+  for (const run of [...runs.values()]) {
+    if (run.sessionId !== sessionId) continue
+    try {
+      run.cancel()
+    } catch {
+      // never let one bad cancel break the sweep
+    }
+  }
+}
+
+/** Test-only: clear the registry between smoke cases. */
+export function _resetToolRuns(): void {
+  runs.clear()
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -136,7 +136,8 @@ const roxy: RoxyApi = {
     }
   },
   tools: {
-    run: (sessionId, name, input) => ipcRenderer.invoke(CHANNELS.toolsRun, sessionId, name, input)
+    run: (sessionId, name, input) => ipcRenderer.invoke(CHANNELS.toolsRun, sessionId, name, input),
+    cancel: (callId) => ipcRenderer.invoke(CHANNELS.toolsCancel, callId)
   },
   queue: {
     list: (chatId) => ipcRenderer.invoke(CHANNELS.queueList, chatId),

--- a/src/renderer/src/components/MessageParts.tsx
+++ b/src/renderer/src/components/MessageParts.tsx
@@ -80,22 +80,37 @@ export function MessageParts({
     [streaming]
   )
 
-  // Selected (not called through `getState()`) so the identity is stable and the
-  // per-card callbacks below stay memo-friendly.
+  // Selected (not called through `getState()`) so the identities are stable and
+  // the per-card callbacks below stay memo-friendly.
   const cancelSubagent = useRoxyStore((s) => s.cancelSubagent)
+  const cancelToolCall = useRoxyStore((s) => s.cancelToolCall)
 
   return (
     <div className="flex flex-col gap-1 text-sm leading-relaxed text-text">
       {parts.map((part, i) => {
         const isLast = i === parts.length - 1
         if (part.type === 'tool') {
-          // Only a live `task` card that knows its delegate's session can offer a
-          // cancel. Everything else gets undefined, and ToolCall draws nothing.
+          // Two cancels, one button. A live `task` card cancels its DELEGATE (by
+          // session id — that path tears the subagent down and reports back to
+          // the parent model). Any other live call cancels ITSELF (by call id),
+          // but only when the harness said it's interruptible: a `read` that
+          // returns in 2ms has no window to click, and a button that can't do
+          // anything is worse than none.
+          //
+          // Both leave the turn running — that is the whole point, and the
+          // difference from the composer's Stop.
           const subChatId = part.subChatId
+          const callId = part.callId
           const cancel =
-            part.tool === 'task' && part.state === 'running' && subChatId
-              ? () => void cancelSubagent(subChatId)
-              : undefined
+            part.state !== 'running'
+              ? undefined
+              : part.tool === 'task'
+                ? subChatId
+                  ? () => void cancelSubagent(subChatId)
+                  : undefined
+                : part.cancellable && callId
+                  ? () => void cancelToolCall(callId)
+                  : undefined
           return (
             <ToolCall
               key={i}

--- a/src/renderer/src/components/ToolCall.tsx
+++ b/src/renderer/src/components/ToolCall.tsx
@@ -61,6 +61,39 @@ const TOOL_ICON: Record<string, LucideIcon> = {
 }
 
 /**
+ * How long a call must have been running before its cancel button appears.
+ *
+ * Every running tool card can offer a cancel now, and most tools finish fast — a
+ * `grep` in 200ms, a screenshot in 400. Showing the button immediately would make
+ * it strobe on and off through a normal turn, which reads as jitter and trains
+ * you to ignore it. Nothing you could physically click in under a second needed
+ * cancelling anyway.
+ *
+ * So the affordance waits until the call is visibly *taking a while*, and then
+ * fades in. Arriving late is the point: it turns up exactly when you start
+ * wondering how long this is going to take.
+ */
+const CANCEL_REVEAL_MS = 1200
+
+/**
+ * True once `active` has stayed true for `delayMs` without interruption. Resets
+ * the instant it goes false, so a fast call never reaches the threshold and the
+ * next call starts its own clock.
+ */
+function useSettledDelay(active: boolean, delayMs: number): boolean {
+  const [reached, setReached] = useState(false)
+  useEffect(() => {
+    if (!active) {
+      setReached(false)
+      return
+    }
+    const t = setTimeout(() => setReached(true), delayMs)
+    return () => clearTimeout(t)
+  }, [active, delayMs])
+  return reached
+}
+
+/**
  * How many steps a subagent has taken — tool calls only. Its reasoning and prose
  * are how it narrates the work, not work itself, and counting them would inflate
  * "12 steps" for a delegate that only thought out loud.
@@ -151,9 +184,10 @@ export const ToolCall = memo(function ToolCall({
   image?: string
   diff?: ToolDiff
   /**
-   * Cancel just this call — supplied only for a running `task` card whose
-   * delegate we can address. Absent means there is nothing honest to offer, and
-   * no button is drawn (a Stop that does nothing is worse than no Stop).
+   * Cancel just this call, leaving the turn running — a `task` card stops its
+   * delegate, any other card aborts its own tool. Supplied only when there is
+   * something real to cancel; absent means no button is drawn, because a Stop
+   * that does nothing is worse than no Stop.
    */
   onCancel?: () => void
   /** A subagent's live transcript, for a `task` card. */
@@ -168,6 +202,14 @@ export const ToolCall = memo(function ToolCall({
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const Icon = TOOL_ICON[tool] ?? Wrench
+  // Gate the cancel button on BOTH "there is something to cancel" and "this has
+  // been running long enough to be worth offering" -- except for `task`, which is
+  // long-running by definition (a delegate works for tens of seconds, so its
+  // button can never strobe) and offered its cancel immediately before this
+  // delay existed. See CANCEL_REVEAL_MS.
+  const canCancel = state === 'running' && Boolean(onCancel)
+  const revealed = useSettledDelay(canCancel && tool !== 'task', CANCEL_REVEAL_MS)
+  const showCancel = canCancel && (tool === 'task' || revealed)
   const body = output?.trimEnd() ?? ''
   const nested = nestedParts && nestedParts.length > 0 ? nestedParts : undefined
   const live = state === 'running'
@@ -234,17 +276,22 @@ export const ToolCall = memo(function ToolCall({
               {stepCount} {stepCount === 1 ? 'step' : 'steps'}
             </span>
           )}
-          {/* Skip this delegate without stopping the turn — the answer to "a hook
-              spun up a README subagent and I just want it gone". Rendered as a
-              nested <span role="button">, not a <button>: the header is itself a
-              button (expand/collapse) and nesting one is invalid HTML that React
-              warns about and browsers un-nest. Stops propagation so cancelling
-              doesn't also toggle the card open. */}
-          {live && onCancel && (
+          {/* Kill this one step without stopping the turn — the answer to "that
+              bash is sleeping for five minutes" and to "a hook spun up a README
+              subagent and I just want it gone". The turn keeps its reasoning and
+              every other tool result; the model reads a cancelled result for
+              this call and moves on.
+
+              Rendered as a nested <span role="button">, not a <button>: the
+              header is itself a button (expand/collapse) and nesting one is
+              invalid HTML that React warns about and browsers un-nest. Stops
+              propagation so cancelling doesn't also toggle the card open. */}
+          {showCancel && onCancel && (
             <span
               role="button"
               tabIndex={0}
-              title="Cancel this subagent"
+              title={tool === 'task' ? 'Cancel this subagent' : `Cancel this ${tool} call`}
+              aria-label={tool === 'task' ? 'Cancel this subagent' : `Cancel this ${tool} call`}
               onClick={(e) => {
                 e.stopPropagation()
                 onCancel()
@@ -255,7 +302,7 @@ export const ToolCall = memo(function ToolCall({
                 e.stopPropagation()
                 onCancel()
               }}
-              className="press-scale flex h-5 w-5 items-center justify-center rounded text-text-subtle transition-colors hover:bg-white/10 hover:text-text"
+              className="press-scale animate-fade-in flex h-5 w-5 items-center justify-center rounded text-text-subtle transition-colors hover:bg-white/10 hover:text-text"
             >
               <Square className="h-2.5 w-2.5 fill-current" />
             </span>

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -200,6 +200,13 @@ interface RoxyStore {
   stop: (targetChatId?: string) => void
   /** Cancel ONE running subagent by its session id, leaving its parent turn alive. */
   cancelSubagent: (subChatId: string) => Promise<void>
+  /**
+   * Cancel ONE running tool call by its call id, leaving the turn alive.
+   *
+   * The narrow-gauge Stop: kill the wedged `bash` or the fetch that will never
+   * answer, and let the model keep the rest of the step and carry on.
+   */
+  cancelToolCall: (callId: string) => Promise<void>
   /** Cancel one detached background task launched by a session. */
   cancelBackgroundTask: (sessionId: string, jobId: string) => Promise<void>
   /** Start sharing the active session to a phone via the roxy.gg relay. */
@@ -1785,6 +1792,14 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       return { runningSubagents: next }
     })
     await api.subagents.cancel(subChatId)
+  },
+
+  cancelToolCall: async (callId) => {
+    // No optimistic update, unlike cancelSubagent: the card's `running` state is
+    // owned by the live fold, and a local flip would be overwritten by the very
+    // next delta anyway. The real end state arrives as the `tool-end` the
+    // cancelled call emits on its way out, which is a single frame later.
+    await api.tools.cancel(callId)
   },
 
   cancelBackgroundTask: async (sessionId, jobId) => {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -280,6 +280,18 @@ export type LlmEvent =
        * button name the one delegate to stop.
        */
       subChatId?: string
+      /**
+       * Whether this call can be cancelled on its own while it runs — resolved in
+       * the harness from the tool catalog (`isInterruptibleTool`), which is the
+       * only place that knows an MCP tool's runtime name.
+       *
+       * Sent rather than re-derived in the renderer so the button and the thing
+       * it triggers can never disagree: one source, decided where the signal is
+       * actually threaded. Beside `input` for the same reason `subChatId` is —
+       * `input` is replayed verbatim as the model's tool_calls arguments, and
+       * this is UI addressing the model never sent.
+       */
+      cancellable?: boolean
     }
   | { type: 'tool-delta'; callId: string; chunk: string }
   | {
@@ -711,6 +723,13 @@ export interface RoxyApi {
   }
   tools: {
     run(sessionId: string, name: string, input: Record<string, unknown>): Promise<ToolResult>
+    /**
+     * Cancel ONE tool call that is running right now, without stopping the turn
+     * around it. Resolves false when nothing was running for that call id — it
+     * finished between the click and the call — which the UI uses to avoid
+     * pretending it did something.
+     */
+    cancel(callId: string): Promise<boolean>
   }
   queue: {
     list(chatId: string): Promise<QueueItem[]>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -91,6 +91,20 @@ export const CHANNELS = {
   loopsTick: 'loops:tick',
 
   toolsRun: 'tools:run',
+  /**
+   * renderer -> main: cancel ONE running tool call, by the model's call id.
+   *
+   * The gap this closes: Stop is all-or-nothing. A turn that fires `bash npm
+   * test` on a wedged suite, or a `webfetch` at a host that will never answer,
+   * could only be rescued by killing the whole turn — losing the reasoning and
+   * every other tool result with it. This aborts just that call; the tool reports
+   * back as cancelled and the model carries on with the rest of its work.
+   *
+   * Keyed by callId (not requestId) because that is what a tool card already
+   * carries and what uniquely names one call inside a turn. Broadcast-free: it's
+   * an invoke, and the answer (did anything get cancelled?) comes straight back.
+   */
+  toolsCancel: 'tools:cancel',
 
   queueList: 'queue:list',
   queueAdd: 'queue:add',

--- a/src/shared/parts.ts
+++ b/src/shared/parts.ts
@@ -78,7 +78,8 @@ function foldInto(
         title: event.title,
         callId: event.callId,
         input: event.input,
-        subChatId: event.subChatId
+        subChatId: event.subChatId,
+        cancellable: event.cancellable
       }
     ]
   }

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -22,6 +22,27 @@ export interface ToolDef {
   category: ToolCategory
   /** Whether the tool can modify the workspace or the outside world. */
   mutates: boolean
+  /**
+   * Whether cancelling this ONE call, mid-flight, does something real.
+   *
+   * This gates the per-call cancel button, and the rule is honesty: a button
+   * that does nothing is worse than no button. It is true only for the tools
+   * whose dispatch actually honors `ctx.signal` — either by killing the work
+   * (`bash` kills the process tree, `webfetch`/`websearch` abort the request,
+   * `grep`/`glob` break out of their scan) or by making the TURN stop waiting on
+   * work that cannot itself be interrupted (the `untilAborted` calls: Electron
+   * `webContents`, the language server, an MCP round trip).
+   *
+   * Everything else finishes in single-digit milliseconds — a local `read`, a
+   * `list`, a loop toggle. There is no window in which you could click, so the
+   * flag is false and no button is drawn.
+   *
+   * `task` is deliberately false despite being the longest-running tool of all:
+   * it has a BETTER cancel of its own, addressed by the delegate's session id,
+   * which tears the subagent down through its normal exit path and reports back
+   * to the parent model properly (see `cancelSubagentRun`).
+   */
+  interruptible: boolean
 }
 
 export const TOOLS: ToolDef[] = [
@@ -31,42 +52,50 @@ export const TOOLS: ToolDef[] = [
     name: 'read',
     description: 'Read a file from the workspace.',
     category: 'Files',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'write',
     name: 'write',
     description: 'Create or overwrite a file.',
     category: 'Files',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'edit',
     name: 'edit',
     description: 'Replace an exact, unique substring in a file.',
     category: 'Files',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'list',
     name: 'list',
     description: 'List the entries of a directory.',
     category: 'Files',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'glob',
     name: 'glob',
     description: 'Find files matching a glob pattern.',
     category: 'Files',
-    mutates: false
+    mutates: false,
+    // A glob over a huge tree (or a network drive) can run for a long time.
+    interruptible: true
   },
   {
     id: 'grep',
     name: 'grep',
     description: 'Search file contents with a regex.',
     category: 'Files',
-    mutates: false
+    mutates: false,
+    // Scans up to 2000 files; the loop checks the signal between them.
+    interruptible: true
   },
 
   // ---- Shell ----
@@ -75,28 +104,34 @@ export const TOOLS: ToolDef[] = [
     name: 'bash',
     description: 'Run a shell command (foreground or long-lived background).',
     category: 'Shell',
-    mutates: true
+    mutates: true,
+    // The headline case: `sleep 300`, a hung install, a test suite that wedged.
+    // Cancelling kills the process tree for real (see killProc).
+    interruptible: true
   },
   {
     id: 'bash_list',
     name: 'bash_list',
     description: 'List the running background processes.',
     category: 'Shell',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'bash_output',
     name: 'bash_output',
     description: 'Read new output from a background process.',
     category: 'Shell',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'bash_kill',
     name: 'bash_kill',
     description: 'Stop a background process.',
     category: 'Shell',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
 
   // ---- Web ----
@@ -105,14 +140,17 @@ export const TOOLS: ToolDef[] = [
     name: 'webfetch',
     description: 'Fetch a URL and return it as markdown, text, or HTML.',
     category: 'Web',
-    mutates: false
+    mutates: false,
+    // A dead host holds the socket open until the timeout; the fetch takes our signal.
+    interruptible: true
   },
   {
     id: 'websearch',
     name: 'websearch',
     description: 'Search the web for fresh context beyond the training cutoff.',
     category: 'Web',
-    mutates: false
+    mutates: false,
+    interruptible: true
   },
 
   // ---- Browser (Roxy's persistent, logged-in browser) ----
@@ -121,77 +159,90 @@ export const TOOLS: ToolDef[] = [
     name: 'browser_open',
     description: 'Open or navigate the built-in browser to a URL (logins persist).',
     category: 'Browser',
-    mutates: false
+    mutates: false,
+    // `loadURL` against a slow host is the classic multi-minute hang. The
+    // navigation itself cannot be aborted, but the turn stops waiting on it.
+    interruptible: true
   },
   {
     id: 'browser_screenshot',
     name: 'browser_screenshot',
     description: 'Capture a screenshot of the current page.',
     category: 'Browser',
-    mutates: false
+    mutates: false,
+    interruptible: true
   },
   {
     id: 'browser_read',
     name: 'browser_read',
     description: "Read the current page's HTML (optionally a CSS selector).",
     category: 'Browser',
-    mutates: false
+    mutates: false,
+    interruptible: true
   },
   {
     id: 'browser_console',
     name: 'browser_console',
     description: 'Read console logs and errors from the current page.',
     category: 'Browser',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'browser_click',
     name: 'browser_click',
     description: 'Click the first element matching a CSS selector.',
     category: 'Browser',
-    mutates: true
+    mutates: true,
+    interruptible: true
   },
   {
     id: 'browser_scroll',
     name: 'browser_scroll',
     description: 'Scroll the page into a selector or by direction.',
     category: 'Browser',
-    mutates: true
+    mutates: true,
+    interruptible: true
   },
   {
     id: 'browser_type',
     name: 'browser_type',
     description: 'Type text into a field matching a CSS selector.',
     category: 'Browser',
-    mutates: true
+    mutates: true,
+    interruptible: true
   },
   {
     id: 'browser_tabs',
     name: 'browser_tabs',
     description: 'List the open browser tabs and which is active.',
     category: 'Browser',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'browser_new_tab',
     name: 'browser_new_tab',
     description: 'Open a new browser tab (optionally at a URL).',
     category: 'Browser',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'browser_activate_tab',
     name: 'browser_activate_tab',
     description: 'Switch to a browser tab by its id.',
     category: 'Browser',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'browser_close',
     name: 'browser_close',
     description: 'Close the built-in browser.',
     category: 'Browser',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
 
   // ---- Automation (recurring loops + this session's metadata) ----
@@ -200,35 +251,40 @@ export const TOOLS: ToolDef[] = [
     name: 'loop_create',
     description: 'Create a scheduled loop that re-runs a prompt every N minutes.',
     category: 'Automation',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'loop_remove',
     name: 'loop_remove',
     description: 'Delete a loop by name or id.',
     category: 'Automation',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'loop_list',
     name: 'loop_list',
     description: 'List scheduled loops and whether each is running.',
     category: 'Automation',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'loop_enable',
     name: 'loop_enable',
     description: 'Resume a paused loop by name or id.',
     category: 'Automation',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'loop_disable',
     name: 'loop_disable',
     description: 'Pause a running loop by name or id.',
     category: 'Automation',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
   {
     id: 'change_session_metadata',
@@ -236,7 +292,8 @@ export const TOOLS: ToolDef[] = [
     description:
       "Set the session's title, description, task checklist, and workstream branch name.",
     category: 'Automation',
-    mutates: true
+    mutates: true,
+    interruptible: false
   },
 
   // ---- Agents & code intelligence ----
@@ -245,21 +302,27 @@ export const TOOLS: ToolDef[] = [
     name: 'task',
     description: 'Spawn a subagent to handle a sub-task (optionally in the background).',
     category: 'Agents',
-    mutates: false
+    mutates: false,
+    // NOT interruptible by the generic per-call path — it has its own, better
+    // cancel keyed by the delegate's session id. See the field's doc comment.
+    interruptible: false
   },
   {
     id: 'skill',
     name: 'skill',
     description: 'Load a packaged SKILL.md skill on demand.',
     category: 'Agents',
-    mutates: false
+    mutates: false,
+    interruptible: false
   },
   {
     id: 'lsp',
     name: 'lsp',
     description: 'Report language-server diagnostics for a file.',
     category: 'Agents',
-    mutates: false
+    mutates: false,
+    // Waits on a language server that may still be indexing a large project.
+    interruptible: true
   }
 ]
 
@@ -276,3 +339,21 @@ export function resolveToolIds(tools: string[] | 'all'): string[] {
 
 /** The distinct categories, in catalog order — for grouped rendering. */
 export const TOOL_CATEGORIES: ToolCategory[] = [...new Set(TOOLS.map((t) => t.category))]
+
+/**
+ * Whether a running call to this tool can be cancelled on its own.
+ *
+ * Unknown names are treated as interruptible, which covers MCP tools: they are
+ * contributed at runtime (so they can't be in this static catalog), they are a
+ * network round trip to someone else's server, and `runTool` already routes them
+ * through `untilAborted`. An unknown BUILT-IN name can't reach here — dispatch
+ * would have rejected it — so the permissive default has no other reachable case.
+ *
+ * `skill_manage` is likewise absent from the catalog (it isn't offered on the
+ * Skills & Tools page) but does take the signal for its GitHub fetch, so the
+ * default is right for it too.
+ */
+export function isInterruptibleTool(name: string): boolean {
+  const def = TOOL_BY_ID.get(name)
+  return def ? def.interruptible : true
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -219,6 +219,14 @@ export type MessagePart =
        * on every other tool, and on task cards from before this existed.
        */
       subChatId?: string
+      /**
+       * Whether this call could be cancelled while it was running — set from the
+       * `tool-start` event (see LlmEvent), which resolves it from the tool
+       * catalog. Only meaningful while `state === 'running'`; it is persisted
+       * with the rest of the card simply because the whole part is, and a
+       * settled card never reads it.
+       */
+      cancellable?: boolean
       /** Result body, shown when the card is expanded. */
       output?: string
       /** Optional inline image (data URL), e.g. a browser screenshot. */

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -2,7 +2,13 @@
  * Pure-Node validation of the shared catalogs (no Electron, no DB).
  * Run: npm run smoke:shared
  */
-import { TOOLS, getTool, resolveToolIds, TOOL_CATEGORIES } from '../src/shared/tools'
+import {
+  TOOLS,
+  getTool,
+  resolveToolIds,
+  TOOL_CATEGORIES,
+  isInterruptibleTool
+} from '../src/shared/tools'
 import {
   AGENTS,
   getAgent,
@@ -259,6 +265,36 @@ check(
   ['bash_list', 'bash_output', 'bash_kill'].every((id) => Boolean(getTool(id)))
 )
 check('resolveToolIds("all") expands to every tool', resolveToolIds('all').length === TOOLS.length)
+// ---- per-call cancel: the catalog flag must match what the harness can honor ----
+// The contract is honesty: `interruptible` is what draws the cancel button, so a
+// tool marked true whose dispatch ignores ctx.signal ships a button that lies.
+check(
+  'every tool declares whether it is interruptible',
+  TOOLS.every((t) => typeof t.interruptible === 'boolean')
+)
+check(
+  'the long-blocking tools are cancellable',
+  ['bash', 'webfetch', 'websearch', 'grep', 'glob', 'lsp', 'browser_open'].every((id) =>
+    isInterruptibleTool(id)
+  )
+)
+check(
+  'instant local tools offer no cancel button',
+  ['read', 'write', 'edit', 'list', 'loop_list', 'bash_list', 'change_session_metadata'].every(
+    (id) => !isInterruptibleTool(id)
+  )
+)
+// `task` has its OWN cancel (by sub chat id), which reports back to the parent
+// model properly. It must not also be routed through the generic per-call path,
+// or the card would offer the weaker of the two.
+check('task is excluded from the generic per-call cancel', !isInterruptibleTool('task'))
+// MCP tools are contributed at runtime, so they can never be in this static
+// catalog — but they ARE a network round trip and runTool wraps them in
+// untilAborted. The unknown-name default has to be permissive for that to work.
+check(
+  'an unknown (MCP) tool name defaults to cancellable',
+  isInterruptibleTool('mcp__github__create_issue') && isInterruptibleTool('skill_manage')
+)
 check('resolveToolIds passthrough', resolveToolIds(['read', 'bash']).join() === 'read,bash')
 // ---- catalog reflects reality (guards against drift back to the old aspirational list) ----
 check(
@@ -1316,11 +1352,22 @@ check('renderBackgroundStarted warns against polling', /DO NOT poll/i.test(start
     card.type === 'tool' && !('subChatId' in (card.input ?? {}))
   )
 
-  fold.apply({ type: 'tool-start', callId: 'b1', tool: 'bash', title: 'ls' })
+  fold.apply({ type: 'tool-start', callId: 'b1', tool: 'bash', title: 'ls', cancellable: true })
   const plain = fold.parts[1]
   check(
     'fold: a non-task card has no subChatId',
     plain.type === 'tool' && plain.subChatId === undefined
+  )
+  // The other half of the cancel addressing: whether THIS call can be aborted on
+  // its own. Decided in the harness (only it knows an MCP tool's runtime name)
+  // and carried on the event, so the button and the signal cannot disagree.
+  check(
+    'fold: a card keeps its cancellable flag',
+    plain.type === 'tool' && plain.cancellable === true
+  )
+  check(
+    'fold: cancellable stays out of the model-facing input',
+    plain.type === 'tool' && !('cancellable' in (plain.input ?? {}))
   )
 
   // Resuming a run (opening a subagent session mid-flight) must not lose it.
@@ -1331,6 +1378,15 @@ check('renderBackgroundStarted warns against polling', /DO NOT poll/i.test(start
   check(
     'fold: subChatId survives a seed + later tool-end',
     after.type === 'tool' && after.subChatId === 'sub-42' && after.state === 'done'
+  )
+  // A cancelled call still emits a normal tool-end (that is what keeps the
+  // model's tool_calls -> role:'tool' pairing valid), so the card must settle
+  // into `error` rather than spinning forever.
+  resumed.apply({ type: 'tool-end', callId: 'b1', output: 'stopped', ok: false })
+  const cancelled = resumed.parts[1]
+  check(
+    'fold: a cancelled call settles as an error card, not a stuck spinner',
+    cancelled.type === 'tool' && cancelled.state === 'error' && cancelled.output === 'stopped'
   )
 }
 

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -57,6 +57,13 @@ import {
   cancelSessionBackgroundJobs,
   _resetBackgroundJobs
 } from '../src/main/services/background-tasks'
+import {
+  startToolRun,
+  cancelToolCall,
+  cancelToolCallsFor,
+  wasToolCallCancelled,
+  _resetToolRuns
+} from '../src/main/services/tool-runs'
 import * as lsp from '../src/main/services/lsp'
 import {
   ensureMcpConnected,
@@ -2501,6 +2508,135 @@ async function main(): Promise<void> {
       '_resetBackgroundJobs clears the registry',
       listRunningBackgroundJobs(s1).length === 0 && !hasActiveBackgroundJobs(s1)
     )
+  }
+
+  // ---- per-call tool cancellation: the registry that makes Stop granular ----
+  // Stop used to be all-or-nothing: a wedged `bash` could only be escaped by
+  // killing the whole turn, losing its reasoning and every other tool result.
+  {
+    _resetToolRuns()
+    let aborted = false
+    const run = startToolRun({
+      callId: 'call_1',
+      tool: 'bash',
+      sessionId: 'sess_1',
+      cancel: () => {
+        aborted = true
+      }
+    })
+    check('a fresh tool run is not cancelled', run.wasCancelled() === false)
+    check('cancelToolCall finds a running call', cancelToolCall('call_1') === true)
+    check('cancelToolCall aborts the call', aborted === true)
+    // The flag is how the harness tells "the user did this" from "the tool
+    // failed" — both abort the same signal, so only the registry knows which.
+    check(
+      'a cancelled call is marked as such',
+      run.wasCancelled() && wasToolCallCancelled('call_1')
+    )
+
+    // Cancelling something that already finished must report false, so the UI
+    // never pretends it did something.
+    run.end()
+    check('a finished call is gone from the registry', cancelToolCall('call_1') === false)
+    check('an unknown call id cancels nothing', cancelToolCall('nope') === false)
+
+    // `end` is idempotent, and a duplicate call id (providers do reuse them
+    // across steps) must leave the NEWER call cancellable rather than have the
+    // older one's teardown deregister it.
+    _resetToolRuns()
+    let secondAborted = false
+    const first = startToolRun({ callId: 'dup', tool: 'bash', sessionId: 's', cancel: () => {} })
+    const second = startToolRun({
+      callId: 'dup',
+      tool: 'bash',
+      sessionId: 's',
+      cancel: () => {
+        secondAborted = true
+      }
+    })
+    first.end()
+    check('a replaced call id stays cancellable', cancelToolCall('dup') === true && secondAborted)
+    second.end()
+
+    // A session-wide sweep hits only that session's calls.
+    _resetToolRuns()
+    let mine = false
+    let theirs = false
+    const a2 = startToolRun({
+      callId: 'c_a',
+      tool: 'bash',
+      sessionId: 'sess_a',
+      cancel: () => {
+        mine = true
+      }
+    })
+    const b2 = startToolRun({
+      callId: 'c_b',
+      tool: 'bash',
+      sessionId: 'sess_b',
+      cancel: () => {
+        theirs = true
+      }
+    })
+    cancelToolCallsFor('sess_a')
+    check('cancelToolCallsFor is scoped to one session', mine === true && theirs === false)
+    // A session-wide Stop aborts the same signal but must NOT mark the call as
+    // individually cancelled: that flag makes the harness tell the model "you
+    // cancelled this, carry on with the rest of your work" — a lie in a
+    // transcript whose entire turn just stopped.
+    check(
+      'a session-wide stop is not recorded as a per-call cancel',
+      a2.wasCancelled() === false && wasToolCallCancelled('c_a') === false
+    )
+    // A throwing cancel must not break the sweep for the calls after it.
+    const boom = startToolRun({
+      callId: 'c_boom',
+      tool: 'bash',
+      sessionId: 'sess_b',
+      cancel: () => {
+        throw new Error('nope')
+      }
+    })
+    cancelToolCallsFor('sess_b')
+    check('a throwing cancel does not break the sweep', theirs === true)
+    a2.end()
+    b2.end()
+    boom.end()
+    _resetToolRuns()
+  }
+
+  // ---- end to end: cancelling one call kills the real process ----
+  // The registry above is bookkeeping; this proves the signal reaches the work.
+  // A 30s sleep would hold the turn open for its full duration — the exact case
+  // the feature exists for — so this must return in well under that.
+  {
+    _resetToolRuns()
+    const controller = new AbortController()
+    const started = Date.now()
+    const run = startToolRun({
+      callId: 'sleepy',
+      tool: 'bash',
+      sessionId: ws,
+      cancel: () => controller.abort()
+    })
+    const sleeping = runTool(
+      'bash',
+      { command: process.platform === 'win32' ? 'timeout /t 30 /nobreak' : 'sleep 30' },
+      { cwd: ws, signal: controller.signal }
+    )
+    // Give the shell a moment to actually spawn before pulling the rug.
+    await new Promise((r) => setTimeout(r, 400))
+    check('the sleeping call is cancellable', cancelToolCall('sleepy') === true)
+    const result = await sleeping
+    const elapsed = Date.now() - started
+    run.end()
+    check(
+      'cancelling one call returns long before its command would end',
+      elapsed < 10_000,
+      `${elapsed}ms`
+    )
+    check('a cancelled bash is not reported as ok', result.ok === false)
+    _resetToolRuns()
   }
 
   // ---- LSP diagnostics after edit (Phase 12) via a real mock language server ----


### PR DESCRIPTION
Stop was all-or-nothing. A turn that fired `bash npm test` on a wedged suite, or a `webfetch` at a host that never answers, left exactly one lever: kill the entire turn -- throwing away the model's reasoning and every other tool result alongside the one call you wanted gone.

Running tool cards now offer the same stop button subagents already had. Clicking it aborts that call only; the turn keeps going and the model reads a "the user cancelled this, carry on" result for it.

Each call gets its own AbortController chained to the turn's signal -- the shape a subagent already gets. Stop still cascades down; cancelling one call aborts only its own controller. A cancelled call still emits a normal tool-end, which is load-bearing rather than incidental: providers require a role:'tool' result for every tool_calls entry, so skipping the normal exit path would leave a dangling call and 400 the next request.

The button is opt-in per tool. ToolDef.interruptible marks only the tools whose dispatch genuinely honors ctx.signal -- a `read` returns in 2ms, so a button there is theater, and a Stop that does nothing is worse than no Stop. Unknown names default to cancellable, covering runtime MCP tools. A shared test pins the flag against reality so it cannot rot. `task` is excluded: it already has a better cancel keyed by its session id that reports back to the parent model, and routing it here would downgrade it.

Also: grep and glob now honor the signal (they ignored it), and the button waits 1.2s before fading in -- otherwise it strobes on every fast tool through a normal turn, which reads as jitter and trains you to ignore it. `task` skips that delay, since it was immediate before and a delegate never finishes that fast.

The session-wide Stop sweep deliberately does NOT set the cancelled flag: that flag makes the harness say "carry on with the rest of your work", a lie in a transcript whose entire turn just ended.