### PR TITLE
chore: point release/update feed at roxy-gg/roxy and bump to 0.0.79

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Roxy (https://github.com/FreddyJD/roxy)
+Copyright (c) 2026 Roxy (https://github.com/roxy-gg/roxy)
 Copyright (c) 2025 opencode (https://github.com/sst/opencode)
 
 Roxy is a fork of opencode. The copyright notice above and the permission

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -3,6 +3,6 @@
 # uses the generated app-update.yml instead. Excluded from the build (see the
 # `files` globs in electron-builder.yml).
 provider: github
-owner: FreddyJD
+owner: roxy-gg
 repo: roxy
 updaterCacheDirName: roxy-updater

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -43,5 +43,5 @@ appImage:
 npmRebuild: true
 publish:
   provider: github
-  owner: FreddyJD
+  owner: roxy-gg
   repo: roxy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.78",
+      "version": "0.0.79",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "roxy",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
-  "author": "Roxy (https://github.com/FreddyJD/roxy)",
+  "author": "Roxy (https://github.com/roxy-gg/roxy)",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/FreddyJD/roxy.git"
+    "url": "https://github.com/roxy-gg/roxy.git"
   },
   "engines": {
     "node": ">=20"

--- a/resources/prompts/anthropic.txt
+++ b/resources/prompts/anthropic.txt
@@ -7,7 +7,7 @@ IMPORTANT: You must NEVER generate or guess URLs for the user unless you are con
 If the user asks for help or wants to give feedback inform them of the following:
 - Open Settings to configure Roxy
 - To give feedback, users should report the issue at
-  https://github.com/FreddyJD/roxy
+  https://github.com/roxy-gg/roxy
 
 When the user directly asks about Roxy (eg. "can Roxy do...", "does Roxy have..."), or asks in second person (eg. "are you able...", "can you do..."), answer based on your available tools and the capabilities described in this prompt.
 

--- a/resources/prompts/default.txt
+++ b/resources/prompts/default.txt
@@ -4,7 +4,7 @@ IMPORTANT: You must NEVER generate or guess URLs for the user unless you are con
 
 If the user asks for help or wants to give feedback inform them of the following:
 - Open Settings to get help with using Roxy
-- To give feedback, users should report the issue at https://github.com/FreddyJD/roxy/issues
+- To give feedback, users should report the issue at https://github.com/roxy-gg/roxy/issues
 
 When the user directly asks about Roxy (eg 'can Roxy do...', 'does Roxy have...') or asks in second person (eg 'are you able...', 'can you do...'), answer based on your available tools and the capabilities described in this prompt.
 


### PR DESCRIPTION
The repo moved from FreddyJD/roxy to roxy-gg/roxy. electron-builder's `publish.owner` is baked into the packaged app-update.yml, which is the feed electron-updater polls, so it has to track the new owner or shipped builds keep checking the old repo's releases.

- electron-builder.yml + dev-app-update.yml: owner -> roxy-gg
- package.json author/repository, LICENSE, and the feedback URL in the system prompts