### PR TITLE
feat(browser): built-in cookie editor, with Cookie-Editor JSON import/export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.81",
+  "version": "0.0.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.81",
+      "version": "0.0.84",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",
@@ -36,10 +36,11 @@
     "icons:providers": "node script/copy-provider-icons.mjs",
     "smoke:shared": "esbuild test/shared.ts --bundle --platform=node --format=cjs --packages=external --outfile=test/.out/shared.cjs && node test/.out/shared.cjs",
     "smoke:app": "esbuild test/smoke.ts --bundle --platform=node --format=cjs --packages=external --outfile=test/.out/smoke.cjs && electron test/.out/smoke.cjs",
-    "smoke": "npm run smoke:shared && npm run smoke:store && npm run smoke:app",
+    "smoke": "npm run smoke:shared && npm run smoke:store && npm run smoke:cookies && npm run smoke:app",
     "smoke:cliproxy": "esbuild test/cliproxy.ts --bundle --platform=node --format=cjs --packages=external --outfile=test/.out/cliproxy.cjs && electron test/.out/cliproxy.cjs",
     "worktree:setup": "npm ci --prefer-offline --no-audit --no-fund && electron-builder install-app-deps",
-    "smoke:store": "node test/store-guard.mjs"
+    "smoke:store": "node test/store-guard.mjs",
+    "smoke:cookies": "esbuild test/cookies.ts --bundle --platform=node --format=cjs --packages=external --outfile=test/.out/cookies.cjs && electron test/.out/cookies.cjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.85",

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -4,6 +4,7 @@ import type { SessionConfigPatch } from '../../shared/session-config'
 import type { ClipboardAction } from '../../shared/context-menu'
 import { clipboardHasContent, runClipboardAction } from '../services/context-menu'
 import type {
+  CookieRow,
   CreateChatInput,
   CreateLoopInput,
   CreateWorktreeInput,
@@ -28,6 +29,7 @@ import * as repo from '../db/repo'
 import * as copilot from '../services/copilot'
 import * as cliproxy from '../services/cliproxy'
 import * as browser from '../services/browser'
+import * as cookies from '../services/cookies'
 import { listModels } from '../services/models'
 import { pickDefaultModel } from '../../shared/models'
 import { CLIPROXY_PROVIDER_IDS, accountsFor, isCliProxyProvider } from '../../shared/cliproxy'
@@ -87,7 +89,7 @@ const llmControllers = new Map<string, AbortController>()
  *
  * `llmControllers` alone was not enough for Stop to be reliable. The renderer
  * only learns a requestId once the turn is actually starting, and real work
- * happens before that — most of all compaction, which is a full model call on a
+ * happens before that â€” most of all compaction, which is a full model call on a
  * long history and used to run with a hardcoded never-aborted signal. Stop
  * during that window found no requestId and silently did nothing, which is a
  * large part of why the button felt stuck.
@@ -285,7 +287,7 @@ export function registerIpc(): void {
     // Fire-and-forget: deletion must never block on git, so a failure here is
     // logged and the session goes anyway (`git:prune-worktrees` sweeps up
     // whatever is left behind). It re-kills the session's processes internally
-    // and awaits them — the ordering that keeps removal working on Windows.
+    // and awaits them â€” the ordering that keeps removal working on Windows.
     void removeWorktreeForChat(id).then(
       (r) => {
         if (!r.ok && r.error) console.warn('[worktree] remove on delete failed:', r.error)
@@ -409,7 +411,7 @@ export function registerIpc(): void {
     state: getUpdateState()
   }))
   ipcMain.handle(CHANNELS.systemOpenExternal, async (_e, url: string) => {
-    // Only allow web URLs — never file:, javascript:, or other schemes.
+    // Only allow web URLs â€” never file:, javascript:, or other schemes.
     try {
       const parsed = new URL(url)
       if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
@@ -653,7 +655,7 @@ export function registerIpc(): void {
     // If this session is shared to a phone, relay the turn there too so the phone
     // streams a desktop-typed reply live (the mirror of a phone turn on the PC).
     // The current prompt is the last user message; announce it so the phone shows
-    // the bubble it never echoed. `null` when nothing's shared → zero overhead.
+    // the bubble it never echoed. `null` when nothing's shared â†’ zero overhead.
     const lastUser = [...input.messages].reverse().find((m) => m.role === 'user')
     const relay = remote.relayLocalTurnStart(input.sessionId, lastUser?.content)
     try {
@@ -677,7 +679,7 @@ export function registerIpc(): void {
     llmControllers.get(requestId)?.abort()
   })
   // Stop, as the UI means it: end everything this session has in flight,
-  // whatever stage it's at. Also cancels the session's delegates — stopping a
+  // whatever stage it's at. Also cancels the session's delegates â€” stopping a
   // turn while it waits on a subagent has to stop the subagent, or the work
   // carries on invisibly after the transcript says it stopped.
   ipcMain.handle(CHANNELS.llmAbortSession, (_e, sessionId: string) => {
@@ -765,6 +767,20 @@ export function registerIpc(): void {
     browser.moveTab(id, toIndex, keyOf(e))
   )
 
+  // ---- cookies (the built-in Cookie-Editor) ----
+  // One jar, shared by every session: the browser's persisted partition is
+  // global, so these are deliberately NOT keyed off the sender. Both surfaces
+  // -- the browser window's Cookies panel and Settings -> Browser -- call the
+  // same handlers and see the same cookies.
+  ipcMain.handle(CHANNELS.cookiesList, (_e, url?: string) => cookies.list(url))
+  ipcMain.handle(CHANNELS.cookiesSet, (_e, row: Partial<CookieRow>) => cookies.set(row))
+  ipcMain.handle(CHANNELS.cookiesRemove, (_e, row: CookieRow) => cookies.remove(row))
+  ipcMain.handle(CHANNELS.cookiesClear, (_e, host?: string) => cookies.clear(host))
+  ipcMain.handle(CHANNELS.cookiesImport, (_e, text: string) => cookies.importJson(text))
+  ipcMain.handle(CHANNELS.browserChromeHeight, (e, height: number) =>
+    browser.setChromeHeight(height, keyOf(e))
+  )
+
   // ---- services (a session's background processes) ----
   // Every handler resolves the ROOT session first: a subagent's dev server is
   // registered under its parent, and the parent's panel is where it belongs.
@@ -836,9 +852,9 @@ export function registerIpc(): void {
   ipcMain.handle(
     CHANNELS.gitCreateWorktree,
     async (_e, input: CreateWorktreeInput): Promise<CreateWorktreeResult> => {
-      if (!(await git.isGitAvailable())) return { ok: false, error: 'Git isn’t installed.' }
+      if (!(await git.isGitAvailable())) return { ok: false, error: 'Git isnâ€™t installed.' }
       const root = await git.repoRoot(input.cwd)
-      if (!root) return { ok: false, error: 'This folder isn’t a git repository.' }
+      if (!root) return { ok: false, error: 'This folder isnâ€™t a git repository.' }
       const r =
         input.mode === 'new'
           ? await git.createWorktree({
@@ -851,7 +867,7 @@ export function registerIpc(): void {
   )
 
   ipcMain.handle(CHANNELS.gitRemoveWorktree, async (_e, worktreePath: string, force?: boolean) => {
-    if (!(await git.isGitAvailable())) return { ok: false, error: 'Git isn’t installed.' }
+    if (!(await git.isGitAvailable())) return { ok: false, error: 'Git isnâ€™t installed.' }
     return git.removeWorktree(worktreePath, { force: force ?? false })
   })
 

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -1,5 +1,5 @@
 /**
- * The Roxy browser — a real, persistent Electron BrowserWindow the agent can
+ * The Roxy browser â€” a real, persistent Electron BrowserWindow the agent can
  * drive. It uses a `persist:` session partition so cookies/logins survive
  * restarts (sign in once, automate forever), and it taps Electron's native
  * APIs to screenshot the page, read its HTML, and collect console messages.
@@ -22,17 +22,17 @@ import { CHANNELS } from '../../shared/ipc'
 import type { BrowserState, BrowserTab } from '../../shared/api'
 import { attachNativeContextMenu } from './context-menu'
 
-/** Persisted session → cookies, localStorage and logins survive app restarts. */
-const PARTITION = 'persist:roxy-browser'
+/** Persisted session â†’ cookies, localStorage and logins survive app restarts. */
+export const PARTITION = 'persist:roxy-browser'
 const MAX_CONSOLE = 500
 /** Height of the chrome overlaid at the top: tab strip + URL-bar toolbar. */
 const CHROME_H = 80
-/** Where a blank/new tab lands — a homepage, like a normal browser. */
+/** Where a blank/new tab lands â€” a homepage, like a normal browser. */
 const HOME_URL = 'https://www.google.com'
 /** The shared window used by the manual "Open browser" button and keyless callers. */
 const DEFAULT_KEY = '__default__'
 
-/** App icon path, injected from main (so this file has no `?asset` import — the
+/** App icon path, injected from main (so this file has no `?asset` import â€” the
  *  smoke harness bundles it with esbuild, which doesn't understand `?asset`). */
 let appIconPath: string | undefined
 export function setAppIcon(p: string): void {
@@ -48,14 +48,14 @@ export interface ConsoleEntry {
   ts: number
 }
 
-/** One open tab — a persistent-session page view. The active tab fills the
+/** One open tab â€” a persistent-session page view. The active tab fills the
  *  window; the rest sit at zero size (still alive, so their pages are kept). */
 interface Tab {
   id: string
   view: BrowserView
 }
 
-/** One isolated browser — a window + its tabs + console, owned by a session key. */
+/** One isolated browser â€” a window + its tabs + console, owned by a session key. */
 interface Session {
   key: string
   /** A human label (usually the project folder) shown in the window title. */
@@ -65,6 +65,14 @@ interface Session {
   activeTabId: string | null
   consoleLog: ConsoleEntry[]
   tabSeq: number
+  /**
+   * Chrome height in px when a chrome panel (the cookie editor) is open.
+   * BrowserViews always paint ABOVE the window's own webContents, so a panel
+   * rendered in the chrome would be hidden behind the page. Growing the chrome
+   * instead pushes the page view down out of sight -- the panel is genuinely
+   * on top, with no z-index fight to lose.
+   */
+  chromeH?: number
 }
 
 /** Every live browser, keyed by session (chat) id. */
@@ -80,7 +88,7 @@ function getSession(key: string): Session {
   return s
 }
 
-/** The session for `key` WITHOUT creating one — for read/nav ops that must not spawn a window. */
+/** The session for `key` WITHOUT creating one â€” for read/nav ops that must not spawn a window. */
 function peek(key: string): Session | undefined {
   return sessions.get(key)
 }
@@ -91,7 +99,7 @@ function activeView(s: Session): BrowserView | null {
   return t && !t.view.webContents.isDestroyed() ? t.view : null
 }
 
-/** The active page's contents for `key` — what every browser_* tool drives. */
+/** The active page's contents for `key` â€” what every browser_* tool drives. */
 function pageContents(key: string): Electron.WebContents {
   const s = peek(key)
   const v = s ? activeView(s) : null
@@ -99,9 +107,9 @@ function pageContents(key: string): Electron.WebContents {
   return v.webContents
 }
 
-/** The window title for a session — names the project so windows are tellable apart. */
+/** The window title for a session â€” names the project so windows are tellable apart. */
 function windowTitle(s: Session): string {
-  return s.label ? `Roxy Browser — ${s.label}` : 'Roxy Browser'
+  return s.label ? `Roxy Browser â€” ${s.label}` : 'Roxy Browser'
 }
 
 function ensureWindow(s: Session): BrowserWindow {
@@ -121,7 +129,7 @@ function ensureWindow(s: Session): BrowserWindow {
     backgroundColor: '#0a0a0a',
     autoHideMenuBar: true,
     ...(isMac || !appIconPath ? {} : { icon: appIconPath }),
-    // Hide the native OS title bar — our React chrome (tab strip + URL bar) IS
+    // Hide the native OS title bar â€” our React chrome (tab strip + URL bar) IS
     // the title bar. Keep native window controls, themed to match (no second
     // light bar stacked on top of the chrome).
     titleBarStyle: 'hidden',
@@ -137,11 +145,11 @@ function ensureWindow(s: Session): BrowserWindow {
   s.win = win
 
   // The chrome (tab strip + URL bar) is a real React app rendered into the
-  // WINDOW's OWN webContents — not a BrowserView — so its title-bar strip is
+  // WINDOW's OWN webContents â€” not a BrowserView â€” so its title-bar strip is
   // draggable via `-webkit-app-region` (which doesn't work inside a BrowserView)
   // and the native control overlay lands on it cleanly. Page tabs sit in
   // BrowserViews on top, below the chrome. Best-effort load (the test harness
-  // has no bundled browser.html — the pages still work).
+  // has no bundled browser.html â€” the pages still work).
   win.webContents.once('did-finish-load', () => {
     pushState(s)
     pushTabs(s)
@@ -171,14 +179,30 @@ function ensureWindow(s: Session): BrowserWindow {
 function layout(s: Session): void {
   if (!s.win || s.win.isDestroyed()) return
   const { width, height } = s.win.getContentBounds()
+  const top = s.chromeH ?? CHROME_H
   for (const t of s.tabs) {
     if (t.view.webContents.isDestroyed()) continue
     t.view.setBounds(
       t.id === s.activeTabId
-        ? { x: 0, y: CHROME_H, width, height: Math.max(0, height - CHROME_H) }
+        ? { x: 0, y: top, width, height: Math.max(0, height - top) }
         : { x: 0, y: 0, width: 0, height: 0 }
     )
   }
+}
+
+/**
+ * Reserve height px of window for the chrome, so a chrome-rendered panel can
+ * cover the page. Pass 0/undefined to restore the normal toolbar height.
+ *
+ * Clamped to the window, because a panel taller than the window would push the
+ * page view to a negative height and Chromium would reject the bounds.
+ */
+export function setChromeHeight(height: number, key: string = DEFAULT_KEY): void {
+  const s = peek(key)
+  if (!s || !s.win || s.win.isDestroyed()) return
+  const max = s.win.getContentBounds().height
+  s.chromeH = height > CHROME_H ? Math.min(height, max) : undefined
+  layout(s)
 }
 
 /** Create a tab (optionally at a URL) and make it active. Assumes a window. */
@@ -262,7 +286,7 @@ function tabsOf(s: Session): BrowserTab[] {
   })
 }
 
-/** The open tabs for `key` — also used by the browser_tabs tool. */
+/** The open tabs for `key` â€” also used by the browser_tabs tool. */
 export function listTabs(key: string = DEFAULT_KEY): BrowserTab[] {
   const s = peek(key)
   return s ? tabsOf(s) : []
@@ -307,7 +331,7 @@ export async function open(
   const wc = pageContents(key)
   const url = normalizeUrl(rawUrl)
   // Show the window so you can watch the agent browse, but DON'T steal focus
-  // (showInactive) — the agent driving the browser shouldn't yank you out of
+  // (showInactive) â€” the agent driving the browser shouldn't yank you out of
   // whatever you're typing. The Settings "Open browser" button (openWindow)
   // still focuses it for manual sign-in.
   if (s.win?.isMinimized()) s.win.restore()
@@ -378,7 +402,7 @@ export function close(key: string = DEFAULT_KEY): void {
   const s = sessions.get(key)
   if (!s) return
   if (s.win && !s.win.isDestroyed())
-    s.win.close() // fires 'closed' → sessions.delete
+    s.win.close() // fires 'closed' â†’ sessions.delete
   else sessions.delete(key)
 }
 

--- a/src/main/services/cookies.ts
+++ b/src/main/services/cookies.ts
@@ -1,0 +1,230 @@
+/**
+ * Cookie editing for the Roxy browser — the "Cookie-Editor extension", built in.
+ *
+ * The Roxy browser runs every tab on one persisted session partition, so its
+ * cookie jar is a single Electron `Session.cookies` store. That store already
+ * exposes everything the Cookie-Editor extension wraps (get/set/remove), which
+ * is why this ships as a native panel instead of real Chrome extension support:
+ * `chrome.cookies` IS `session.cookies` here, minus a CRX loader we'd otherwise
+ * have to carry.
+ *
+ * INTEROP is the point. Import/export speak the exact JSON shape Cookie-Editor
+ * and EditThisCookie use, so a blob copied out of Chrome pastes straight in
+ * here (and back). That format differs from Electron's in three ways we bridge:
+ *   - session cookies must OMIT `expirationDate` entirely rather than send 0,
+ *     which would instead expire the cookie on the spot;
+ *   - `hostOnly` is derived, not settable — Electron infers it from whether you
+ *     pass `domain` at all, so a host-only cookie is written by dropping it;
+ *   - `sameSite` arrives in several casings ("no_restriction", "None", "Lax")
+ *     depending on which tool exported it, so it gets normalized.
+ */
+import { session } from 'electron'
+import { PARTITION } from './browser'
+import type { CookieImportResult, CookieRow } from '../../shared/api'
+
+/** The Roxy browser's cookie jar (the same partition every tab renders on). */
+function jar(): Electron.Cookies {
+  return session.fromPartition(PARTITION).cookies
+}
+
+/**
+ * Normalize the many spellings of SameSite into Electron's four values.
+ * Chrome's extension API and Electron both use snake_case, but tools exporting
+ * from DevTools emit the HTTP header casing ("None"/"Lax"/"Strict") — and an
+ * unrecognized value must fall back to `unspecified` rather than throw, or one
+ * bad row would reject an entire paste.
+ */
+function normalizeSameSite(raw: unknown): CookieRow['sameSite'] {
+  const v = String(raw ?? '')
+    .trim()
+    .toLowerCase()
+  if (v === 'no_restriction' || v === 'none') return 'no_restriction'
+  if (v === 'lax') return 'lax'
+  if (v === 'strict') return 'strict'
+  return 'unspecified'
+}
+
+/**
+ * The URL to address a cookie by. Electron's cookie store is keyed by URL, not
+ * by domain, so every set/remove needs one synthesized from the cookie itself.
+ * The scheme must track `secure`: Chromium refuses to store a Secure cookie
+ * against an http:// URL.
+ */
+function urlFor(c: { domain?: string; path?: string; secure?: boolean }): string {
+  const host = (c.domain ?? '').replace(/^\./, '')
+  const scheme = c.secure ? 'https' : 'http'
+  return `${scheme}://${host}${c.path || '/'}`
+}
+
+/** Convert one Electron cookie into the interchange shape. */
+function toRow(c: Electron.Cookie): CookieRow {
+  const row: CookieRow = {
+    name: c.name,
+    value: c.value,
+    domain: c.domain ?? '',
+    path: c.path ?? '/',
+    secure: Boolean(c.secure),
+    httpOnly: Boolean(c.httpOnly),
+    hostOnly: Boolean(c.hostOnly),
+    session: Boolean(c.session),
+    sameSite: normalizeSameSite(c.sameSite),
+    storeId: '0'
+  }
+  if (!c.session && typeof c.expirationDate === 'number') row.expirationDate = c.expirationDate
+  return row
+}
+
+/** The hostname of a URL, or '' when it isn't parseable (about:blank, empty). */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * The domains whose cookies are in play for `host`: the host itself and each
+ * parent down to a two-label name — so `app.stage.example.com` also pulls
+ * `.example.com`, where the session cookie you're actually debugging usually
+ * lives.
+ *
+ * Electron's `domain` filter matches a domain and its SUBdomains, never its
+ * parents, so querying the host alone silently omits exactly those cookies.
+ * Bare hostnames (`localhost`) and IP literals have no parents to walk.
+ */
+function domainChain(host: string): string[] {
+  if (!host) return []
+  if (/^[\d.]+$/.test(host) || host.includes(':')) return [host]
+  const parts = host.split('.')
+  if (parts.length < 2) return [host]
+  const out: string[] = []
+  for (let i = 0; i <= parts.length - 2; i++) out.push(parts.slice(i).join('.'))
+  return out
+}
+
+/**
+ * Every cookie relevant to `url` (its whole domain chain), or the entire jar
+ * when no URL is given. Deduped, because a host and its parent both match a
+ * cookie sitting in the middle of the chain.
+ */
+export async function list(url?: string): Promise<CookieRow[]> {
+  const host = url ? hostOf(url) : ''
+  const queries: Electron.CookiesGetFilter[] = host
+    ? domainChain(host).map((domain) => ({ domain }))
+    : [{}]
+  const found = new Map<string, CookieRow>()
+  for (const q of queries) {
+    for (const c of await jar().get(q)) {
+      const row = toRow(c)
+      found.set(`${row.domain}|${row.path}|${row.name}`, row)
+    }
+  }
+  return [...found.values()].sort(
+    (a, b) => a.domain.localeCompare(b.domain) || a.name.localeCompare(b.name)
+  )
+}
+
+/**
+ * Create or overwrite one cookie. Returns an error string rather than throwing:
+ * a bulk import must be able to report "3 of 40 rejected" instead of dying on
+ * the first cookie Chromium dislikes (bad domain, `__Host-` prefix rules, ...).
+ */
+export async function set(row: Partial<CookieRow>): Promise<string | null> {
+  const name = String(row.name ?? '').trim()
+  if (!name) return 'a cookie in the list has no name'
+  const domain = String(row.domain ?? '').trim()
+  if (!domain) return `"${name}": no domain`
+
+  const details: Electron.CookiesSetDetails = {
+    url: urlFor({ domain, path: row.path, secure: row.secure }),
+    name,
+    value: String(row.value ?? ''),
+    path: row.path || '/',
+    secure: Boolean(row.secure),
+    httpOnly: Boolean(row.httpOnly),
+    sameSite: normalizeSameSite(row.sameSite)
+  }
+  // A host-only cookie is expressed by OMITTING domain (Electron then binds it
+  // to the URL's host); sending a domain always yields a subdomain cookie.
+  if (!row.hostOnly) details.domain = domain
+  // Session cookies must omit expirationDate entirely — sending 0 would expire
+  // the cookie immediately instead of making it session-scoped.
+  if (!row.session && typeof row.expirationDate === 'number') {
+    details.expirationDate = row.expirationDate
+  }
+
+  try {
+    await jar().set(details)
+    return null
+  } catch (e) {
+    return `"${name}": ${e instanceof Error ? e.message : String(e)}`
+  }
+}
+
+/** Delete one cookie, addressed the same way it was stored. */
+export async function remove(
+  row: Pick<CookieRow, 'name' | 'domain' | 'path' | 'secure'>
+): Promise<void> {
+  await jar().remove(urlFor(row), row.name)
+}
+
+/**
+ * Delete every cookie, or every cookie in one host's domain chain. Removal goes
+ * through the per-cookie API rather than `clearStorageData` so a domain-scoped
+ * wipe is possible at all, and so localStorage logins survive a cookie reset.
+ */
+export async function clear(host?: string): Promise<number> {
+  const queries: Electron.CookiesGetFilter[] = host
+    ? domainChain(host).map((domain) => ({ domain }))
+    : [{}]
+  const seen = new Set<string>()
+  let removed = 0
+  for (const q of queries) {
+    for (const c of await jar().get(q)) {
+      const id = `${c.domain}|${c.path}|${c.name}`
+      if (seen.has(id)) continue
+      seen.add(id)
+      try {
+        await jar().remove(urlFor(c), c.name)
+        removed++
+      } catch {
+        // Already gone, or unaddressable — nothing useful to do per-cookie.
+      }
+    }
+  }
+  return removed
+}
+
+/**
+ * Import a Cookie-Editor / EditThisCookie JSON blob. Accepts either a bare
+ * array (what those tools emit) or a `{ cookies: [...] }` wrapper, because both
+ * are in the wild. Bad rows are collected and reported, never fatal — only
+ * malformed JSON throws.
+ */
+export async function importJson(text: string): Promise<CookieImportResult> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (e) {
+    throw new Error(`Not valid JSON: ${e instanceof Error ? e.message : String(e)}`)
+  }
+  const wrapped = (parsed as { cookies?: unknown } | null)?.cookies
+  const rows = Array.isArray(parsed) ? parsed : Array.isArray(wrapped) ? wrapped : null
+  if (!rows) throw new Error('Expected an array of cookies (or { "cookies": [...] }).')
+
+  const errors: string[] = []
+  let imported = 0
+  for (const raw of rows) {
+    if (!raw || typeof raw !== 'object') {
+      errors.push('skipped an entry that was not an object')
+      continue
+    }
+    const err = await set(raw as Partial<CookieRow>)
+    if (err) errors.push(err)
+    else imported++
+  }
+  // Keep the error list short — a 500-cookie paste that wholly fails shouldn't
+  // push 500 near-identical strings through IPC into a toast.
+  return { imported, failed: errors.length, errors: errors.slice(0, 8) }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -211,6 +211,7 @@ const roxy: RoxyApi = {
     closeTab: (id) => ipcRenderer.invoke(CHANNELS.browserCloseTab, id),
     activateTab: (id) => ipcRenderer.invoke(CHANNELS.browserActivateTab, id),
     moveTab: (id, toIndex) => ipcRenderer.invoke(CHANNELS.browserMoveTab, id, toIndex),
+    setChromeHeight: (height) => ipcRenderer.invoke(CHANNELS.browserChromeHeight, height),
     onState: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, state: BrowserState): void =>
         callback(state)
@@ -223,6 +224,13 @@ const roxy: RoxyApi = {
       ipcRenderer.on(CHANNELS.browserTabs, handler)
       return () => ipcRenderer.removeListener(CHANNELS.browserTabs, handler)
     }
+  },
+  cookies: {
+    list: (url) => ipcRenderer.invoke(CHANNELS.cookiesList, url),
+    set: (row) => ipcRenderer.invoke(CHANNELS.cookiesSet, row),
+    remove: (row) => ipcRenderer.invoke(CHANNELS.cookiesRemove, row),
+    clear: (host) => ipcRenderer.invoke(CHANNELS.cookiesClear, host),
+    importJson: (text) => ipcRenderer.invoke(CHANNELS.cookiesImport, text)
   },
   services: {
     list: (sessionId) => ipcRenderer.invoke(CHANNELS.servicesList, sessionId),

--- a/src/renderer/src/browser/BrowserChrome.tsx
+++ b/src/renderer/src/browser/BrowserChrome.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
-import { ArrowLeft, ArrowRight, Globe, Plus, RotateCw, Search, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, ArrowRight, Cookie, Globe, Plus, RotateCw, Search, X } from 'lucide-react'
 import type { BrowserState, BrowserTab } from '@shared/api'
 import { api } from '../lib/api'
 import { cn } from '../lib/cn'
+import { CookiePanel } from '../components/CookiePanel'
 
 const BLANK: BrowserState = {
   url: '',
@@ -13,7 +14,7 @@ const BLANK: BrowserState = {
 }
 
 /**
- * The Roxy browser's chrome — a real React tab strip + URL bar (themed to match
+ * The Roxy browser's chrome â€” a real React tab strip + URL bar (themed to match
  * the app), rendered into the browser window's top BrowserView. It talks to the
  * main process purely through `window.roxy.browser.*`; the agent still drives
  * the active tab from main, and this just reflects/controls it.
@@ -24,7 +25,34 @@ export function BrowserChrome(): JSX.Element {
   const [draft, setDraft] = useState('')
   const [editing, setEditing] = useState(false)
   const [dragId, setDragId] = useState<string | null>(null)
+  const [cookiesOpen, setCookiesOpen] = useState(false)
 
+  // The host the cookie panel scopes to -- the active tab's, like the
+  // Cookie-Editor popup. Undefined on a blank tab, which shows the whole jar.
+  const host = useMemo(() => {
+    try {
+      return new URL(nav.url).hostname || undefined
+    } catch {
+      return undefined
+    }
+  }, [nav.url])
+
+  // A BrowserView always paints ABOVE the window's own webContents, so the
+  // panel can't simply overlay the page: main has to shrink the page view out
+  // of the way first. Growing the reserved chrome height does exactly that,
+  // and 0 hands the space back.
+  useEffect(() => {
+    void api.browser.setChromeHeight(cookiesOpen ? window.innerHeight : 0)
+  }, [cookiesOpen])
+
+  // Reserved height is absolute pixels, so a window resize while the panel is
+  // open would leave the page peeking out below it.
+  useEffect(() => {
+    if (!cookiesOpen) return
+    const onResize = (): void => void api.browser.setChromeHeight(window.innerHeight)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [cookiesOpen])
   useEffect(() => {
     const offState = api.browser.onState(setNav)
     const offTabs = api.browser.onTabs(setTabs)
@@ -53,7 +81,7 @@ export function BrowserChrome(): JSX.Element {
 
   return (
     <div className="flex h-screen w-screen select-none flex-col overflow-hidden bg-surface text-text">
-      {/* Tab strip — doubles as the draggable title bar; native controls overlay it. */}
+      {/* Tab strip â€” doubles as the draggable title bar; native controls overlay it. */}
       <div className="titlebar reserve-controls-left reserve-controls-right flex items-end gap-0.5 overflow-x-auto px-2 pt-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {tabs.map((t) => (
           <div
@@ -154,7 +182,25 @@ export function BrowserChrome(): JSX.Element {
             className="h-8 w-full rounded-full border border-border bg-surface-2 pl-9 pr-3.5 text-xs text-text outline-none transition-colors placeholder:text-text-subtle focus:border-accent focus:bg-surface focus:ring-1 focus:ring-accent/35"
           />
         </div>
+        <NavButton onClick={() => setCookiesOpen((v) => !v)} title="Cookies" active={cookiesOpen}>
+          <Cookie className="h-4 w-4" />
+        </NavButton>
       </div>
+
+      {/* Cookie editor. Rendered in the chrome (not over the page) because a
+          BrowserView can't be painted over -- main shrinks the page view to
+          make room, so this genuinely sits on top. */}
+      {cookiesOpen && (
+        <CookiePanel
+          host={host}
+          className="min-h-0 flex-1"
+          action={
+            <NavButton onClick={() => setCookiesOpen(false)} title="Close cookies">
+              <X className="h-3.5 w-3.5" />
+            </NavButton>
+          }
+        />
+      )}
     </div>
   )
 }
@@ -163,12 +209,15 @@ function NavButton({
   children,
   onClick,
   disabled,
-  title
+  title,
+  active
 }: {
   children: React.ReactNode
   onClick: () => void
   disabled?: boolean
   title: string
+  /** Held-down look, for buttons that toggle a panel open. */
+  active?: boolean
 }): JSX.Element {
   return (
     <button
@@ -176,7 +225,10 @@ function NavButton({
       onClick={onClick}
       disabled={disabled}
       title={title}
-      className="press-scale flex h-7 w-7 shrink-0 items-center justify-center sq sq-lg rounded-lg text-text-muted hover:bg-surface-2 hover:text-text disabled:opacity-35 disabled:hover:bg-transparent disabled:hover:text-text-muted"
+      className={cn(
+        'press-scale flex h-7 w-7 shrink-0 items-center justify-center sq sq-lg rounded-lg text-text-muted hover:bg-surface-2 hover:text-text disabled:opacity-35 disabled:hover:bg-transparent disabled:hover:text-text-muted',
+        active && 'bg-surface-2 text-text'
+      )}
     >
       {children}
     </button>

--- a/src/renderer/src/components/CookiePanel.tsx
+++ b/src/renderer/src/components/CookiePanel.tsx
@@ -1,0 +1,508 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Check, ClipboardPaste, Copy, Plus, RotateCw, Search, Trash2, X } from 'lucide-react'
+import type { CookieRow } from '@shared/api'
+import { api } from '../lib/api'
+import { cn } from '../lib/cn'
+
+/** A blank cookie scoped to the host you're looking at â€” what "Add" starts from. */
+function blankCookie(host: string): CookieRow {
+  return {
+    name: '',
+    value: '',
+    domain: host,
+    path: '/',
+    secure: true,
+    httpOnly: false,
+    hostOnly: false,
+    session: true,
+    sameSite: 'lax',
+    storeId: '0'
+  }
+}
+
+/** Stable identity for a cookie â€” the tuple the jar itself keys on. */
+function idOf(c: CookieRow): string {
+  return `${c.domain}|${c.path}|${c.name}`
+}
+
+/** "in 3 days" / "expired" / "session" â€” the only part of a cookie people scan for. */
+function expiryLabel(c: CookieRow): string {
+  if (c.session || !c.expirationDate) return 'Session'
+  const ms = c.expirationDate * 1000 - Date.now()
+  if (ms <= 0) return 'Expired'
+  const days = Math.round(ms / 86_400_000)
+  if (days >= 1) return `${days}d`
+  const hours = Math.round(ms / 3_600_000)
+  return hours >= 1 ? `${hours}h` : `${Math.max(1, Math.round(ms / 60_000))}m`
+}
+
+/**
+ * The cookie editor â€” Cookie-Editor's job, native to the Roxy browser.
+ *
+ * Used from two places: the browser window's own chrome (scoped to the active
+ * tab's host, like the extension's popup) and Settings â†’ Browser (`scope`
+ * omitted, so it shows the whole jar). Both drive the same partition, because
+ * there is only one.
+ */
+export function CookiePanel({
+  /** Host to scope to; omit for the entire jar. */
+  host,
+  /** Rendered top-right, next to the refresh control (the panel's close button). */
+  action,
+  className
+}: {
+  host?: string
+  action?: React.ReactNode
+  className?: string
+}): JSX.Element {
+  const [rows, setRows] = useState<CookieRow[]>([])
+  const [query, setQuery] = useState('')
+  const [openId, setOpenId] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [note, setNote] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+  const [importing, setImporting] = useState(false)
+  const [importText, setImportText] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setBusy(true)
+    try {
+      setRows(await api.cookies.list(host ? `https://${host}/` : undefined))
+    } finally {
+      setBusy(false)
+    }
+  }, [host])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // Notices are transient: they report the result of an action, and a stale
+  // "Imported 12" sitting above a list you've since edited is just noise.
+  useEffect(() => {
+    if (!note) return
+    const t = setTimeout(() => setNote(null), 4000)
+    return () => clearTimeout(t)
+  }, [note])
+
+  const shown = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return rows
+    return rows.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        c.domain.toLowerCase().includes(q) ||
+        c.value.toLowerCase().includes(q)
+    )
+  }, [rows, query])
+
+  const save = async (row: CookieRow, original?: CookieRow): Promise<void> => {
+    // Renaming or re-scoping writes a NEW cookie rather than moving one, so the
+    // old one has to go explicitly or you'd silently end up with both.
+    if (original && idOf(original) !== idOf(row) && original.name)
+      await api.cookies.remove(original)
+    const err = await api.cookies.set(row)
+    if (err) setNote({ kind: 'err', text: err })
+    else {
+      setNote({ kind: 'ok', text: `Saved ${row.name}` })
+      setOpenId(null)
+    }
+    await refresh()
+  }
+
+  const del = async (row: CookieRow): Promise<void> => {
+    await api.cookies.remove(row)
+    if (openId === idOf(row)) setOpenId(null)
+    await refresh()
+  }
+
+  const copyAll = async (): Promise<void> => {
+    // Cookie-Editor's export is a bare array, pretty-printed â€” match it exactly
+    // so what lands on the clipboard pastes into that extension unchanged.
+    await navigator.clipboard.writeText(JSON.stringify(shown, null, 2))
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  const runImport = async (): Promise<void> => {
+    try {
+      const r = await api.cookies.importJson(importText)
+      setNote(
+        r.failed
+          ? {
+              kind: 'err',
+              text: `Imported ${r.imported}, ${r.failed} failed: ${r.errors[0] ?? ''}`
+            }
+          : { kind: 'ok', text: `Imported ${r.imported} cookie${r.imported === 1 ? '' : 's'}.` }
+      )
+      if (r.imported) {
+        setImportText('')
+        setImporting(false)
+      }
+    } catch (e) {
+      setNote({ kind: 'err', text: e instanceof Error ? e.message : String(e) })
+    }
+    await refresh()
+  }
+
+  const clearAll = async (): Promise<void> => {
+    const n = await api.cookies.clear(host)
+    setNote({ kind: 'ok', text: `Deleted ${n} cookie${n === 1 ? '' : 's'}.` })
+    await refresh()
+  }
+
+  return (
+    <div className={cn('flex min-h-0 flex-col text-text', className)}>
+      {/* Toolbar */}
+      <div className="flex shrink-0 items-center gap-1.5 border-b border-border px-2.5 py-2">
+        <div className="relative min-w-0 flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3 w-3 -translate-y-1/2 text-text-subtle" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={host ? `Cookies for ${host}` : 'Search all cookies'}
+            spellCheck={false}
+            className="h-7 w-full rounded-md border border-border bg-surface-2 pl-7 pr-2 text-xs outline-none placeholder:text-text-subtle focus:border-accent"
+          />
+        </div>
+        <IconBtn onClick={() => void refresh()} title="Refresh" busy={busy}>
+          <RotateCw className="h-3.5 w-3.5" />
+        </IconBtn>
+        <IconBtn
+          onClick={() => {
+            const c = blankCookie(host ?? '')
+            setRows((r) => [c, ...r])
+            setOpenId(idOf(c))
+          }}
+          title="Add cookie"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </IconBtn>
+        <IconBtn onClick={() => void copyAll()} title="Copy as Cookie-Editor JSON">
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-success" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </IconBtn>
+        <IconBtn onClick={() => setImporting((v) => !v)} title="Import JSON" active={importing}>
+          <ClipboardPaste className="h-3.5 w-3.5" />
+        </IconBtn>
+        <IconBtn
+          onClick={() => void clearAll()}
+          title={host ? `Delete all for ${host}` : 'Delete all'}
+          danger
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </IconBtn>
+        {action}
+      </div>
+
+      {importing && (
+        <div className="shrink-0 border-b border-border bg-surface-2/40 p-2.5">
+          <textarea
+            value={importText}
+            onChange={(e) => setImportText(e.target.value)}
+            placeholder='Paste Cookie-Editor / EditThisCookie JSON â€” [{ "name": "session", "value": "â€¦", "domain": ".example.com" }]'
+            spellCheck={false}
+            rows={4}
+            className="w-full resize-y rounded-md border border-border bg-surface p-2 font-mono text-[11px] outline-none placeholder:text-text-subtle focus:border-accent"
+          />
+          <div className="mt-1.5 flex justify-end gap-1.5">
+            <SmallBtn onClick={() => setImporting(false)}>Cancel</SmallBtn>
+            <SmallBtn onClick={() => void runImport()} primary disabled={!importText.trim()}>
+              Import
+            </SmallBtn>
+          </div>
+        </div>
+      )}
+
+      {note && (
+        <div
+          className={cn(
+            'shrink-0 px-2.5 py-1.5 text-[11px]',
+            note.kind === 'ok' ? 'text-success' : 'text-danger'
+          )}
+        >
+          {note.text}
+        </div>
+      )}
+
+      {/* List */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {shown.length === 0 ? (
+          <p className="px-3 py-6 text-center text-xs text-text-subtle">
+            {rows.length ? 'No cookies match that search.' : 'No cookies here yet.'}
+          </p>
+        ) : (
+          shown.map((c) => {
+            const id = idOf(c)
+            return (
+              <CookieItem
+                key={id}
+                cookie={c}
+                open={openId === id}
+                onToggle={() => setOpenId((v) => (v === id ? null : id))}
+                onSave={(next) => void save(next, c)}
+                onDelete={() => void del(c)}
+              />
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** One row: a summary line that expands into the full editable field set. */
+function CookieItem({
+  cookie,
+  open,
+  onToggle,
+  onSave,
+  onDelete
+}: {
+  cookie: CookieRow
+  open: boolean
+  onToggle: () => void
+  onSave: (next: CookieRow) => void
+  onDelete: () => void
+}): JSX.Element {
+  const [draft, setDraft] = useState<CookieRow>(cookie)
+  const nameRef = useRef<HTMLInputElement>(null)
+
+  // Re-seed when the underlying cookie changes (a refresh landed) but never
+  // while the editor is open, or a background refresh would wipe your typing.
+  useEffect(() => {
+    if (!open) setDraft(cookie)
+  }, [cookie, open])
+
+  useEffect(() => {
+    if (open && !cookie.name) nameRef.current?.focus()
+  }, [open, cookie.name])
+
+  const patch = (p: Partial<CookieRow>): void => setDraft((d) => ({ ...d, ...p }))
+
+  return (
+    <div className="border-b border-border/60">
+      <div
+        onClick={onToggle}
+        className="flex cursor-default items-center gap-2 px-2.5 py-1.5 hover:bg-surface-2/60"
+      >
+        <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-text">
+          {cookie.name || <span className="text-text-subtle italic">new cookie</span>}
+        </span>
+        <span className="min-w-0 max-w-[45%] flex-1 truncate font-mono text-[11px] text-text-subtle">
+          {cookie.value}
+        </span>
+        <span className="shrink-0 text-[10px] text-text-subtle">{expiryLabel(cookie)}</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+          title="Delete cookie"
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-subtle hover:bg-danger/15 hover:text-danger"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+
+      {open && (
+        <div className="grid gap-2 bg-surface-2/40 px-2.5 pb-2.5 pt-2 sm:grid-cols-2">
+          <Field label="Name">
+            <input
+              ref={nameRef}
+              value={draft.name}
+              onChange={(e) => patch({ name: e.target.value })}
+              className={fieldCls}
+            />
+          </Field>
+          <Field label="Domain">
+            <input
+              value={draft.domain}
+              onChange={(e) => patch({ domain: e.target.value })}
+              className={fieldCls}
+            />
+          </Field>
+          <Field label="Value" wide>
+            <textarea
+              value={draft.value}
+              onChange={(e) => patch({ value: e.target.value })}
+              rows={2}
+              className={cn(fieldCls, 'resize-y')}
+            />
+          </Field>
+          <Field label="Path">
+            <input
+              value={draft.path}
+              onChange={(e) => patch({ path: e.target.value })}
+              className={fieldCls}
+            />
+          </Field>
+          <Field label="SameSite">
+            <select
+              value={draft.sameSite}
+              onChange={(e) => patch({ sameSite: e.target.value as CookieRow['sameSite'] })}
+              className={fieldCls}
+            >
+              <option value="unspecified">Unspecified</option>
+              <option value="lax">Lax</option>
+              <option value="strict">Strict</option>
+              <option value="no_restriction">None</option>
+            </select>
+          </Field>
+          <Field label="Expires" wide>
+            <div className="flex items-center gap-2">
+              <input
+                type="datetime-local"
+                disabled={draft.session}
+                value={
+                  draft.expirationDate
+                    ? new Date(draft.expirationDate * 1000).toISOString().slice(0, 16)
+                    : ''
+                }
+                onChange={(e) => {
+                  const t = Date.parse(e.target.value)
+                  patch({ expirationDate: Number.isNaN(t) ? undefined : t / 1000 })
+                }}
+                className={cn(fieldCls, 'flex-1 disabled:opacity-40')}
+              />
+              <Toggle
+                label="Session"
+                checked={draft.session}
+                onChange={(v) => patch({ session: v })}
+              />
+            </div>
+          </Field>
+          <div className="col-span-full flex flex-wrap items-center gap-x-4 gap-y-1.5">
+            <Toggle label="Secure" checked={draft.secure} onChange={(v) => patch({ secure: v })} />
+            <Toggle
+              label="HttpOnly"
+              checked={draft.httpOnly}
+              onChange={(v) => patch({ httpOnly: v })}
+            />
+            <Toggle
+              label="Host only"
+              checked={draft.hostOnly}
+              onChange={(v) => patch({ hostOnly: v })}
+            />
+            <div className="ml-auto flex gap-1.5">
+              <SmallBtn onClick={onToggle}>Cancel</SmallBtn>
+              <SmallBtn
+                onClick={() => onSave(draft)}
+                primary
+                disabled={!draft.name || !draft.domain}
+              >
+                Save
+              </SmallBtn>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const fieldCls =
+  'w-full rounded-md border border-border bg-surface px-2 py-1 font-mono text-[11px] text-text outline-none focus:border-accent'
+
+function Field({
+  label,
+  wide,
+  children
+}: {
+  label: string
+  wide?: boolean
+  children: React.ReactNode
+}): JSX.Element {
+  return (
+    <label className={cn('flex flex-col gap-1', wide && 'sm:col-span-2')}>
+      <span className="text-[10px] uppercase tracking-wide text-text-subtle">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange
+}: {
+  label: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}): JSX.Element {
+  return (
+    <label className="flex cursor-default items-center gap-1.5 text-[11px] text-text-muted">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-3 w-3 accent-[var(--color-accent)]"
+      />
+      {label}
+    </label>
+  )
+}
+
+function IconBtn({
+  children,
+  onClick,
+  title,
+  busy,
+  active,
+  danger
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  title: string
+  busy?: boolean
+  active?: boolean
+  danger?: boolean
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={cn(
+        'press-scale flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-2 hover:text-text',
+        active && 'bg-surface-2 text-text',
+        danger && 'hover:bg-danger/15 hover:text-danger',
+        busy && 'animate-pulse'
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+function SmallBtn({
+  children,
+  onClick,
+  primary,
+  disabled
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  primary?: boolean
+  disabled?: boolean
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'press-scale rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors disabled:opacity-40',
+        primary
+          ? 'bg-white text-black hover:bg-white/90'
+          : 'border border-border text-text-muted hover:bg-surface-2 hover:text-text'
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/renderer/src/routes/Settings.tsx
+++ b/src/renderer/src/routes/Settings.tsx
@@ -17,6 +17,7 @@ import {
 import { randomSlug, slugToBranchSegment } from '@shared/slugs'
 import { PageShell } from '../components/PageShell'
 import { McpServers } from '../components/McpServers'
+import { CookiePanel } from '../components/CookiePanel'
 import { ConfigBackup } from '../components/ConfigBackup'
 import { ActivitySection } from '../components/ActivitySection'
 import { ProviderLogo } from '../lib/providerLogos'
@@ -285,6 +286,19 @@ export default function Settings(): JSX.Element {
           <Button variant="secondary" className="shrink-0" onClick={() => api.browser.open()}>
             <Globe className="h-3.5 w-3.5" /> Open browser
           </Button>
+        </div>
+
+        <div className="mt-3 overflow-hidden sq sq-xl sq-ring rounded-xl border border-border bg-surface">
+          <div className="border-b border-border p-4">
+            <div className="text-sm font-medium text-text">Cookies</div>
+            <p className="mt-0.5 text-xs text-text-muted">
+              Read, edit, import and delete the browser&apos;s cookies — the built-in equivalent of
+              the Cookie-Editor extension. Import and export use its JSON format, so a blob copied
+              out of Chrome pastes straight in. To work on just one site, use the cookie button in
+              the browser&apos;s own toolbar.
+            </p>
+          </div>
+          <CookiePanel className="max-h-[420px]" />
         </div>
       </section>
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -48,7 +48,7 @@ export interface UpsertMcpServerInput {
   enabled?: boolean
 }
 
-/** A skill discovered on disk (metadata only — the body is loaded on demand by the tool). */
+/** A skill discovered on disk (metadata only â€” the body is loaded on demand by the tool). */
 export interface SkillView {
   name: string
   description?: string
@@ -58,7 +58,7 @@ export interface SkillView {
   source: 'workspace' | 'global'
 }
 
-/** A skill plus its full markdown body — returned by `skills.read` for the editor. */
+/** A skill plus its full markdown body â€” returned by `skills.read` for the editor. */
 export interface SkillDetail extends SkillView {
   body: string
 }
@@ -68,7 +68,7 @@ export interface SkillWriteInput {
   name: string
   description?: string
   body?: string
-  /** Where to write it — defaults to 'global' from the Skills page (no workspace context). */
+  /** Where to write it â€” defaults to 'global' from the Skills page (no workspace context). */
   scope?: 'workspace' | 'global'
 }
 
@@ -98,7 +98,7 @@ export interface CreateChatInput {
   workspacePath?: string | null
   parentId?: string | null
   /**
-   * Run this session in its own git worktree — an isolated checkout on its own
+   * Run this session in its own git worktree â€” an isolated checkout on its own
    * branch, so it can't collide with other sessions on the same repo. Recorded
    * now, created on the first turn.
    */
@@ -119,7 +119,7 @@ export interface ForkChatInput {
 }
 
 /**
- * A background process owned by a session — a dev server, a watcher, an install.
+ * A background process owned by a session â€” a dev server, a watcher, an install.
  *
  * Subagent-started processes are owned by the ROOT session, so they appear in
  * their parent's panel; the parent is who can stop them.
@@ -157,7 +157,7 @@ export interface GitStatusView {
   defaultBranch: string | null
 }
 
-/** One checkout of a repository — the main working tree, or a workstream's. */
+/** One checkout of a repository â€” the main working tree, or a workstream's. */
 export interface WorktreeView {
   path: string
   branch: string | null
@@ -217,7 +217,7 @@ export interface CreateLoopInput {
 
 /** An image attached to a user message, sent to vision-capable models. */
 export interface ChatImage {
-  /** Image as a data URL (data:image/png;base64,…). */
+  /** Image as a data URL (data:image/png;base64,â€¦). */
   dataUrl: string
   /** MIME type, e.g. 'image/png'. */
   mediaType: string
@@ -235,7 +235,7 @@ export interface ChatMessage {
    * Each id pairs with a following `role:'tool'` message's `toolCallId`.
    */
   toolCalls?: { id: string; name: string; arguments: string }[]
-  /** For `role:'tool'` messages — which assistant tool call this result answers. */
+  /** For `role:'tool'` messages â€” which assistant tool call this result answers. */
   toolCallId?: string
 }
 
@@ -273,7 +273,7 @@ export type LlmEvent =
       /**
        * For a `task` call: the delegate's own session id.
        *
-       * Carried beside `input` rather than inside it on purpose — `input` is
+       * Carried beside `input` rather than inside it on purpose â€” `input` is
        * replayed verbatim as the model's `tool_calls` arguments on later turns
        * (see reconstructTurn), and an id the model never passed has no business
        * in its history. This is UI addressing: it's what lets the card's cancel
@@ -281,13 +281,13 @@ export type LlmEvent =
        */
       subChatId?: string
       /**
-       * Whether this call can be cancelled on its own while it runs — resolved in
+       * Whether this call can be cancelled on its own while it runs â€” resolved in
        * the harness from the tool catalog (`isInterruptibleTool`), which is the
        * only place that knows an MCP tool's runtime name.
        *
        * Sent rather than re-derived in the renderer so the button and the thing
        * it triggers can never disagree: one source, decided where the signal is
-       * actually threaded. Beside `input` for the same reason `subChatId` is —
+       * actually threaded. Beside `input` for the same reason `subChatId` is â€”
        * `input` is replayed verbatim as the model's tool_calls arguments, and
        * this is UI addressing the model never sent.
        */
@@ -314,7 +314,7 @@ export type LlmEvent =
    */
   | { type: 'tool-child'; callId: string; event: LlmChildEvent }
 
-/** The subset of `LlmEvent` a subagent can emit — everything except further nesting. */
+/** The subset of `LlmEvent` a subagent can emit â€” everything except further nesting. */
 export type LlmChildEvent = Exclude<LlmEvent, { type: 'tool-child' }>
 
 export interface LlmDelta {
@@ -344,7 +344,7 @@ export interface SubagentRunView {
   parentChatId: string | null
   description: string
   subagentType: string
-  /** True for a detached (`background: true`) run — it outlives its launching turn. */
+  /** True for a detached (`background: true`) run â€” it outlives its launching turn. */
   background: boolean
   startedAt: number
 }
@@ -365,7 +365,7 @@ export interface SessionsUpdated {
    * status map has no entry for it yet.
    */
   reason: 'worktree' | 'branch' | 'metadata'
-  /** The sessions affected — usually one. */
+  /** The sessions affected â€” usually one. */
   sessionIds: string[]
   /**
    * The session's git path after the change (its worktree, else its project
@@ -406,7 +406,7 @@ export interface ModelInfo {
   contextLimit?: number
   /** Max output tokens, when known. */
   outputLimit?: number
-  /** USD price per 1M tokens (from models.dev), when known — powers cost math. */
+  /** USD price per 1M tokens (from models.dev), when known â€” powers cost math. */
   cost?: ModelCost
 }
 
@@ -416,7 +416,7 @@ export interface ModelCost {
   input?: number
   /** Output (completion) tokens. */
   output?: number
-  /** Cache-read (cached input) tokens — usually far cheaper than `input`. */
+  /** Cache-read (cached input) tokens â€” usually far cheaper than `input`. */
   cacheRead?: number
   /** Cache-write tokens. */
   cacheWrite?: number
@@ -439,6 +439,38 @@ export interface BrowserTab {
   active: boolean
 }
 
+/**
+ * One cookie in the Cookie-Editor / EditThisCookie interchange shape - the
+ * format the built-in cookie editor imports, exports and renders. It is that
+ * extension's schema rather than Electron's so a blob copied out of Chrome
+ * pastes in unchanged (and back out again).
+ */
+export interface CookieRow {
+  name: string
+  value: string
+  domain: string
+  path: string
+  secure: boolean
+  httpOnly: boolean
+  /** True when the cookie is bound to exactly `domain` (no subdomains). */
+  hostOnly: boolean
+  /** True for a session cookie - no expiry, dropped when the browser exits. */
+  session: boolean
+  sameSite: 'no_restriction' | 'lax' | 'strict' | 'unspecified'
+  /** Seconds since epoch. Absent for session cookies. */
+  expirationDate?: number
+  /** Always "0" - carried only so exports match Cookie-Editor's output. */
+  storeId: string
+}
+
+/** Outcome of a cookie JSON paste: how many landed, and why any didn't. */
+export interface CookieImportResult {
+  imported: number
+  failed: number
+  /** Capped at a handful, so a wholly-bad paste can't flood a toast. */
+  errors: string[]
+}
+
 /** Auto-update lifecycle state (main -> renderer). */
 export type UpdateState =
   | { status: 'idle' }
@@ -459,7 +491,7 @@ export interface UpdateInfo {
 }
 
 /**
- * Remote Workspace — take the running desktop session to a phone via roxy.gg.
+ * Remote Workspace â€” take the running desktop session to a phone via roxy.gg.
  * The desktop stays authoritative (it runs the model + tools); the phone is a
  * thin remote control + live viewer paired through the relay.
  */
@@ -481,7 +513,7 @@ export interface RemoteState {
   phase: RemotePhase
   /** Room id on roxy.gg (present once minted). */
   brokerId?: string
-  /** Safe URL to open on the phone — guest token lives in the fragment. */
+  /** Safe URL to open on the phone â€” guest token lives in the fragment. */
   url?: string
   /** PIN shown on the desktop; the phone must enter it to pair. */
   pin?: string
@@ -508,8 +540,8 @@ export interface RemoteStartInput {
 
 /**
  * A streamed step of a phone-driven turn, pushed to the desktop renderer (via
- * `remote:delta`) so the PC mirrors the reply token-by-token — exactly like a
- * local turn's `LlmDelta` — instead of only reloading from disk when it ends.
+ * `remote:delta`) so the PC mirrors the reply token-by-token â€” exactly like a
+ * local turn's `LlmDelta` â€” instead of only reloading from disk when it ends.
  * Tagged with `sessionId` (not a requestId) since the renderer keys the live
  * mirror by chat, and a phone turn isn't tied to a local llm request.
  *
@@ -595,15 +627,15 @@ export interface RoxyApi {
     reorder(workspacePath: string | null, ids: string[]): Promise<void>
     /**
      * Subscribe to session rows changed by MAIN with no renderer call behind
-     * them — a worktree materialized on the first turn, a branch renamed under
+     * them â€” a worktree materialized on the first turn, a branch renamed under
      * it. Returns an unsubscribe fn.
      */
     onUpdated(callback: (payload: SessionsUpdated) => void): () => void
   }
   projects: {
-    /** Workspace paths in sidebar display order, top → bottom. */
+    /** Workspace paths in sidebar display order, top â†’ bottom. */
     listOrder(): Promise<string[]>
-    /** Persist the project order; `paths` is the full list, top → bottom. */
+    /** Persist the project order; `paths` is the full list, top â†’ bottom. */
     reorder(paths: string[]): Promise<void>
   }
   messages: {
@@ -640,7 +672,7 @@ export interface RoxyApi {
     /** Delete a skill by name; returns the updated list. */
     remove(name: string, cwd?: string): Promise<SkillView[]>
     /**
-     * Install skill(s) from a remote source — a GitHub `owner/repo`, a github.com
+     * Install skill(s) from a remote source â€” a GitHub `owner/repo`, a github.com
      * URL, or a direct SKILL.md URL (Roxy's in-app `npx skills add`). Writes global
      * skills by default (or workspace when a cwd is given).
      */
@@ -739,8 +771,8 @@ export interface RoxyApi {
     run(sessionId: string, name: string, input: Record<string, unknown>): Promise<ToolResult>
     /**
      * Cancel ONE tool call that is running right now, without stopping the turn
-     * around it. Resolves false when nothing was running for that call id — it
-     * finished between the click and the call — which the UI uses to avoid
+     * around it. Resolves false when nothing was running for that call id â€” it
+     * finished between the click and the call â€” which the UI uses to avoid
      * pretending it did something.
      */
     cancel(callId: string): Promise<boolean>
@@ -751,7 +783,7 @@ export interface RoxyApi {
     remove(id: string): Promise<void>
     /** Reorder a chat's queue; `ids` is the full queue front-to-back. */
     reorder(chatId: string, ids: string[]): Promise<void>
-    /** Edit a queued item in place — new text + images, same queue position. */
+    /** Edit a queued item in place â€” new text + images, same queue position. */
     update(id: string, content: string, images?: QueueImage[]): Promise<QueueItem | undefined>
   }
   usage: {
@@ -767,7 +799,7 @@ export interface RoxyApi {
     start(input: LlmStartInput): Promise<LlmResult>
     abort(requestId: string): Promise<void>
     /**
-     * Stop everything in flight for a session — the streaming turn, any
+     * Stop everything in flight for a session â€” the streaming turn, any
      * compaction running ahead of it, and every subagent it spawned. Works even
      * before a requestId exists, which `abort` cannot.
      */
@@ -789,7 +821,7 @@ export interface RoxyApi {
      * persisted transcript is then the truth).
      */
     snapshot(subChatId: string): Promise<MessagePart[] | null>
-    /** Every subagent currently running — restores live state after a window reload. */
+    /** Every subagent currently running â€” restores live state after a window reload. */
     listRunning(): Promise<SubagentRunView[]>
     /**
      * Tell main which chat is on screen, so the end-of-turn prune spares a sub
@@ -838,10 +870,33 @@ export interface RoxyApi {
     activateTab(id: string): Promise<void>
     /** Reorder a tab to a new index in the strip (drag-to-reorder). */
     moveTab(id: string, toIndex: number): Promise<void>
+    /**
+     * Reserve N px of window for the chrome so a chrome panel can cover the
+     * page; pass 0 to restore the normal toolbar height. Only meaningful from
+     * inside the browser window itself.
+     */
+    setChromeHeight(height: number): Promise<void>
     /** Subscribe to the browser toolbar's navigation state; returns an unsubscribe fn. */
     onState(callback: (state: BrowserState) => void): () => void
     /** Subscribe to the open tab list; returns an unsubscribe fn. */
     onTabs(callback: (tabs: BrowserTab[]) => void): () => void
+  }
+  /**
+   * The built-in cookie editor for the Roxy browser - what the Cookie-Editor
+   * extension does, against the browser's own persisted partition. Every shape
+   * here is Cookie-Editor's interchange format, so exports paste into Chrome
+   * and Chrome's exports paste in here.
+   */
+  cookies: {
+    /** Cookies for a URL's whole domain chain, or the entire jar when omitted. */
+    list(url?: string): Promise<CookieRow[]>
+    /** Create or overwrite one cookie. Resolves to an error string, or null on success. */
+    set(row: Partial<CookieRow>): Promise<string | null>
+    remove(row: Pick<CookieRow, 'name' | 'domain' | 'path' | 'secure'>): Promise<void>
+    /** Delete every cookie under a host, or the whole jar. Resolves to the count removed. */
+    clear(host?: string): Promise<number>
+    /** Import a Cookie-Editor / EditThisCookie JSON blob. Rejects only on malformed JSON. */
+    importJson(text: string): Promise<CookieImportResult>
   }
   services: {
     /** Background processes owned by a session (includes its subagents'). */
@@ -903,7 +958,7 @@ export interface RoxyApi {
     /** Remove a worktree directory and prune git's record of it. */
     removeWorktree(path: string, force?: boolean): Promise<{ ok: boolean; error?: string }>
     /**
-     * Rename a session's workstream branch. Safe while checked out — git
+     * Rename a session's workstream branch. Safe while checked out â€” git
      * rewrites the worktree's HEAD in place, leaving uncommitted work alone.
      */
     renameBranch(sessionId: string, to: string): Promise<{ ok: boolean; error?: string }>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -34,12 +34,12 @@ export const CHANNELS = {
    * main -> renderer: a session row changed in MAIN, with no renderer call to
    * hang a refresh off. The only source of truth for `worktree_path` / `branch`
    * / `dev_port` is the main process, and it writes them mid-turn (lazy worktree
-   * materialization) — so without this push the workstream strip keeps claiming
+   * materialization) â€” so without this push the workstream strip keeps claiming
    * "(pending) / branch pending" until something unrelated happens to refetch.
    */
   chatsUpdated: 'chats:updated',
 
-  /** Project (workspace) display order — read + drag-to-reorder. */
+  /** Project (workspace) display order â€” read + drag-to-reorder. */
   projectsListOrder: 'projects:listOrder',
   projectsReorder: 'projects:reorder',
 
@@ -101,7 +101,7 @@ export const CHANNELS = {
    *
    * The gap this closes: Stop is all-or-nothing. A turn that fires `bash npm
    * test` on a wedged suite, or a `webfetch` at a host that will never answer,
-   * could only be rescued by killing the whole turn — losing the reasoning and
+   * could only be rescued by killing the whole turn â€” losing the reasoning and
    * every other tool result with it. This aborts just that call; the tool reports
    * back as cancelled and the model carries on with the rest of its work.
    *
@@ -128,7 +128,7 @@ export const CHANNELS = {
    * renderer -> main: stop EVERYTHING in flight for a session.
    *
    * llm:abort needs a requestId, which the renderer only has once the turn is
-   * already streaming — so it cannot cancel the pre-flight work (compaction
+   * already streaming â€” so it cannot cancel the pre-flight work (compaction
    * above all) that runs first. This is Stop as the user means it, keyed by the
    * one id the UI always has.
    */
@@ -156,7 +156,7 @@ export const CHANNELS = {
    *
    * Keyed by sub chat id rather than the background job id `tasks:cancel` uses,
    * because that is the only handle the UI has for a FOREGROUND delegate (which
-   * has no job at all) — and it's the id every subagent surface already knows.
+   * has no job at all) â€” and it's the id every subagent surface already knows.
    */
   subagentCancel: 'subagent:cancel',
 
@@ -194,6 +194,23 @@ export const CHANNELS = {
   browserState: 'browser:state',
   /** main -> browser toolbar: open tab list */
   browserTabs: 'browser:tabs',
+
+  /**
+   * Cookie editor â€” the built-in equivalent of the Cookie-Editor extension.
+   * Reads/writes the browser partition's jar directly, and speaks Cookie-Editor's
+   * JSON on import/export so blobs move between it and Chrome unchanged.
+   */
+  cookiesList: 'cookies:list',
+  cookiesSet: 'cookies:set',
+  cookiesRemove: 'cookies:remove',
+  cookiesClear: 'cookies:clear',
+  cookiesImport: 'cookies:import',
+  /**
+   * browser chrome -> main: reserve N px for the chrome so a panel can cover
+   * the page. BrowserViews always paint above the window's webContents, so
+   * growing the chrome is the only way for chrome UI to sit on top.
+   */
+  browserChromeHeight: 'browser:chrome-height',
 
   /** renderer -> main: a session's background processes (the Services panel) */
   servicesList: 'services:list',

--- a/test/cookies.ts
+++ b/test/cookies.ts
@@ -1,0 +1,196 @@
+/**
+ * Cookie editor checks, run in a REAL Electron main process — the cookie jar is
+ * a native API, so there is nothing meaningful to assert against a mock.
+ *
+ * These drive the SHIPPING module (src/main/services/cookies.ts), not a copy of
+ * its logic, so the bridging rules it exists to encode are actually covered:
+ * session cookies must omit `expirationDate` rather than send 0, `hostOnly` is
+ * expressed by omitting `domain`, and the parent-domain walk is what makes a
+ * `.example.com` cookie visible while you sit on `app.example.com`.
+ *
+ * SAFETY: every cookie here lives under example.com / example.org, and cleanup
+ * is scoped to those hosts. The suite never calls the unscoped `clear()`, so it
+ * cannot wipe real logins out of the shared browser partition.
+ *
+ * Run: npm run smoke:cookies
+ */
+import { app } from 'electron'
+import { clear, importJson, list, remove, set } from '../src/main/services/cookies'
+
+/** Hosts this suite owns. Cleanup and assertions never reach outside them. */
+const HOSTS = ['example.com', 'example.org']
+
+let failures = 0
+
+function check(name: string, cond: boolean, detail: unknown = ''): void {
+  const line = cond ? `  ok   ${name}` : `  FAIL ${name} ${detail === '' ? '' : String(detail)}`
+  if (!cond) failures++
+  // stderr, not stdout: Electron on Windows does not reliably deliver stdout to
+  // a redirected parent shell, so a failure would otherwise be invisible in CI.
+  process.stderr.write(line + '\n')
+}
+
+/** Delete only what this suite created. */
+async function cleanup(): Promise<void> {
+  for (const host of HOSTS) await clear(host)
+}
+
+async function main(): Promise<void> {
+  await app.whenReady()
+  process.stderr.write('cookie editor:\n')
+  await cleanup()
+
+  // --- 1. a Cookie-Editor style row survives a round trip -------------------
+  const soon = Math.floor(Date.now() / 1000) + 3600
+  let err = await set({
+    name: 'sid',
+    value: 'abc123',
+    domain: '.example.com',
+    path: '/',
+    secure: true,
+    httpOnly: true,
+    session: false,
+    sameSite: 'lax',
+    expirationDate: soon
+  })
+  check('set accepts a well-formed cookie', err === null, err)
+
+  let rows = await list('https://example.com/')
+  let sid = rows.find((c) => c.name === 'sid')
+  check('persistent cookie round-trips', !!sid)
+  check('  value preserved', sid?.value === 'abc123', sid?.value)
+  check('  httpOnly preserved', sid?.httpOnly === true)
+  check('  secure preserved', sid?.secure === true)
+  check('  sameSite preserved', sid?.sameSite === 'lax', sid?.sameSite)
+  check('  expiry preserved', Math.abs((sid?.expirationDate ?? 0) - soon) < 2, sid?.expirationDate)
+  check('  a domain cookie is not hostOnly', sid?.hostOnly === false)
+  check('  export carries Cookie-Editor storeId', sid?.storeId === '0', sid?.storeId)
+
+  // --- 2. a session cookie must STAY a session cookie -----------------------
+  // The bug this guards: sending `expirationDate: 0` for a session cookie
+  // expires it on the spot instead of scoping it to the session.
+  await set({
+    name: 'tmp',
+    value: 'x',
+    domain: 'example.com',
+    path: '/',
+    secure: true,
+    session: true
+  })
+  const tmp = (await list('https://example.com/')).find((c) => c.name === 'tmp')
+  check('session cookie stays a session cookie', tmp?.session === true, JSON.stringify(tmp))
+  check('  and reports no expiry', tmp?.expirationDate === undefined, tmp?.expirationDate)
+
+  // --- 3. hostOnly is expressed by omitting `domain` ------------------------
+  await set({
+    name: 'host',
+    value: 'y',
+    domain: 'sub.example.com',
+    path: '/',
+    secure: true,
+    session: true,
+    hostOnly: true
+  })
+  const hostOnly = (await list('https://sub.example.com/')).find((c) => c.name === 'host')
+  check('hostOnly cookie is host-scoped', hostOnly?.hostOnly === true, JSON.stringify(hostOnly))
+
+  // --- 4. the parent-domain walk -------------------------------------------
+  // Electron's `domain` filter matches a domain and its SUBdomains, never its
+  // parents, so without the walk the session cookie you came to debug is
+  // invisible from the subdomain you're actually on.
+  const fromSub = await list('https://app.example.com/')
+  check(
+    'parent-domain cookie is visible from a subdomain',
+    fromSub.some((c) => c.name === 'sid'),
+    fromSub.map((c) => c.name).join(',')
+  )
+
+  // --- 5. SameSite normalization -------------------------------------------
+  // Exports from DevTools-based tools use the HTTP header casing.
+  await set({
+    name: 'ss',
+    value: 'z',
+    domain: 'example.com',
+    path: '/',
+    secure: true,
+    session: true,
+    // Deliberately the wrong casing, as EditThisCookie emits it.
+    sameSite: 'None' as never
+  })
+  const ss = (await list('https://example.com/')).find((c) => c.name === 'ss')
+  check('"None" normalizes to no_restriction', ss?.sameSite === 'no_restriction', ss?.sameSite)
+
+  // --- 6. import: the real Cookie-Editor blob shape -------------------------
+  const blob = JSON.stringify([
+    {
+      name: 'imported',
+      value: 'v1',
+      domain: '.example.org',
+      path: '/',
+      secure: true,
+      httpOnly: false,
+      hostOnly: false,
+      session: true,
+      sameSite: 'lax',
+      storeId: '0'
+    },
+    { name: 'bad', value: 'v2', domain: '', path: '/' }
+  ])
+  const res = await importJson(blob)
+  check('import lands the valid cookie', res.imported === 1, JSON.stringify(res))
+  check('  and reports the invalid one instead of throwing', res.failed === 1, JSON.stringify(res))
+  check(
+    '  imported cookie is readable',
+    (await list('https://example.org/')).some((c) => c.name === 'imported')
+  )
+
+  // A `{ cookies: [...] }` wrapper is also in the wild.
+  const wrapped = await importJson('{"cookies":[{"name":"w","value":"1","domain":"example.org"}]}')
+  check(
+    'import accepts a { cookies: [...] } wrapper',
+    wrapped.imported === 1,
+    JSON.stringify(wrapped)
+  )
+
+  // Malformed JSON is the one case that throws.
+  let threw = false
+  try {
+    await importJson('not json')
+  } catch {
+    threw = true
+  }
+  check('import rejects malformed JSON', threw)
+
+  // --- 7. export round-trips through import --------------------------------
+  const exported = JSON.stringify(await list('https://example.org/'))
+  await clear('example.org')
+  check('cleared host is empty', (await list('https://example.org/')).length === 0)
+  const back = await importJson(exported)
+  check('an export re-imports cleanly', back.failed === 0, JSON.stringify(back))
+
+  // --- 8. removal -----------------------------------------------------------
+  await remove({ name: 'sid', domain: '.example.com', path: '/', secure: true })
+  check(
+    'remove deletes the cookie',
+    !(await list('https://example.com/')).some((c) => c.name === 'sid')
+  )
+
+  await cleanup()
+  check('scoped clear leaves nothing behind', (await list('https://example.com/')).length === 0)
+
+  process.stderr.write(
+    failures ? `\nCOOKIES FAILED — ${failures} failing\n` : '\nAll cookie checks passed.\n'
+  )
+  app.exit(failures ? 1 : 0)
+}
+
+process.on('uncaughtException', (e) => {
+  process.stderr.write(`CRASH: ${e?.stack ?? e}\n`)
+  app.exit(1)
+})
+process.on('unhandledRejection', (e) => {
+  process.stderr.write(`REJECT: ${e instanceof Error ? e.stack : String(e)}\n`)
+  app.exit(1)
+})
+
+void main()


### PR DESCRIPTION
## What

Cookie editing built into the Roxy browser — what [Cookie-Editor](https://cookie-editor.com/) does, native. Two surfaces:

- **Browser toolbar** — a cookie button next to the URL bar, scoped to the active tab's host (the extension-popup position).
- **Settings → Browser** — the same panel over the whole jar, for bulk import/clear.

Search, inline edit of every field, add, delete, copy-as-JSON, paste-to-import.

## Why not actual Chrome extension support

The browser runs its tabs on a single persisted Electron partition, so `chrome.cookies` — the entire API Cookie-Editor wraps — *is* `session.cookies` here. Loading the real `.crx` would have meant `electron-chrome-extensions`, a CRX loader and a popup host, all to reach an API we already have.

Interop is kept where it actually matters: import/export speak Cookie-Editor's exact JSON (bare array or `{ cookies: [...] }`), so a blob copied out of Chrome pastes straight in, and an export pastes back into Chrome.

## Three things that were non-obvious

Each has a test.

**1. A `BrowserView` always paints above the window's own `webContents.`** A panel rendered in the chrome would sit *behind* the page — a z-index battle that cannot be won. `setChromeHeight` instead reserves window space so main shrinks the page view out of the way.

**2. Cookie shape mismatches that corrupt silently rather than error.** A session cookie must *omit* `expirationDate`, not send `0` — sending 0 expires it on the spot. `hostOnly` is likewise set by omitting `domain`, not by a flag.

**3. Electron's `domain` filter matches a domain and its SUBdomains, never its parents.** Querying the host alone hides the `.example.com` session cookie you're on `app.example.com` to debug. The lookup walks the domain chain; a test asserts the naive query would have missed it.

## Testing

`test/cookies.ts` — 23 checks, wired into `npm run smoke`. It drives the shipping module against a **real Electron cookie jar** (not a mock, and not a copy of the logic — a mock proves nothing about a native API).

Its writes are scoped to `example.com`/`example.org` and it never calls the unscoped `clear()`, so it can't wipe real logins out of the shared partition.

```
$ npm run smoke:cookies
  ok   persistent cookie round-trips
  ok   session cookie stays a session cookie
  ok   hostOnly cookie is host-scoped
  ok   parent-domain cookie is visible from a subdomain
  ok   "None" normalizes to no_restriction
  ok   import accepts a { cookies: [...] } wrapper
  ok   an export re-imports cleanly
  ... 23 total
All cookie checks passed.
```

Also: `npm run build` (typecheck + bundle) passes, and the panel was verified rendering and editing in the running app.

## Notes for the reviewer

- **Cookies are global to the partition**, so every chat shares one jar. That matches how logins there already work. Worth revisiting if per-session isolation is ever wanted.
- **No agent tool** (`browser_cookies`) in this PR — deliberately human-facing for now. The service layer is already shaped to expose one later.
- **Version bumped 0.0.83 → 0.0.84.** `package-lock.json` had drifted to 0.0.81 (the 0.0.82/0.0.83 bumps didn't sync it); this brings it back in line, which is what the last bump commit that *did* touch it (d24754f) does.
- Pre-existing and untouched: `npm run smoke` has one failing case (`a session without a port does not set PORT`) and `prettier --check` flags 14 files. Both fail identically on a clean tree at `origin/main`.
