### PR TITLE
feat: anonymous usage tracking with a real opt-out

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import { shutdownAllMcp } from './services/mcp'
 import { shutdownRemote } from './services/remote'
 import { shutdownCliProxy } from './services/cliproxy'
 import { initAutoUpdater } from './services/updater'
+import { initTracking, shutdownTracking } from './services/track'
 import { killAllBackground, setPromptText, setAgentPromptText } from './harness'
 import { PROMPT_TEXT, AGENT_PROMPT_TEXT } from '../shared/prompt-text'
 
@@ -105,6 +106,10 @@ app.whenReady().then(() => {
   // Open the database (runs migrations) and wire up IPC before the first window.
   getDb()
   registerIpc()
+  // Anonymous usage tracking (opt-out in Settings). Deliberately after the DB
+  // and IPC are up so nothing here can delay the first window, and it owns its
+  // own storage - a failure in it can't touch either.
+  initTracking()
   startLoopScheduler()
   // Sweep tool-output spill files older than the retention window (best-effort).
   void cleanupToolOutputs()
@@ -130,6 +135,13 @@ app.on('window-all-closed', () => {
 // Kill any agent-started background processes (dev servers/watchers) on quit,
 // cancel any in-flight background subagent tasks (Phase 11), and shut down any
 // warm language servers (Phase 12).
+// Last chance to send the queued events: 'before-quit' fires before windows
+// start tearing down, which gives the final flush a real (if not guaranteed)
+// window to reach the network. Losing it costs one app_close, nothing more.
+app.on('before-quit', () => {
+  shutdownTracking()
+})
+
 app.on('will-quit', () => {
   killAllBackground()
   cancelAllBackgroundJobs()

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -73,6 +73,7 @@ import {
   installSkillFromSource
 } from '../services/skills'
 import { runSessionTurn } from '../services/session-turn'
+import { isTrackingEnabled, setTrackingEnabled } from '../services/track'
 import * as remote from '../services/remote'
 import { buildExport, applyImport } from '../services/portable'
 import { promises as fsp } from 'node:fs'
@@ -194,6 +195,13 @@ export function registerIpc(): void {
     }
     return repo.resetAll()
   })
+
+  // Telemetry lives outside the settings table (see services/track), so it gets
+  // its own handlers instead of riding along on AppSettings.
+  ipcMain.handle(CHANNELS.settingsGetTelemetry, () => isTrackingEnabled())
+  ipcMain.handle(CHANNELS.settingsSetTelemetry, (_e, enabled: boolean) =>
+    setTrackingEnabled(enabled)
+  )
 
   // ---- providers ----
   ipcMain.handle(CHANNELS.providersList, () => repo.listConnectedProviders())

--- a/src/main/services/remote.ts
+++ b/src/main/services/remote.ts
@@ -41,6 +41,7 @@ import * as repo from '../db/repo'
 import { listModels } from './models'
 import { pickDefaultModel } from '../../shared/models'
 import { runSessionTurn } from './session-turn'
+import { track } from './track'
 import { sessionCwd } from './workspace'
 import {
   MAX_FRAME_BYTES,
@@ -693,6 +694,9 @@ function onFrame(raw: string): void {
   if (!frame || typeof frame.t !== 'string' || !share) return
   switch (frame.t) {
     case 'guest-joined': {
+      // A pairing actually completed. Counted here rather than at share start:
+      // opening a share nobody scans isn't someone using Remote Workspace.
+      track('remote_pair')
       // A phone entered the PIN and paired — send it the workspace session list
       // plus the current session's transcript + live turn state.
       share.guests = typeof frame.guests === 'number' ? frame.guests : share.guests

--- a/src/main/services/session-turn.ts
+++ b/src/main/services/session-turn.ts
@@ -17,6 +17,7 @@ import { protectedSubChatIds } from './subagent-stream'
 import { setLabel as setBrowserLabel } from './browser'
 import { sessionCwd } from './workspace'
 import { materializePendingWorktree } from './worktree'
+import { track } from './track'
 import path from 'node:path'
 
 /**
@@ -55,6 +56,30 @@ function keepSubchats(): Set<string> {
  * `{ ok: false, error }` on failure (a caller-triggered abort reports "Stopped.").
  */
 export async function runSessionTurn(
+  input: LlmStartInput,
+  emit: (event: LlmEvent) => void,
+  signal: AbortSignal
+): Promise<LlmResult> {
+  // Usage tracking wraps the whole turn HERE, not at either caller: this is the
+  // one function both the local (renderer) and remote (phone) paths go through,
+  // so counting here is the only way the two can't drift. It records that a turn
+  // happened and how it ended - never what was said, which model ran, or where.
+  track('prompt')
+  const startedAt = Date.now()
+  try {
+    const result = await runTurn(input, emit, signal)
+    track('turn_end', { ok: result.ok, durationMs: Date.now() - startedAt })
+    return result
+  } catch (e) {
+    // runTurn maps its own failures, so reaching here means an unexpected one.
+    // Count it as a failed turn and rethrow untouched - tracking never changes
+    // behaviour.
+    track('turn_end', { ok: false, durationMs: Date.now() - startedAt })
+    throw e
+  }
+}
+
+async function runTurn(
   input: LlmStartInput,
   emit: (event: LlmEvent) => void,
   signal: AbortSignal

--- a/src/main/services/track.ts
+++ b/src/main/services/track.ts
@@ -1,0 +1,273 @@
+/**
+ * Anonymous usage tracking.
+ *
+ * WHAT IT SENDS: a random UUID minted once at install, an event name, and the
+ * coarse build facts (platform, arch, app version, stable/dev). No account, no
+ * IP, no file paths, no prompt text, no model or provider, no repo names. The
+ * server HMACs the id before storing it, so a row can't be mapped back to the
+ * id this client holds.
+ *
+ * WHY IT'S SHAPED LIKE THIS:
+ *  - **Never blocks the app.** Every call is fire-and-forget and every failure
+ *    is swallowed. Analytics must not be able to break, slow, or crash a launch.
+ *  - **Queued and batched.** Events accumulate and flush on a timer, so a user
+ *    on a plane doesn't lose their session and we don't make one HTTP request
+ *    per action.
+ *  - **Idempotent.** Each event carries a `clientId`; the server dedupes on it,
+ *    so re-sending a failed batch can't inflate the numbers.
+ *  - **Opt-out is real.** `setTrackingEnabled(false)` stops collection *and*
+ *    drops anything already queued.
+ *
+ * The install id and the opt-out live in their own JSON file, NOT in the
+ * settings table: a factory reset (`repo.resetAll`) wipes settings, and someone
+ * who opted out must stay opted out across one. It also means tracking has no
+ * dependency on the database being open or mid-migration.
+ */
+import { randomUUID } from 'node:crypto'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { app } from 'electron'
+
+/** Production ingest endpoint. Read per-request so tests can point it at a stub. */
+function endpoint(): string {
+  return process.env.ROXY_TRACK_ENDPOINT || 'https://roxy.gg/track'
+}
+
+/** Events the server accepts. Anything else is dropped server-side. */
+export type TrackEvent =
+  /** App launched. The DAU heartbeat — sent exactly once per process start. */
+  | 'app_open'
+  /** A turn was submitted to the agent. The "real usage" signal. */
+  | 'prompt'
+  /** An agent turn finished. Carries `{ ok, durationMs }`. */
+  | 'turn_end'
+  /** Keeps a long-running session counted as active on later days. */
+  | 'heartbeat'
+  /** Remote Workspace paired with a phone. */
+  | 'remote_pair'
+  /** The app updated itself (first launch on a new version). */
+  | 'update'
+  /** Clean shutdown. */
+  | 'app_close'
+
+/** Only scalars — the server rejects nested objects and arrays anyway. */
+type Props = Record<string, string | number | boolean>
+
+interface QueuedEvent {
+  name: TrackEvent
+  clientId: string
+  ts: number
+  props?: Props
+}
+
+interface StoredState {
+  deviceId?: string
+  enabled?: boolean
+  /** Last version that reported an `app_open`, so we can detect an update. */
+  appVersion?: string
+}
+
+const FLUSH_INTERVAL_MS = 30_000
+const HEARTBEAT_INTERVAL_MS = 30 * 60_000
+/** The server caps a batch at 50; stay under it. */
+const MAX_QUEUE = 40
+const REQUEST_TIMEOUT_MS = 8_000
+
+let queue: QueuedEvent[] = []
+let deviceId: string | null = null
+let enabled = true
+let flushTimer: NodeJS.Timeout | null = null
+let heartbeatTimer: NodeJS.Timeout | null = null
+/** `ROXY_TRACK_DISABLE=1` — a hard machine-level kill the toggle can't undo. */
+let forcedOff = false
+
+/** Where the install id lives. Persisting it is what makes retention possible. */
+function stateFilePath(): string {
+  return join(app.getPath('userData'), 'install-id.json')
+}
+
+function readState(): StoredState {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(stateFilePath(), 'utf8'))
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as StoredState
+  } catch {
+    /* first run, or unreadable — treat as empty */
+  }
+  return {}
+}
+
+/** Best-effort persist. A read-only profile must not break anything. */
+function writeState(next: StoredState): void {
+  try {
+    writeFileSync(stateFilePath(), JSON.stringify(next), 'utf8')
+  } catch {
+    /* non-fatal — the id just won't survive this launch */
+  }
+}
+
+/** Turn tracking on/off and persist the choice. Wired to the Settings toggle. */
+export function setTrackingEnabled(next: boolean): boolean {
+  if (forcedOff) return false
+  if (next === enabled) return enabled
+  enabled = next
+
+  if (!next) {
+    // Opting out has to be immediate: drop the queue, stop the timers, and let
+    // go of the id in memory. Nothing further is collected or sent.
+    queue = []
+    stopTimers()
+    persist()
+    deviceId = null
+    return enabled
+  }
+
+  // Opting back in. Reuse the stored id if there is one so this doesn't look
+  // like a brand-new install, and mint one otherwise.
+  const state = readState()
+  deviceId =
+    typeof state.deviceId === 'string' && state.deviceId.length >= 8 ? state.deviceId : randomUUID()
+  persist()
+  startTimers()
+  return enabled
+}
+
+/** Write the current id + opt-out, keeping whatever else is in the file. */
+function persist(): void {
+  const state = readState()
+  writeState({ ...state, deviceId: deviceId ?? state.deviceId, enabled })
+}
+
+export function isTrackingEnabled(): boolean {
+  return enabled
+}
+
+/**
+ * Record an event. Cheap, synchronous, and safe to call from anywhere — it only
+ * appends to an in-memory queue.
+ */
+export function track(name: TrackEvent, props?: Props): void {
+  if (!enabled || !deviceId) return
+  if (queue.length >= MAX_QUEUE) return // shed rather than grow without bound
+  queue.push({ name, clientId: randomUUID(), ts: Date.now(), props })
+}
+
+/**
+ * Send whatever is queued.
+ *
+ * On failure the batch goes BACK on the queue: each event keeps its original
+ * `clientId`, so the server dedupes the retry and the counts stay honest.
+ */
+export async function flush(): Promise<void> {
+  if (!enabled || !deviceId || queue.length === 0) return
+
+  const batch = queue
+  queue = []
+
+  try {
+    const res = await fetch(endpoint(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        deviceId,
+        platform: process.platform,
+        arch: process.arch,
+        appVersion: app.getVersion(),
+        channel: app.isPackaged ? 'stable' : 'dev',
+        events: batch
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+
+    // 4xx means we sent something malformed — retrying won't fix it, so drop
+    // the batch instead of looping forever. 5xx and network errors are worth a
+    // retry, since the events are idempotent.
+    if (!res.ok && res.status >= 500) throw new Error(`status ${res.status}`)
+  } catch {
+    // Requeue, oldest first, without letting the backlog grow unbounded.
+    queue = [...batch, ...queue].slice(0, MAX_QUEUE)
+  }
+}
+
+/**
+ * Call once from the main process after `app.whenReady()`.
+ *
+ * Set `ROXY_TRACK_DISABLE=1` to opt a whole machine out without touching the
+ * stored preference — handy for CI, smoke runs, and contributors who don't want
+ * their dev builds counted.
+ */
+export function initTracking(): void {
+  if (process.env.ROXY_TRACK_DISABLE === '1') {
+    forcedOff = true
+    enabled = false
+    return
+  }
+
+  const state = readState()
+  if (state.enabled === false) enabled = false
+  // Someone who opted out gets no id at all — not a stored one we promise never
+  // to send. There is nothing to leak if it was never generated.
+  if (!enabled) return
+
+  const existing =
+    typeof state.deviceId === 'string' && state.deviceId.length >= 8 ? state.deviceId : null
+  deviceId = existing ?? randomUUID()
+
+  const version = app.getVersion()
+  // A different version than last launch means an update landed and restarted
+  // into this build. Only meaningful once we've seen a previous launch — a
+  // fresh install is an install, not an update.
+  const updated = Boolean(state.appVersion) && state.appVersion !== version
+  if (!existing || state.appVersion !== version) {
+    writeState({ ...state, deviceId, enabled, appVersion: version })
+  }
+
+  // The DAU heartbeat.
+  track('app_open')
+  if (updated) track('update')
+  void flush()
+
+  startTimers()
+}
+
+/** Idempotent: start the flush + heartbeat timers if they aren't already up. */
+function startTimers(): void {
+  if (flushTimer) return
+  flushTimer = setInterval(() => void flush(), FLUSH_INTERVAL_MS)
+  // Someone who leaves Roxy open for days is active on every one of those days.
+  heartbeatTimer = setInterval(() => track('heartbeat'), HEARTBEAT_INTERVAL_MS)
+  // Don't hold the event loop open on quit.
+  flushTimer.unref?.()
+  heartbeatTimer.unref?.()
+}
+
+function stopTimers(): void {
+  if (flushTimer) clearInterval(flushTimer)
+  if (heartbeatTimer) clearInterval(heartbeatTimer)
+  flushTimer = null
+  heartbeatTimer = null
+}
+
+/**
+ * Stop the timers and make a last attempt to drain the queue. Called from the
+ * app's quit path; the flush is genuinely best-effort, since Electron won't
+ * wait on a promise there.
+ */
+export function shutdownTracking(): void {
+  stopTimers()
+  track('app_close')
+  void flush()
+}
+
+/** Test-only: drop all module state so each case starts from a known point. */
+export function _resetTracking(): void {
+  stopTimers()
+  queue = []
+  deviceId = null
+  enabled = true
+  forcedOff = false
+}
+
+/** Test-only: how many events are waiting to be sent. */
+export function _queueDepth(): number {
+  return queue.length
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -31,7 +31,9 @@ const roxy: RoxyApi = {
     setAutoWorkstream: (enabled) => ipcRenderer.invoke(CHANNELS.settingsSetAutoWorkstream, enabled),
     setBranchPrefix: (prefix) => ipcRenderer.invoke(CHANNELS.settingsSetBranchPrefix, prefix),
     completeOnboarding: () => ipcRenderer.invoke(CHANNELS.settingsCompleteOnboarding),
-    reset: () => ipcRenderer.invoke(CHANNELS.settingsReset)
+    reset: () => ipcRenderer.invoke(CHANNELS.settingsReset),
+    getTelemetry: () => ipcRenderer.invoke(CHANNELS.settingsGetTelemetry),
+    setTelemetry: (enabled) => ipcRenderer.invoke(CHANNELS.settingsSetTelemetry, enabled)
   },
   providers: {
     listConnected: () => ipcRenderer.invoke(CHANNELS.providersList),

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -46,6 +46,11 @@ import type { ForgeStatusView } from '@shared/forge'
 interface RoxyStore {
   ready: boolean
   settings: AppSettings | null
+  /**
+   * Anonymous usage tracking. Not part of settings because the main process
+   * stores it outside the database, so a factory reset can't opt someone back in.
+   */
+  telemetryEnabled: boolean
   providers: ConnectedProvider[]
   /** models.dev model lists per provider id (lazy-loaded + cached). */
   modelCatalog: Record<string, ModelInfo[]>
@@ -155,6 +160,7 @@ interface RoxyStore {
   setContextLimit: (limit: number | null) => Promise<void>
   setWebSearchApiKey: (key: string | null) => Promise<void>
   setAutoWorkstream: (enabled: boolean) => Promise<void>
+  setTelemetryEnabled: (enabled: boolean) => Promise<void>
   setBranchPrefix: (prefix: string) => Promise<void>
   selectChat: (id: string) => Promise<void>
   clearActive: () => void
@@ -700,6 +706,9 @@ async function syncBranch(
 export const useRoxyStore = create<RoxyStore>((set, get) => ({
   ready: false,
   settings: null,
+  // Assumed on until the main process answers, matching the shipped default;
+  // the toggle would otherwise flicker off on every Settings open.
+  telemetryEnabled: true,
   providers: [],
   modelCatalog: {},
   recentModels: {},
@@ -729,14 +738,15 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   usageStats: null,
 
   bootstrap: async () => {
-    const [settings, providers, chats, loops, projectOrder] = await Promise.all([
+    const [settings, providers, chats, loops, projectOrder, telemetryEnabled] = await Promise.all([
       api.settings.getAll(),
       api.providers.listConnected(),
       api.chats.list(),
       api.loops.list(),
-      api.projects.listOrder()
+      api.projects.listOrder(),
+      api.settings.getTelemetry()
     ])
-    set({ settings, providers, chats, loops, projectOrder, ready: true })
+    set({ settings, providers, chats, loops, projectOrder, telemetryEnabled, ready: true })
     // Warm the usage/cost dashboard for the titlebar pill (best-effort, async).
     void get().refreshUsage()
 
@@ -1169,6 +1179,14 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   setAutoWorkstream: async (enabled) => {
     const settings = await api.settings.setAutoWorkstream(enabled)
     set({ settings })
+  },
+
+  setTelemetryEnabled: async (enabled) => {
+    // Optimistic: the toggle should move the instant it's pressed, and the main
+    // process returns the state it actually settled on, which then wins.
+    set({ telemetryEnabled: enabled })
+    const next = await api.settings.setTelemetry(enabled)
+    set({ telemetryEnabled: next })
   },
 
   setBranchPrefix: async (prefix) => {

--- a/src/renderer/src/routes/Settings.tsx
+++ b/src/renderer/src/routes/Settings.tsx
@@ -31,6 +31,8 @@ export default function Settings(): JSX.Element {
   const reorderProviders = useRoxyStore((s) => s.reorderProviders)
   const setWebSearchApiKey = useRoxyStore((s) => s.setWebSearchApiKey)
   const setAutoWorkstream = useRoxyStore((s) => s.setAutoWorkstream)
+  const telemetryEnabled = useRoxyStore((s) => s.telemetryEnabled)
+  const setTelemetryEnabled = useRoxyStore((s) => s.setTelemetryEnabled)
   const setBranchPrefix = useRoxyStore((s) => s.setBranchPrefix)
   const [prefix, setPrefix] = useState('')
   const prefixError = branchPrefixError(prefix)
@@ -365,6 +367,22 @@ export default function Settings(): JSX.Element {
         </div>
       </section>
 
+      <section className="mb-8">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">
+          Privacy
+        </h2>
+        <div className="flex flex-col gap-3 sq sq-xl sq-ring rounded-xl border border-border bg-surface p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-text">Send anonymous usage data</div>
+            <p className="mt-0.5 text-xs text-text-muted">
+              Counts of things like app launches and finished turns, tied to a random id generated
+              on this machine. Never your prompts, code, file paths, repo names, model, or provider.
+              It is the only way we can tell whether a release helped or broke things.
+            </p>
+          </div>
+          <Switch checked={telemetryEnabled} onChange={(v) => void setTelemetryEnabled(v)} />
+        </div>
+      </section>
       <section>
         <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">
           About

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -564,6 +564,13 @@ export interface RoxyApi {
     setBranchPrefix(prefix: string): Promise<AppSettings>
     completeOnboarding(): Promise<AppSettings>
     reset(): Promise<void>
+    /**
+     * Whether anonymous usage tracking is on. Deliberately NOT part of
+     * `AppSettings`: the flag is stored outside the database so a factory reset
+     * can't silently opt someone back in. Both calls return the resulting state.
+     */
+    getTelemetry(): Promise<boolean>
+    setTelemetry(enabled: boolean): Promise<boolean>
   }
   providers: {
     listConnected(): Promise<ConnectedProvider[]>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -10,6 +10,11 @@ export const CHANNELS = {
   settingsSetBranchPrefix: 'settings:setBranchPrefix',
   settingsCompleteOnboarding: 'settings:completeOnboarding',
   settingsReset: 'settings:reset',
+  // Anonymous usage tracking. Its own pair of channels rather than a field on
+  // AppSettings: the flag lives in a file outside the database, so opting out
+  // survives a factory reset (which wipes the settings table).
+  settingsGetTelemetry: 'settings:getTelemetry',
+  settingsSetTelemetry: 'settings:setTelemetry',
 
   providersList: 'providers:listConnected',
   providersConnect: 'providers:connect',

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -106,6 +106,17 @@ import { getUsageStats } from '../src/main/services/usage'
 import { consumeAiSdkStream } from '../src/main/services/aisdk'
 import { APICallError } from 'ai'
 import type { MessagePart } from '../src/shared/types'
+import {
+  initTracking,
+  track,
+  flush,
+  setTrackingEnabled,
+  isTrackingEnabled,
+  shutdownTracking,
+  _resetTracking,
+  _queueDepth
+} from '../src/main/services/track'
+import { createServer } from 'node:http'
 
 let pass = 0
 const fails: string[] = []
@@ -3968,6 +3979,244 @@ async function main(): Promise<void> {
     }
   } catch (e) {
     check('overnight resilience (streamTurn)', false, e instanceof Error ? e.message : String(e))
+  }
+
+  // ---- usage tracking (real HTTP against a local stub) ----
+  // Worth booting a server for: the whole point of this module is what lands on
+  // the wire, and every failure inside it is swallowed by design. A unit test
+  // that only asserts on queue depth would pass even if the payload were empty.
+  try {
+    interface Batch {
+      deviceId?: string
+      platform?: string
+      appVersion?: string
+      channel?: string
+      events?: { name: string; clientId: string; ts: number; props?: Record<string, unknown> }[]
+    }
+    let batches: Batch[] = []
+    let status = 200
+    let hits = 0
+
+    const server = createServer((req, res) => {
+      hits++
+      let body = ''
+      req.on('data', (c) => (body += c))
+      req.on('end', () => {
+        try {
+          batches.push(JSON.parse(body) as Batch)
+        } catch {
+          batches.push({})
+        }
+        res.writeHead(status, { 'Content-Type': 'application/json' })
+        res.end('{}')
+      })
+    })
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    const addr = server.address()
+    const port = typeof addr === 'object' && addr ? addr.port : 0
+    process.env.ROXY_TRACK_ENDPOINT = `http://127.0.0.1:${port}/track`
+    const idFile = path.join(tmp, 'install-id.json')
+    // initTracking() fires its own flush without awaiting it (deliberately - it
+    // must never delay startup), so tests have to wait for the request to land
+    // rather than assume flush() covered it.
+    const settled = async (n: number): Promise<void> => {
+      for (let i = 0; i < 100 && hits < n; i++) await new Promise((r) => setTimeout(r, 10))
+    }
+    const reset = async (): Promise<void> => {
+      _resetTracking()
+      batches = []
+      hits = 0
+      status = 200
+      await fs.rm(idFile, { force: true }).catch(() => undefined)
+    }
+
+    // 1. A cold start reports app_open and nothing else.
+    await reset()
+    initTracking()
+    await settled(1)
+    check('track: first launch posts one batch', batches.length === 1, `got ${batches.length}`)
+    const first = batches[0]
+    check('track: app_open is sent on launch', first?.events?.[0]?.name === 'app_open')
+    check(
+      'track: batch carries build facts, not user data',
+      first?.platform === process.platform &&
+        first?.appVersion === app.getVersion() &&
+        first?.channel === 'dev'
+    )
+    check(
+      'track: a fresh install does not report an update',
+      !first?.events?.some((e) => e.name === 'update')
+    )
+    const idA = first?.deviceId
+    check('track: deviceId is a uuid', typeof idA === 'string' && /^[0-9a-f-]{36}$/.test(idA))
+
+    // 2. The payload contains ONLY the fields we promised. This is the check
+    //    that would catch someone helpfully adding `cwd` or `model` later.
+    check(
+      'track: batch has no fields beyond the documented set',
+      Object.keys(first ?? {})
+        .sort()
+        .join(',') === 'appVersion,arch,channel,deviceId,events,platform',
+      Object.keys(first ?? {}).join(',')
+    )
+    check(
+      'track: an event has no fields beyond name/clientId/ts/props',
+      Object.keys(first?.events?.[0] ?? {})
+        .sort()
+        .join(',') === 'clientId,name,ts'
+    )
+
+    // 3. The id survives a restart — that is what makes retention measurable.
+    _resetTracking()
+    batches = []
+    hits = 0
+    initTracking()
+    await settled(1)
+    check('track: deviceId persists across a restart', batches[0]?.deviceId === idA)
+
+    // 4. turn_end props survive the round trip with real values.
+    batches = []
+    hits = 0
+    track('turn_end', { ok: true, durationMs: 1234 })
+    await flush()
+    await settled(1)
+    const props = batches[0]?.events?.[0]?.props
+    check('track: props round-trip', props?.ok === true && props?.durationMs === 1234)
+
+    // 5. Opting out is immediate: queued events are dropped and nothing sends.
+    batches = []
+    hits = 0
+    track('prompt')
+    check('track: event queued while enabled', _queueDepth() === 1)
+    setTrackingEnabled(false)
+    check('track: opting out drops the queue', _queueDepth() === 0)
+    track('prompt')
+    check('track: opting out stops collection', _queueDepth() === 0)
+    await flush()
+    check('track: opting out stops sending', hits === 0, `${hits} requests`)
+    check('track: opt-out is readable', isTrackingEnabled() === false)
+
+    // 6. ...and survives a restart, including a factory reset of the database.
+    repo.resetAll()
+    _resetTracking()
+    initTracking()
+    check('track: opt-out survives restart + factory reset', isTrackingEnabled() === false)
+    hits = 0
+    track('app_open')
+    await flush()
+    check('track: opted-out restart sends nothing', hits === 0, `${hits} requests`)
+
+    // 7. Opting back in reuses the original id rather than looking like a new
+    //    install (which would silently inflate installs on every toggle).
+    batches = []
+    setTrackingEnabled(true)
+    track('prompt')
+    await flush()
+    check('track: opting back in resumes sending', batches.length === 1)
+    check('track: opting back in reuses the original id', batches[0]?.deviceId === idA)
+
+    // 8. A 5xx requeues (idempotent retry), a 4xx drops (retrying can't help).
+    await reset()
+    initTracking()
+    await settled(1)
+    batches = []
+    hits = 0
+    status = 500
+    track('prompt')
+    await flush()
+    check('track: a 5xx requeues the batch', _queueDepth() === 1)
+    const retried = batches[0]?.events?.[0]?.clientId
+    status = 200
+    await flush()
+    check(
+      'track: the retry reuses clientId so the server can dedupe',
+      batches[1]?.events?.[0]?.clientId === retried && typeof retried === 'string'
+    )
+    check('track: a successful retry clears the queue', _queueDepth() === 0)
+
+    status = 400
+    track('prompt')
+    await flush()
+    check('track: a 4xx drops the batch instead of looping', _queueDepth() === 0)
+    status = 200
+
+    // 9. An unreachable server must not throw, and must not grow the queue past
+    //    the cap. This is the "user on a plane" case.
+    _resetTracking()
+    process.env.ROXY_TRACK_ENDPOINT = 'http://127.0.0.1:1/track'
+    initTracking()
+    for (let i = 0; i < 100; i++) track('prompt')
+    await flush()
+    check('track: an unreachable endpoint never throws', true)
+    check('track: the queue stays bounded offline', _queueDepth() <= 40, String(_queueDepth()))
+    process.env.ROXY_TRACK_ENDPOINT = `http://127.0.0.1:${port}/track`
+
+    // 10. A version change reports exactly one update event.
+    await reset()
+    await fs.writeFile(
+      idFile,
+      JSON.stringify({ deviceId: idA, enabled: true, appVersion: '0.0.0-old' }),
+      'utf8'
+    )
+    initTracking()
+    await settled(1)
+    const names = batches[0]?.events?.map((e) => e.name) ?? []
+    check(
+      'track: a version change reports app_open + update',
+      names.join(',') === 'app_open,update',
+      names.join(',')
+    )
+    _resetTracking()
+    batches = []
+    hits = 0
+    initTracking()
+    await settled(1)
+    check(
+      'track: the update is not re-reported on the next launch',
+      (batches[0]?.events ?? []).every((e) => e.name !== 'update')
+    )
+
+    // 11. The kill switch beats everything, including the stored preference.
+    _resetTracking()
+    process.env.ROXY_TRACK_DISABLE = '1'
+    initTracking()
+    hits = 0
+    track('app_open')
+    setTrackingEnabled(true)
+    track('prompt')
+    await flush()
+    check('track: ROXY_TRACK_DISABLE cannot be re-enabled', isTrackingEnabled() === false)
+    check('track: ROXY_TRACK_DISABLE sends nothing', hits === 0, `${hits} requests`)
+    delete process.env.ROXY_TRACK_DISABLE
+
+    // 12. Shutdown drains rather than dropping.
+    await reset()
+    initTracking()
+    await settled(1)
+    batches = []
+    hits = 0
+    shutdownTracking()
+    await settled(1)
+    check(
+      'track: shutdown flushes app_close',
+      batches.some((b) => b.events?.some((e) => e.name === 'app_close'))
+    )
+
+    // 13. A read-only profile degrades instead of crashing.
+    _resetTracking()
+    await fs.writeFile(idFile, 'not json at all{{{', 'utf8')
+    initTracking()
+    check('track: a corrupt id file does not crash the launch', isTrackingEnabled() === true)
+    batches = []
+    hits = 0
+    await settled(1)
+    check('track: a corrupt id file still reports', batches.length === 1)
+
+    _resetTracking()
+    await new Promise<void>((r) => server.close(() => r()))
+    delete process.env.ROXY_TRACK_ENDPOINT
+  } catch (e) {
+    check('usage tracking', false, e instanceof Error ? e.message : String(e))
   }
 
   closeDb()


### PR DESCRIPTION
Adds a fire-and-forget tracking client (src/main/services/track.ts) that posts batched, anonymous events to /track: a random install id plus an event name, never prompts, code, paths, repo names, model, or provider.

Departures from the drop-in draft, all for correctness:

- The install id and opt-out live in their own JSON file rather than the settings table. repo.resetAll() wipes settings, so storing the flag there would silently opt a user back in on factory reset. It also drops the dependency on the database being open.
- Opting out releases the id and stops the timers, instead of only clearing the queue and then flushing an empty queue forever. Opting back in reuses the stored id so a toggle isn't counted as an install.
- update is derived by comparing the stored appVersion to the current one, so it fires on the first launch after an update but never on a fresh install.
- ROXY_TRACK_DISABLE=1 is a hard kill the toggle cannot override, for CI, smoke runs, and contributor dev builds.

prompt/turn_end are emitted from runSessionTurn, the single choke point shared by the local and phone-driven paths, so the two cannot drift. remote_pair fires on guest-joined (a completed pairing), not on share open. Opt-out ships as a Privacy toggle in Settings.

Covered by 31 runtime checks in smoke:app against a local HTTP stub, asserting on what actually reaches the wire: payload shape (including that no undocumented field is present), id persistence across restart, opt-out surviving a factory reset, 5xx requeue with a stable clientId, 4xx drop, bounded offline queue, and corrupt-state recovery.