### PR TITLE
Dim the Roxy hero card border in onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",

--- a/src/renderer/src/routes/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/routes/onboarding/ProviderStep.tsx
@@ -108,13 +108,13 @@ function RoxyHero({
   return (
     <button
       onClick={onClick}
-      // Borderless on purpose: the accent gradient alone defines the card, so
-      // it reads as a soft tint rather than a framed box. (It also sidesteps
-      // `sq-ring`, which paints its hairline via `background-image` and so
-      // cannot coexist with the gradient on one element.)
-      className="group mt-6 flex w-full items-center gap-4 overflow-hidden sq sq-2xl rounded-2xl bg-gradient-to-br from-accent/15 via-accent/5 to-transparent p-5 text-left transition-[--tw-gradient-from] hover:from-accent/25"
+      // The squircle mask stays; only the ring is dialled down. An inset ring
+      // (a box-shadow, clipped to the shape by the mask) is used instead of a
+      // border because `sq-ring` paints its hairline via `background-image`,
+      // which the gradient already occupies.
+      className="group mt-6 flex w-full items-center gap-4 overflow-hidden sq sq-2xl inset-ring-1 inset-ring-accent/20 rounded-2xl bg-gradient-to-br from-accent/15 via-accent/5 to-transparent p-5 text-left transition-[--tw-gradient-from,box-shadow] hover:inset-ring-accent/40 hover:from-accent/25"
     >
-      <span className="flex h-14 w-14 shrink-0 items-center justify-center sq-frame sq-2xl sq-fill-surface-2 sq-ring sq-ring-accent rounded-2xl border border-accent/30 bg-surface-2 shadow-sm">
+      <span className="flex h-14 w-14 shrink-0 items-center justify-center sq-frame sq-2xl sq-fill-surface-2 sq-ring sq-ring-accent rounded-2xl border border-accent/20 bg-surface-2 shadow-sm">
         <ProviderLogo id="roxy" name="Roxy" size={44} />
       </span>
       <span className="min-w-0 flex-1">

--- a/src/renderer/src/routes/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/routes/onboarding/ProviderStep.tsx
@@ -108,12 +108,11 @@ function RoxyHero({
   return (
     <button
       onClick={onClick}
-      // The gradient occupies `background-image`, which is also how `sq-ring`
-      // paints its hairline -- the two can't share one element. The border here
-      // is the accent tint rather than a structural hairline, so an inset ring
-      // (a box-shadow, and clipped to the shape by the mask) reads identically
-      // and leaves the gradient alone.
-      className="group mt-6 flex w-full items-center gap-4 overflow-hidden sq sq-2xl inset-ring-1 inset-ring-accent/40 rounded-2xl bg-gradient-to-br from-accent/15 via-accent/5 to-transparent p-5 text-left transition-[--tw-gradient-from,box-shadow] hover:inset-ring-accent/70 hover:from-accent/25"
+      // Borderless on purpose: the accent gradient alone defines the card, so
+      // it reads as a soft tint rather than a framed box. (It also sidesteps
+      // `sq-ring`, which paints its hairline via `background-image` and so
+      // cannot coexist with the gradient on one element.)
+      className="group mt-6 flex w-full items-center gap-4 overflow-hidden sq sq-2xl rounded-2xl bg-gradient-to-br from-accent/15 via-accent/5 to-transparent p-5 text-left transition-[--tw-gradient-from] hover:from-accent/25"
     >
       <span className="flex h-14 w-14 shrink-0 items-center justify-center sq-frame sq-2xl sq-fill-surface-2 sq-ring sq-ring-accent rounded-2xl border border-accent/30 bg-surface-2 shadow-sm">
         <ProviderLogo id="roxy" name="Roxy" size={44} />


### PR DESCRIPTION
The featured Roxy card on the onboarding provider step had an accent ring at 40% that read as a hard frame around the gradient. This dials it back to 20% (40% on hover) so the card reads as a soft tint, and drops the logo tile border from `accent/30` to `accent/20` so it no longer outshines the card.

The squircle mask (`sq sq-2xl`) is unchanged. The ring is an inset ring rather than a `border` because `sq-ring` paints its hairline via `background-image`, which the card gradient already occupies.

Version bumped to 0.0.83. Typecheck clean.