### PR TITLE
Show thinking effort for Roxy inference

### DIFF
--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -68,6 +68,7 @@ import { startToolRun } from '../services/tool-runs'
 import {
   messagesHaveImages,
   openAiContent,
+  openAiReasoning,
   openaiEndpoint,
   streamChat,
   withCopilotRetry,
@@ -1795,7 +1796,9 @@ async function streamOnce(
     messages,
     tools,
     tool_choice: 'auto',
-    ...(reasoning && effort ? { reasoning_effort: effort } : {}),
+    // Via the shared helper, not a raw spread: it is what knows which providers
+    // accept xhigh/max and which 400 on anything past high.
+    ...openAiReasoning(providerId, reasoning, effort),
     stream: true,
     // Ask OpenAI-compatible providers for a final token-usage chunk. Providers
     // that ignore it just don't send one — we fall back to an estimate below.

--- a/src/main/services/llm.ts
+++ b/src/main/services/llm.ts
@@ -223,18 +223,30 @@ const THINK_BUDGET: Record<ReasoningEffort, number> = {
 }
 
 /**
- * OpenAI-style `reasoning_effort`, only when the model supports reasoning.
- * GitHub Copilot accepts the full Low→Max ladder (it's exactly what VS Code
- * sends for Claude); strict OpenAI-compatible endpoints only know low/medium/
- * high, so clamp the extra levels there to avoid a 400.
+ * Providers that accept the full Low->Max ladder.
+ *
+ * GitHub Copilot does because it is exactly what VS Code sends for Claude.
+ * Roxy's own gateway does because it publishes a PER-MODEL ladder in its
+ * catalog (`ModelInfo.reasoningEfforts`) that callers clamp against before we
+ * get here - capping it again to `high` would silently discard a level the
+ * model genuinely supports and the user explicitly picked.
+ *
+ * Everything else is a strict OpenAI-compatible endpoint that only knows
+ * low/medium/high, where an extra level is a 400 rather than a nuance.
  */
-function openAiReasoning(
+const FULL_EFFORT_LADDER_PROVIDERS = new Set(['github-copilot', 'roxy'])
+
+/**
+ * OpenAI-style `reasoning_effort`, only when the model supports reasoning.
+ * Clamps the ladder to what the provider accepts (see above).
+ */
+export function openAiReasoning(
   providerId: string,
   reasoning?: boolean,
   effort?: ReasoningEffort
 ): { reasoning_effort?: ReasoningEffort } {
   if (!reasoning || !effort) return {}
-  if (providerId !== 'github-copilot' && (effort === 'xhigh' || effort === 'max')) {
+  if (!FULL_EFFORT_LADDER_PROVIDERS.has(providerId) && (effort === 'xhigh' || effort === 'max')) {
     return { reasoning_effort: 'high' }
   }
   return { reasoning_effort: effort }

--- a/src/main/services/models.ts
+++ b/src/main/services/models.ts
@@ -4,6 +4,8 @@
  * Fetched once and cached (the JSON is large; ~144 providers).
  */
 import type { ModelInfo, ModelCost } from '../../shared/api'
+import type { ReasoningEffort } from '../../shared/types'
+import { REASONING_EFFORTS } from '../../shared/session-config'
 import { getProviderToken, listConnectedProviders } from '../db/repo'
 import { isCliProxyProvider } from '../../shared/cliproxy'
 import { ensureRunning as ensureCliProxy, listProxyModels } from './cliproxy'
@@ -42,10 +44,88 @@ const ROXY_DEFAULT_BASE = 'https://roxy.gg/v1'
 const ROXY_TTL_MS = 5 * 60 * 1000
 let roxyCache: { at: number; data: ModelInfo[] } | null = null
 
+/**
+ * A model as roxy.gg's gateway reports it (an OpenRouter-shaped record).
+ *
+ * Two fields matter beyond the name: `supported_parameters` says whether
+ * the model can take tools and a reasoning effort at all, and `reasoning`
+ * gives the PER-MODEL effort ladder. `pricing` is USD per SINGLE token
+ * here, not per 1M like models.dev.
+ */
 interface RoxyModel {
   id: string
   name?: string
   context_length?: number
+  supported_parameters?: string[]
+  reasoning?: {
+    mandatory?: boolean
+    default_enabled?: boolean
+    supported_efforts?: string[]
+    default_effort?: string
+  }
+  pricing?: {
+    prompt?: string
+    completion?: string
+    input_cache_read?: string
+    input_cache_write?: string
+  }
+  top_provider?: { context_length?: number; max_completion_tokens?: number }
+}
+
+/** Parse a roxy.gg per-token price string into USD per 1M tokens. */
+function perMillion(v: string | undefined): number | undefined {
+  if (typeof v !== 'string' || v === '') return undefined
+  const n = Number(v)
+  return Number.isFinite(n) ? n * 1_000_000 : undefined
+}
+
+/** roxy.gg `pricing` (USD per token) -> our ModelCost (USD per 1M tokens). */
+function roxyCost(p: RoxyModel['pricing']): ModelCost | undefined {
+  if (!p) return undefined
+  const cost: ModelCost = {}
+  const input = perMillion(p.prompt)
+  const output = perMillion(p.completion)
+  const cacheRead = perMillion(p.input_cache_read)
+  const cacheWrite = perMillion(p.input_cache_write)
+  if (input !== undefined) cost.input = input
+  if (output !== undefined) cost.output = output
+  if (cacheRead !== undefined) cost.cacheRead = cacheRead
+  if (cacheWrite !== undefined) cost.cacheWrite = cacheWrite
+  return Object.keys(cost).length ? cost : undefined
+}
+
+/**
+ * The model's effort ladder, narrowed to the levels Roxy's picker has.
+ *
+ * The gateway also reports `minimal` and `none`, which sit below our
+ * weakest rung and have no UI - they are dropped rather than folded into
+ * `low`, since
+ * silently spending more thinking than the model was told to is worse than
+ * offering one fewer level. An empty result means "no usable ladder", which
+ * reads as unknown so the full range stays available.
+ */
+function roxyEfforts(m: RoxyModel): ReasoningEffort[] | undefined {
+  const raw = m.reasoning?.supported_efforts
+  if (!Array.isArray(raw)) return undefined
+  const efforts = REASONING_EFFORTS.filter((e) => raw.includes(e))
+  return efforts.length ? efforts : undefined
+}
+
+/**
+ * Whether the gateway will accept a thinking effort for this model.
+ *
+ * `supported_parameters` is the authority (it is what the request
+ * validator reads); the `reasoning` block alone is enough for models that think
+ * unconditionally, where effort is implicit rather than a parameter.
+ */
+function roxyReasoning(m: RoxyModel): boolean {
+  const params = m.supported_parameters ?? []
+  return (
+    params.includes('reasoning_effort') ||
+    params.includes('reasoning') ||
+    Boolean(m.reasoning?.mandatory) ||
+    Boolean(m.reasoning?.default_enabled)
+  )
 }
 
 /** Where to fetch the Roxy catalog from + how to authenticate, if at all. */
@@ -58,16 +138,31 @@ function roxyCatalogSource(): { url: string; token: string | null } {
   return { url: `${base}/models`, token }
 }
 
+/**
+ * Map the gateway's catalog into ModelInfo, KEEPING the capability flags.
+ *
+ * These used to be hardcoded to false, which quietly disabled three features
+ * for every roxy.gg model at once: the thinking-effort picker hides itself
+ * when `reasoning` is false, `pickDefaultModel` skips models that
+ * are not tool-capable, and unpriced models make the usage meter report zero
+ * spend. The gateway reports all three, so read them rather than assume.
+ */
 function toModelInfo(body: { data?: RoxyModel[] }): ModelInfo[] {
   return (body.data ?? [])
-    .map((m) => ({
-      id: m.id,
-      name: m.name || m.id,
-      reasoning: false,
-      toolCall: false,
-      contextLimit: m.context_length,
-      outputLimit: undefined
-    }))
+    .map((m) => {
+      const reasoning = roxyReasoning(m)
+      const cost = roxyCost(m.pricing)
+      return {
+        id: m.id,
+        name: m.name || m.id,
+        reasoning,
+        toolCall: (m.supported_parameters ?? []).includes('tools'),
+        ...(reasoning ? { reasoningEfforts: roxyEfforts(m) } : {}),
+        contextLimit: m.context_length ?? m.top_provider?.context_length,
+        outputLimit: m.top_provider?.max_completion_tokens,
+        ...(cost ? { cost } : {})
+      }
+    })
     .sort((a, b) => a.name.localeCompare(b.name))
 }
 
@@ -201,6 +296,12 @@ export async function listModels(providerId: string): Promise<ModelInfo[]> {
  * catalog before running, so by record-pricing time the cache is warm.
  */
 export function modelCost(providerId: string, modelId: string): ModelCost | undefined {
+  // Roxy's gateway isn't in models.dev and prices its own (marked-up) catalog,
+  // so read the price the user is actually charged from the roxy cache. Without
+  // this every roxy turn records $0 and the usage meter reports no spend at all.
+  if (providerId === 'roxy') {
+    return roxyCache?.data.find((m) => m.id === modelId)?.cost
+  }
   if (!cache) return undefined
   const models = cache.data[providerId]?.models
   if (!models) return undefined

--- a/src/main/services/remote.ts
+++ b/src/main/services/remote.ts
@@ -32,7 +32,11 @@ import type { Message } from '../../shared/types'
 import { reconstructTurn } from '../../shared/tool-history'
 import { PartsFold, partsToContent } from '../../shared/parts'
 import { pruneToolMessages, KEEP_RECENT_TOKENS } from '../../shared/context'
-import { contextBudgetFor, resolveSessionConfig } from '../../shared/session-config'
+import {
+  clampReasoningEffort,
+  contextBudgetFor,
+  resolveSessionConfig
+} from '../../shared/session-config'
 import * as repo from '../db/repo'
 import { listModels } from './models'
 import { pickDefaultModel } from '../../shared/models'
@@ -494,7 +498,9 @@ async function runTurn(
         // when it is driven from the phone.
         agentId: config.agentId,
         reasoning: info?.reasoning ?? false,
-        reasoningEffort: config.reasoningEffort,
+        // Same clamp as the desktop send path: the session's effort is sticky,
+        // the model's ladder is not, and an unsupported level 400s the turn.
+        reasoningEffort: clampReasoningEffort(config.reasoningEffort, info?.reasoningEfforts),
         contextLimit: contextBudget
       },
       (event) => {

--- a/src/renderer/src/components/InferenceControls.tsx
+++ b/src/renderer/src/components/InferenceControls.tsx
@@ -5,7 +5,9 @@ import type { ModelInfo } from '@shared/api'
 import { PRIMARY_AGENTS, getAgent, DEFAULT_AGENT_ID } from '@shared/agents'
 import { buildSystemPrompt, useRoxyStore } from '../lib/store'
 import {
+  clampReasoningEffort,
   contextBudgetFor,
+  DEFAULT_REASONING_EFFORT,
   effectiveContextMax,
   resolveSessionConfig,
   type SessionConfig
@@ -131,8 +133,20 @@ export function ThinkingPicker(): JSX.Element | null {
   const { open, setOpen, ref, anchor } = usePopover(POPOVER_W)
 
   if (!info?.reasoning) return null
-  const current = config.reasoningEffort
-  const currentLabel = EFFORTS.find((e) => e.value === current)?.label ?? 'High'
+  // Offer only the rungs this model accepts, when the provider says which.
+  // A gateway like roxy.gg reports a per-model ladder, and several models
+  // expose just one level - listing Max there would render a choice that 400s.
+  const efforts = info.reasoningEfforts?.length
+    ? EFFORTS.filter((e) => info.reasoningEfforts!.includes(e.value))
+    : EFFORTS
+  // What the session is SET to may not be what this model will run: a session
+  // left on Max that switches to a high-only model sends `high`. Show the level
+  // that will actually be used, so the footer never states a comfortable lie.
+  const current = clampReasoningEffort(config.reasoningEffort, info.reasoningEfforts)
+  const currentLabel = efforts.find((e) => e.value === current)?.label ?? 'High'
+  // "Default" marks the level a session starts on — clamped too, so a model
+  // without `high` still marks one row instead of none.
+  const defaultEffort = clampReasoningEffort(DEFAULT_REASONING_EFFORT, info.reasoningEfforts)
 
   return (
     <div ref={ref} className="relative">
@@ -151,7 +165,7 @@ export function ThinkingPicker(): JSX.Element | null {
             Thinking Effort
           </div>
           <div className="py-1">
-            {EFFORTS.map((e) => {
+            {efforts.map((e) => {
               const selected = e.value === current
               return (
                 <button
@@ -171,7 +185,7 @@ export function ThinkingPicker(): JSX.Element | null {
                   />
                   <span className="text-xs font-medium text-text">{e.label}</span>
                   <span className="ml-auto text-[11px] text-text-subtle">
-                    {e.value === 'high' ? 'Default' : ''}
+                    {e.value === defaultEffort ? 'Default' : ''}
                   </span>
                 </button>
               )

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -30,6 +30,7 @@ import { PartsFold, partsToContent } from '@shared/parts'
 import { isOverflow, pruneToolMessages, KEEP_RECENT_TOKENS } from '@shared/context'
 import { pickDefaultModel } from '@shared/models'
 import {
+  clampReasoningEffort,
   contextBudgetFor,
   resolveSessionConfig,
   type SessionConfig,
@@ -1684,7 +1685,10 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
           messages: chatMessages,
           agentId,
           reasoning: info?.reasoning ?? false,
-          reasoningEffort: config.reasoningEffort,
+          // Clamp to what THIS model accepts. A session's effort is sticky
+          // across model switches, so "Max" set on one model would otherwise
+          // ride along to a model that only knows `high` and 400 the turn.
+          reasoningEffort: clampReasoningEffort(config.reasoningEffort, info?.reasoningEfforts),
           contextLimit: contextBudget
         })
       } catch (e) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -395,6 +395,13 @@ export interface ModelInfo {
   name: string
   reasoning: boolean
   toolCall: boolean
+  /**
+   * The effort levels this model actually accepts, when the provider says so.
+   * Undefined = unknown, so the full Low..Max ladder is offered and clamping
+   * falls back to per-provider rules. An explicit list lets the picker hide
+   * levels the model would reject, and lets the wire send one it accepts.
+   */
+  reasoningEfforts?: ReasoningEffort[]
   /** Max input context window in tokens, when known. */
   contextLimit?: number
   /** Max output tokens, when known. */

--- a/src/shared/session-config.ts
+++ b/src/shared/session-config.ts
@@ -49,6 +49,36 @@ export type SessionConfigSource = Pick<
 
 export const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'high'
 
+/** The full ladder, weakest to strongest — the order the picker renders. */
+export const REASONING_EFFORTS: ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh', 'max']
+
+/**
+ * Narrow a chosen effort to one the model will actually accept.
+ *
+ * Providers disagree about the ladder: OpenAI-compatible endpoints classically
+ * know low/medium/high, Copilot takes the whole Low->Max range, and a gateway
+ * like roxy.gg reports a PER-MODEL list (
+easoningEfforts) where a model may
+ * expose only ['high']. Sending an unsupported level is a 400, so a session
+ * left on Max must degrade to the nearest supported level rather than fail.
+ *
+ * "Nearest" is deliberately downward-first: too much thinking costs money the
+ * user did not ask for, too little only costs quality. We fall back to the
+ * strongest supported level only when nothing weaker exists.
+ */
+export function clampReasoningEffort(
+  effort: ReasoningEffort,
+  supported: ReasoningEffort[] | undefined
+): ReasoningEffort {
+  if (!supported || supported.length === 0) return effort
+  const allowed = REASONING_EFFORTS.filter((e) => supported.includes(e))
+  if (allowed.length === 0) return effort
+  if (allowed.includes(effort)) return effort
+  const want = REASONING_EFFORTS.indexOf(effort)
+  const weaker = allowed.filter((e) => REASONING_EFFORTS.indexOf(e) < want)
+  return weaker.length ? weaker[weaker.length - 1] : allowed[0]
+}
+
 /** Narrow an untrusted string (DB column, IPC payload) to a ReasoningEffort. */
 export function parseReasoningEffort(v: unknown): ReasoningEffort | null {
   return v === 'low' || v === 'medium' || v === 'high' || v === 'xhigh' || v === 'max' ? v : null

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -87,6 +87,7 @@ import {
   placeholderBranchName
 } from '../src/shared/branch'
 import {
+  clampReasoningEffort,
   contextBudgetFor,
   effectiveContextMax,
   parseReasoningEffort,
@@ -3960,6 +3961,31 @@ async function main(): Promise<void> {
     parseReasoningEffort('turbo') === null &&
       parseReasoningEffort(null) === null &&
       parseReasoningEffort(7) === null
+  )
+
+  // clampReasoningEffort keeps a sticky session effort from 400ing a model that
+  // publishes a narrower ladder (roxy.gg reports one per model).
+  check(
+    'clamp effort: an unknown ladder is left alone',
+    clampReasoningEffort('max', undefined) === 'max' && clampReasoningEffort('low', []) === 'low'
+  )
+  check(
+    'clamp effort: a supported level passes through',
+    clampReasoningEffort('high', ['low', 'high', 'max']) === 'high'
+  )
+  check(
+    'clamp effort: an unsupported level steps DOWN to the nearest supported one',
+    clampReasoningEffort('max', ['low', 'high']) === 'high' &&
+      clampReasoningEffort('xhigh', ['low', 'medium']) === 'medium'
+  )
+  check(
+    'clamp effort: with nothing weaker it takes the weakest supported level',
+    clampReasoningEffort('low', ['xhigh', 'max']) === 'xhigh'
+  )
+  check(
+    'clamp effort: a single-level ladder always resolves to that level',
+    clampReasoningEffort('max', ['high']) === 'high' &&
+      clampReasoningEffort('low', ['high']) === 'high'
   )
 
   // Claude reports a 200K base but really exposes 1M - the picker's ceiling.


### PR DESCRIPTION
The thinking-effort picker hid itself for every roxy.gg model, because the catalog mapper hardcoded the capability flags to false:

    reasoning: false,
    toolCall: false,

Every other provider is described by models.dev, which supplies real flags. Roxy's gateway has its own (OpenRouter-shaped) catalog and the mapper threw away everything but id/name/context, so the `if (!info?.reasoning) return null` guard in ThinkingPicker fired for all 332 models.

That one line broke three things at once: the effort picker was hidden, pickDefaultModel skipped every model (it prefers `toolCall`, always false) and fell through to "first alphabetically", and unpriced models made the usage meter record $0 for every Roxy turn.

So: read what the gateway actually reports. Against the live catalog that is 210/332 models reasoning-capable, 269 tool-capable and all 332 priced. Prices are scaled x1e6 -- roxy.gg quotes USD per single token, models.dev per 1M -- and are already marked up server-side with the same multiplier that bills the team, so the meter's estimate lines up with the ledger.

Roxy also reports a per-model effort ladder, and the ladders genuinely differ (gemini-3.6-flash is low/medium/high; claude-opus-5-fast has all five). Since a session's effort is sticky across model switches, "Max" set on one model would ride along to a model that only knows `high` and 400 the turn. New clampReasoningEffort steps *down* to the nearest supported level -- too much thinking costs money nobody asked for, too little only costs quality -- and the picker both filters to the supported rungs and labels the clamped value, so the footer never claims an effort that will not be used.

Two latent bugs surfaced on the way:

  - the agent harness spread `reasoning_effort` in raw, bypassing the provider clamp entirely, so xhigh/max reached strict OpenAI-compatible endpoints that only know low/medium/high. Now routed through the shared openAiReasoning helper.
  - that helper keyed off `providerId !== 'github-copilot'`, which would have capped Roxy back to `high` and discarded levels its models really do support. Replaced with an explicit provider set.

No server change is required for this to work: managed inference defaults to off, and the plain proxy path forwards `reasoning_effort` untouched.