### PR TITLE
perf(model-picker): window the list so opening it is instant

### DIFF
--- a/src/renderer/src/components/ModelPicker.tsx
+++ b/src/renderer/src/components/ModelPicker.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Brain, Check, ChevronsUpDown, Clock, Pin, Search, Wrench } from 'lucide-react'
+import { buildModelIndex, buildModelRows } from '../lib/modelRows'
 import { useRoxyStore } from '../lib/store'
 import { resolveSessionConfig } from '@shared/session-config'
 import { ProviderLogo } from '../lib/providerLogos'
 import { triggerClass } from './InferenceControls'
 import { useMenuAnchor } from '../lib/useMenuAnchor'
+import { rowOffsets, visibleRange } from '../lib/windowing'
 import { cn } from '../lib/cn'
 
 /**
@@ -16,16 +18,92 @@ import { cn } from '../lib/cn'
  * followed by a LATEST section per provider showing its last five distinct
  * picks. Hovering any row reveals a pin toggle; nothing pinned means the
  * section simply doesn't render, so the feature costs zero space unused.
+ *
+ * PERFORMANCE, and why this file looks the way it does
+ * ----------------------------------------------------
+ * The catalogs behind this are not small. A gateway provider (roxy.gg,
+ * OpenRouter) reports 300-600 models, and the menu shows EVERY connected
+ * provider at once — so the naive version mounted ~450 rows, each with a logo
+ * and up to three icons, in a single commit. Measured with the real component
+ * and real catalog sizes: ~200ms of React commit plus ~60ms of layout to open,
+ * and ~100ms per keystroke in the search field. That is the "clunky, delayed"
+ * feel; it is one long task on the main thread, so the popover's own open
+ * animation drops most of its frames too.
+ *
+ * Three things fix it, in order of how much they matter:
+ *
+ *   1. WINDOWING (`useWindow` + `lib/windowing`). The menu is height-capped at
+ *      360px and rows have known heights, so at most ~14 can ever be visible.
+ *      We flatten the whole menu into one array of row descriptors and mount
+ *      only the visible slice plus a small overscan, with spacer divs holding
+ *      the scrollbar honest. Cost becomes a function of the WINDOW, not the
+ *      catalog — opening is O(20 rows) whether the user has 30 models or 3000.
+ *
+ *   2. INDEXING (`index`). Every row used to run `models[provider].find(...)`
+ *      two or three times to resolve its own label, capabilities and pinned
+ *      state — quadratic in the catalog. One memoized Map keyed `provider:model`
+ *      makes each lookup O(1).
+ *
+ *   3. MEMOIZING THE SEARCH. Filtering lowercased every model name on every
+ *      keystroke. Names are lowercased once when the catalog loads, and the
+ *      filtered result is memoized on the query.
+ *
+ * The fixed row height is the load-bearing assumption for (1): it is what lets
+ * us compute the visible slice arithmetically instead of measuring. ROW_H and
+ * HEADER_H must therefore match the classes below.
  */
 const MENU_W = 320
+/** Row height in px — `py-1.5` (12) + `text-xs`/`leading-4` (16). Must match the button's classes. */
+const ROW_H = 28
+/** Section header height in px — `pt-2 pb-1` (12) + 11px text at leading-4 (16). */
+const HEADER_H = 28
+
+/**
+ * Track a scroll container's visible band, in px.
+ *
+ * Deliberately not throttled to rAF: the handler only reads `scrollTop` and
+ * sets a number, and React already batches the resulting render. Adding a frame
+ * of latency here would make the list visibly lag the scrollbar.
+ *
+ * `reset` exists because a scroll set programmatically (jumping back to the top
+ * when the query changes) fires its `scroll` event ASYNCHRONOUSLY. Without it
+ * we would render one frame with the new, shorter row list against the old
+ * scroll offset — a flash of blank menu on the first keystroke.
+ */
+function useWindow(
+  ref: React.RefObject<HTMLElement>,
+  open: boolean
+): { band: { top: number; height: number }; reset: () => void } {
+  const [band, setBand] = useState({ top: 0, height: 0 })
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!open || !el) return
+    // Measure once on open: the anchor's maxHeight decides how tall we are, and
+    // that isn't known until the element exists.
+    setBand({ top: el.scrollTop, height: el.clientHeight })
+    const onScroll = (): void => setBand({ top: el.scrollTop, height: el.clientHeight })
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [ref, open])
+  const reset = useCallback((): void => {
+    const el = ref.current
+    if (!el) return
+    el.scrollTop = 0
+    setBand((b) => (b.top === 0 ? b : { top: 0, height: el.clientHeight || b.height }))
+  }, [ref])
+  return { band, reset }
+}
 
 export function ModelPicker(): JSX.Element {
   const providers = useRoxyStore((s) => s.providers)
   const settings = useRoxyStore((s) => s.settings)
-  const chats = useRoxyStore((s) => s.chats)
-  const activeChatId = useRoxyStore((s) => s.activeChatId)
+  // Only the ACTIVE chat's config matters here, and it is the sole reason this
+  // component ever needed `chats`. Subscribing to the whole array re-rendered
+  // the open menu on every sidebar tick and every streamed title update.
+  const activeChat = useRoxyStore((s) => s.chats.find((c) => c.id === s.activeChatId))
   const selectModel = useRoxyStore((s) => s.selectModel)
   const models = useRoxyStore((s) => s.modelCatalog)
+  const modelsTried = useRoxyStore((s) => s.modelsTried)
   const recentModels = useRoxyStore((s) => s.recentModels)
   const pinnedModels = useRoxyStore((s) => s.pinnedModels)
   const ensureModels = useRoxyStore((s) => s.ensureModels)
@@ -36,25 +114,26 @@ export function ModelPicker(): JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const rootRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
   // Leftmost control, so it only clips in a narrow window — but it clips the
   // same way, and one rule for all of them beats a special case.
   const anchor = useMenuAnchor(rootRef, open, MENU_W, { gap: 8 })
+  const { band, reset: resetScroll } = useWindow(listRef, open)
 
   // The model shown is the OPEN SESSION's, not a global one: two sessions can
   // sit on different models at once, and each remembers its own across
   // restarts. A session with nothing pinned falls back to the last-used pair.
-  const config = resolveSessionConfig(
-    chats.find((c) => c.id === activeChatId),
-    settings
+  const config = useMemo(() => resolveSessionConfig(activeChat, settings), [activeChat, settings])
+  const activeProvider = useMemo(
+    () => providers.find((p) => p.id === config.providerId) ?? providers[0] ?? null,
+    [providers, config.providerId]
   )
-  const activeProvider = providers.find((p) => p.id === config.providerId) ?? providers[0] ?? null
   // Only show the session's model when it belongs to the provider we resolved.
   // A session pinned to a provider that was since disconnected falls back to
   // another one, and labelling that fallback with the old model would claim a
   // pairing the turn will not actually use (the send path picks the fallback
   // provider's own default instead).
   const activeModel = activeProvider?.id === config.providerId ? config.model : null
-  const loading = providers.some((p) => !models[p.id])
 
   // Lazy-load every connected provider's models and recents into shared caches.
   useEffect(() => {
@@ -82,79 +161,148 @@ export function ModelPicker(): JSX.Element {
     }
   }, [open])
 
+  // Reset the scroll position when the query changes, or a filtered list would
+  // open scrolled into the middle of nothing.
+  useLayoutEffect(() => {
+    resetScroll()
+  }, [query, resetScroll])
+
+  // ---- derived data, all memoized ------------------------------------------
+
+  /**
+   * `providerId:modelId` -> model + pre-lowercased search text. Rebuilt only
+   * when a catalog actually loads, not on every render.
+   */
+  const index = useMemo(() => buildModelIndex(models), [models])
+
+  const q = query.trim().toLowerCase()
+
+  /**
+   * The whole menu as a flat list of rows. The only place that walks the
+   * catalogs, and it re-runs only when the catalogs, pins, recents or the query
+   * change - not when the popover re-renders for a scroll.
+   */
+  const rows = useMemo(
+    () =>
+      buildModelRows({
+        providers,
+        catalogs: models,
+        recent: recentModels,
+        pinned: pinnedModels,
+        index,
+        query
+      }),
+    [providers, models, recentModels, pinnedModels, index, query]
+  )
+
+  /**
+   * Row offsets, so a header and a row can differ in height while the window
+   * math stays a pair of binary searches. Cheap: one pass over the row list.
+   */
+  const offsets = useMemo(
+    () => rowOffsets(rows.map((r) => (r.kind === 'header' ? HEADER_H : ROW_H))),
+    [rows]
+  )
+
+  const totalH = offsets.length ? offsets[offsets.length - 1] : 0
+  // Which rows the 360px viewport can actually see, plus overscan. `height` is
+  // 0 on the very first paint (the element hasn't been measured yet), so fall
+  // back to the anchor's ceiling rather than rendering nothing.
+  const { first, last } = useMemo(
+    () =>
+      visibleRange(offsets, rows.length, band.top, band.height || Number(anchor.maxHeight) || 360),
+    [offsets, rows.length, band.top, band.height, anchor.maxHeight]
+  )
+
+  // A provider is "loading" only until its own fetch settles. All-or-nothing
+  // used to blank the entire menu — including already-loaded pinned entries —
+  // behind whichever provider answered last.
+  const loading = providers.length > 0 && providers.some((p) => !models[p.id] && !modelsTried[p.id])
+
+  const triggerLabel = useMemo(() => {
+    if (!activeModel) return 'Select a model'
+    if (!activeProvider) return activeModel
+    return index.get(`${activeProvider.id}:${activeModel}`)?.info.name ?? activeModel
+  }, [activeModel, activeProvider, index])
+
+  const pick = useCallback(
+    async (providerId: string, modelId: string): Promise<void> => {
+      // Close FIRST. `selectModel` awaits two IPC round trips (session config,
+      // then the refreshed recents), and leaving the menu up until they resolve
+      // is what made a click feel like it hadn't registered.
+      setOpen(false)
+      setQuery('')
+      await selectModel(providerId, modelId)
+    },
+    [selectModel]
+  )
+
+  const togglePin = useCallback(
+    (e: React.MouseEvent, providerId: string, modelId: string, pinned: boolean): void => {
+      e.stopPropagation()
+      void togglePinnedModel(providerId, modelId, !pinned)
+    },
+    [togglePinnedModel]
+  )
+
   if (providers.length === 0) {
     return <span className="px-1 text-xs text-text-subtle">No provider connected</span>
   }
 
-  const q = query.trim().toLowerCase()
-  const triggerLabel = ((): string => {
-    if (!activeModel) return 'Select a model'
-    const found = activeProvider && models[activeProvider.id]?.find((m) => m.id === activeModel)
-    return found ? found.name : activeModel
-  })()
-
-  const pick = async (providerId: string, modelId: string): Promise<void> => {
-    await selectModel(providerId, modelId)
-    setOpen(false)
-    setQuery('')
-  }
-
-  const modelName = (providerId: string, modelId: string): string =>
-    models[providerId]?.find((m) => m.id === modelId)?.name ?? modelId
-
-  const isPinned = (providerId: string, modelId: string): boolean =>
-    pinnedModels.some((p) => p.providerId === providerId && p.model === modelId)
-
-  const togglePin = (e: React.MouseEvent, providerId: string, modelId: string): void => {
-    e.stopPropagation()
-    void togglePinnedModel(providerId, modelId, !isPinned(providerId, modelId))
-  }
-
-  const renderModelButton = (
-    providerId: string,
-    providerName: string,
-    modelId: string,
-    label = modelName(providerId, modelId)
-  ): JSX.Element => {
-    const info = models[providerId]?.find((m) => m.id === modelId)
-    const selected = providerId === activeProvider?.id && modelId === activeModel
-    const pinned = isPinned(providerId, modelId)
-    return (
+  const visible: JSX.Element[] = []
+  for (let i = first; i < last; i++) {
+    const row = rows[i]
+    if (row.kind === 'header') {
+      visible.push(
+        <div
+          key={row.key}
+          style={{ height: HEADER_H }}
+          className="flex items-center gap-1.5 px-3 text-[11px] font-medium uppercase tracking-wide text-text-subtle"
+        >
+          {row.icon === 'pin' && <Pin className="h-3 w-3 shrink-0 fill-current" />}
+          {row.icon === 'clock' && <Clock className="h-3 w-3 shrink-0" />}
+          {row.icon === 'provider' && (
+            <ProviderLogo id={row.providerId} name={row.label} size={13} />
+          )}
+          {row.label}
+        </div>
+      )
+      continue
+    }
+    const selected = row.providerId === activeProvider?.id && row.modelId === activeModel
+    visible.push(
       <button
-        key={`${providerId}:${modelId}`}
+        key={row.key}
         type="button"
-        onClick={() => pick(providerId, modelId)}
+        onClick={() => pick(row.providerId, row.modelId)}
+        style={{ height: ROW_H }}
         className={cn(
-          'group flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition',
+          'group flex w-full items-center gap-2 px-3 text-left text-xs transition',
           selected ? 'bg-accent/15 text-text' : 'text-text-muted hover:bg-white/5 hover:text-text'
         )}
       >
         <Check className={cn('h-3.5 w-3.5 shrink-0', selected ? 'text-accent' : 'opacity-0')} />
-        <ProviderLogo id={providerId} name={providerName} size={14} />
-        <span className="min-w-0 flex-1 truncate">{label}</span>
-        {info?.reasoning && <Brain className="h-3 w-3 shrink-0 text-accent" />}
-        {info?.toolCall && <Wrench className="h-3 w-3 shrink-0 text-success" />}
+        <ProviderLogo id={row.providerId} name={row.providerName} size={14} />
+        <span className="min-w-0 flex-1 truncate">{row.label}</span>
+        {row.info?.reasoning && <Brain className="h-3 w-3 shrink-0 text-accent" />}
+        {row.info?.toolCall && <Wrench className="h-3 w-3 shrink-0 text-success" />}
+        {/* A <span> rather than a nested <button>: a button inside a button is
+            invalid HTML, and the browser is free to drop the inner one. */}
         <span
           role="button"
-          title={pinned ? 'Unpin model' : 'Pin model'}
-          onClick={(e) => togglePin(e, providerId, modelId)}
+          tabIndex={-1}
+          title={row.pinned ? 'Unpin model' : 'Pin model'}
+          onClick={(e) => togglePin(e, row.providerId, row.modelId, row.pinned)}
           className={cn(
             'shrink-0 rounded p-0.5 transition hover:bg-white/10',
-            pinned ? 'text-accent' : 'text-text-subtle opacity-0 group-hover:opacity-100'
+            row.pinned ? 'text-accent' : 'text-text-subtle opacity-0 group-hover:opacity-100'
           )}
         >
-          <Pin className={cn('h-3 w-3', pinned && 'fill-current')} />
+          <Pin className={cn('h-3 w-3', row.pinned && 'fill-current')} />
         </span>
       </button>
     )
   }
-
-  // Pinned models render as one flat list (not grouped per provider) so a
-  // shortlist spanning several providers stays a single glanceable block
-  // instead of being scattered across per-provider sections.
-  const pinnedList = q
-    ? []
-    : pinnedModels.filter((p) => models[p.providerId]?.some((m) => m.id === p.model))
 
   return (
     <div ref={rootRef} className="relative">
@@ -181,53 +329,29 @@ export function ModelPicker(): JSX.Element {
               className="w-full bg-transparent text-xs text-text outline-none placeholder:text-text-subtle"
             />
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto py-1">
-            {loading && <div className="px-3 py-3 text-xs text-text-subtle">Loading models…</div>}
-            {!loading && pinnedList.length > 0 && (
-              <div>
-                <div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-text-subtle">
-                  <Pin className="h-3 w-3 fill-current" /> Pinned
-                </div>
-                {pinnedList.map((p) => {
-                  const provider = providers.find((pr) => pr.id === p.providerId)
-                  if (!provider) return null
-                  return renderModelButton(p.providerId, provider.name, p.model)
-                })}
-              </div>
+          {/* No vertical padding on the scroller: `scrollTop` is measured from
+              the padding box, so any padding here would offset every row
+              against the windowing math that positions them. */}
+          <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto">
+            {rows.length > 0 && (
+              // Spacers stand in for the rows we didn't mount, so the scrollbar
+              // reflects the full list and the visible slice lands at the right
+              // offset.
+              <>
+                <div style={{ height: offsets[first] }} />
+                {visible}
+                <div style={{ height: totalH - offsets[last] }} />
+              </>
             )}
-            {!loading &&
-              providers.map((p) => {
-                const list = (models[p.id] ?? []).filter(
-                  (m) => !q || m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q)
-                )
-                const latest = q
-                  ? []
-                  : (recentModels[p.id] ?? []).filter((r) => !isPinned(p.id, r.model))
-                if (list.length === 0 && latest.length === 0) return null
-                return (
-                  <div key={p.id}>
-                    {latest.length > 0 && (
-                      <>
-                        <div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-text-subtle">
-                          <Clock className="h-3 w-3" /> Latest · {p.name}
-                        </div>
-                        {latest.map((r) => renderModelButton(p.id, p.name, r.model))}
-                      </>
-                    )}
-                    {list.length > 0 && (
-                      <>
-                        <div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-[11px] font-medium text-text-subtle">
-                          <ProviderLogo id={p.id} name={p.name} size={13} /> {p.name}
-                        </div>
-                        {list.map((m) => renderModelButton(p.id, p.name, m.id, m.name))}
-                      </>
-                    )}
-                  </div>
-                )
-              })}
-            {!loading && Object.values(models).every((l) => l.length === 0) && (
+            {rows.length === 0 && loading && (
+              <div className="px-3 py-3 text-xs text-text-subtle">Loading models…</div>
+            )}
+            {rows.length === 0 && !loading && q && (
+              <div className="px-3 py-3 text-xs text-text-subtle">No models match “{query}”.</div>
+            )}
+            {rows.length === 0 && !loading && !q && (
               <div className="px-3 py-3 text-xs text-text-subtle">
-                Couldn't load models from models.dev — you can still send with the current
+                Couldn&apos;t load models from models.dev — you can still send with the current
                 model.
               </div>
             )}

--- a/src/renderer/src/lib/modelRows.ts
+++ b/src/renderer/src/lib/modelRows.ts
@@ -1,0 +1,165 @@
+/**
+ * The model picker's list, as data.
+ *
+ * Extracted from the component for one reason: the flattened list has a
+ * correctness property that is invisible in JSX and was got WRONG in review —
+ * every row needs a React key unique across the whole list, and the same model
+ * legitimately appears in up to three sections at once (Pinned, its provider's
+ * Latest, and that provider's full catalog). Keying rows by `provider:model`
+ * therefore produced duplicate sibling keys, and React reused the wrong DOM
+ * node while the windowed list scrolled: rows visibly duplicated and stuck.
+ *
+ * Pure data with no DOM and no React means that property can be asserted
+ * directly in test/shared.ts instead of being eyeballed in a running app.
+ */
+import type { ModelInfo } from '../../../shared/api'
+
+/** The subset of a connected provider this list needs. */
+export interface RowProvider {
+  id: string
+  name: string
+}
+
+/** A section header. `providerId` is '' for the cross-provider Pinned header. */
+export interface HeaderRow {
+  kind: 'header'
+  key: string
+  label: string
+  icon: 'pin' | 'clock' | 'provider'
+  providerId: string
+}
+
+/** A selectable model. */
+export interface ModelRow {
+  kind: 'model'
+  key: string
+  providerId: string
+  providerName: string
+  modelId: string
+  label: string
+  info: ModelInfo | undefined
+  pinned: boolean
+}
+
+export type Row = HeaderRow | ModelRow
+
+/** A model catalog entry plus its pre-lowercased search text. */
+export interface IndexEntry {
+  info: ModelInfo
+  haystack: string
+}
+
+/**
+ * Build the `provider:model` lookup used for both search and per-row detail.
+ *
+ * Names are lowercased ONCE here rather than on every keystroke, and the
+ * per-row `find()` scans this replaces were quadratic in the catalog size.
+ */
+export function buildModelIndex(catalogs: Record<string, ModelInfo[]>): Map<string, IndexEntry> {
+  const map = new Map<string, IndexEntry>()
+  for (const [providerId, list] of Object.entries(catalogs)) {
+    for (const info of list) {
+      map.set(`${providerId}:${info.id}`, {
+        info,
+        haystack: `${info.name.toLowerCase()}\u0000${info.id.toLowerCase()}`
+      })
+    }
+  }
+  return map
+}
+
+/**
+ * Flatten the whole menu — Pinned, then per provider: Latest, then everything —
+ * into one array the windowing math can index into.
+ *
+ * A search query collapses it to a flat filtered catalog: Pinned and Latest are
+ * shortcuts for "no query", and repeating their entries above the matches would
+ * just show the same model three times in a five-row result.
+ */
+export function buildModelRows(input: {
+  providers: RowProvider[]
+  catalogs: Record<string, ModelInfo[]>
+  recent: Record<string, { model: string }[]>
+  pinned: { providerId: string; model: string }[]
+  index: Map<string, IndexEntry>
+  query: string
+}): Row[] {
+  const { providers, catalogs, recent, pinned, index, query } = input
+  const q = query.trim().toLowerCase()
+  const pinnedKeys = new Set(pinned.map((p) => `${p.providerId}:${p.model}`))
+  const out: Row[] = []
+
+  const modelRow = (
+    section: string,
+    providerId: string,
+    providerName: string,
+    modelId: string,
+    label?: string
+  ): ModelRow => {
+    const hit = index.get(`${providerId}:${modelId}`)
+    return {
+      kind: 'model',
+      // Section-prefixed: see the note at the top of this file.
+      key: `${section}:${providerId}:${modelId}`,
+      providerId,
+      providerName,
+      modelId,
+      label: label ?? hit?.info.name ?? modelId,
+      info: hit?.info,
+      pinned: pinnedKeys.has(`${providerId}:${modelId}`)
+    }
+  }
+
+  // Pinned renders as ONE flat list rather than grouped per provider, so a
+  // shortlist spanning several providers stays a single glanceable block.
+  if (!q) {
+    const rows = pinned.flatMap((p) => {
+      const provider = providers.find((pr) => pr.id === p.providerId)
+      // Skip a pin whose provider was disconnected, or whose model is no longer
+      // in the catalog - it would render as a row that cannot be selected.
+      if (!provider || !index.has(`${p.providerId}:${p.model}`)) return []
+      return [modelRow('pin', p.providerId, provider.name, p.model)]
+    })
+    if (rows.length > 0) {
+      out.push({ kind: 'header', key: 'h:pinned', label: 'Pinned', icon: 'pin', providerId: '' })
+      out.push(...rows)
+    }
+  }
+
+  for (const p of providers) {
+    const catalog = catalogs[p.id] ?? []
+    const list = q
+      ? catalog.filter((m) => index.get(`${p.id}:${m.id}`)?.haystack.includes(q))
+      : catalog
+    // A pinned model is already shown above; repeating it under Latest wastes a
+    // row on a duplicate.
+    const latest = q
+      ? []
+      : (recent[p.id] ?? []).filter(
+          (r) => !pinnedKeys.has(`${p.id}:${r.model}`) && index.has(`${p.id}:${r.model}`)
+        )
+    if (list.length === 0 && latest.length === 0) continue
+
+    if (latest.length > 0) {
+      out.push({
+        kind: 'header',
+        key: `h:latest:${p.id}`,
+        label: `Latest · ${p.name}`,
+        icon: 'clock',
+        providerId: p.id
+      })
+      for (const r of latest) out.push(modelRow('recent', p.id, p.name, r.model))
+    }
+    if (list.length > 0) {
+      out.push({
+        kind: 'header',
+        key: `h:${p.id}`,
+        label: p.name,
+        icon: 'provider',
+        providerId: p.id
+      })
+      for (const m of list) out.push(modelRow('all', p.id, p.name, m.id, m.name))
+    }
+  }
+  return out
+}

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -54,6 +54,15 @@ interface RoxyStore {
   providers: ConnectedProvider[]
   /** models.dev model lists per provider id (lazy-loaded + cached). */
   modelCatalog: Record<string, ModelInfo[]>
+  /**
+   * Providers whose catalog has been REQUESTED and settled, however it settled.
+   *
+   * Distinct from `modelCatalog` having a key, because an empty result is not
+   * cached (a starting-up proxy has to be retried). Without this the picker
+   * cannot tell "still fetching" from "genuinely has no models", and blanked
+   * the whole menu behind whichever provider was slowest.
+   */
+  modelsTried: Record<string, boolean>
   /** Last 5 distinct model picks per provider, lazy-loaded + refreshed on selection. */
   recentModels: Record<string, { model: string; usedAt: number }[]>
   /**
@@ -310,6 +319,16 @@ const deltaHandlers = new Map<string, (event: LlmEvent) => void>()
 const chatRequests = new Map<string, string>()
 /** Cross-render cache of models.dev lists so we fetch each provider once. */
 const modelCatalogCache = new Map<string, ModelInfo[]>()
+/**
+ * In-flight `ensureModels` calls, keyed by provider.
+ *
+ * The picker asks for every connected provider in one tick, and the composer's
+ * other controls ask for the active one on the same tick. Without this each
+ * caller awaits its own IPC round trip - and for a subscription provider
+ * `models:list` can BOOT THE SIDECAR, so the duplicates aren't merely wasteful,
+ * they queue behind a process launch. One promise per provider, shared.
+ */
+const modelCatalogInflight = new Map<string, Promise<void>>()
 /** Loaded once per app session — `ensurePinnedModels` is called from every ModelPicker mount. */
 let pinnedModelsLoaded = false
 /** Set when a remote turn lands while a local send streams into the shared chat. */
@@ -723,6 +742,7 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
   telemetryEnabled: true,
   providers: [],
   modelCatalog: {},
+  modelsTried: {},
   recentModels: {},
   pinnedModels: [],
   chats: [],
@@ -1166,13 +1186,35 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
     const existing = get().modelCatalog[providerId]
     if (existing && existing.length > 0) return
     const cached = modelCatalogCache.get(providerId)
-    const list = cached && cached.length > 0 ? cached : await api.models.list(providerId)
-    // Only cache non-empty lists. If the proxy or connection is starting up,
-    // we want to try again on the next mount/action rather than caching an empty list forever.
-    if (list.length > 0) {
-      modelCatalogCache.set(providerId, list)
-      set((s) => ({ modelCatalog: { ...s.modelCatalog, [providerId]: list } }))
+    if (cached && cached.length > 0) {
+      set((s) => ({ modelCatalog: { ...s.modelCatalog, [providerId]: cached } }))
+      return
     }
+    // Share one round trip between every caller that asks in the same tick.
+    const pending = modelCatalogInflight.get(providerId)
+    if (pending) return pending
+    const load = (async () => {
+      try {
+        const list = await api.models.list(providerId)
+        // Only cache non-empty lists. If the proxy or connection is starting up,
+        // we want to try again on the next mount/action rather than caching an
+        // empty list forever.
+        if (list.length > 0) {
+          modelCatalogCache.set(providerId, list)
+          set((s) => ({ modelCatalog: { ...s.modelCatalog, [providerId]: list } }))
+        }
+      } catch {
+        // Leave the catalog untouched - the picker shows the provider as empty
+        // and the next mount retries.
+      } finally {
+        // Mark the attempt either way, so the picker can stop showing a
+        // provider as "loading" once it has actually been asked.
+        modelCatalogInflight.delete(providerId)
+        set((s) => ({ modelsTried: { ...s.modelsTried, [providerId]: true } }))
+      }
+    })()
+    modelCatalogInflight.set(providerId, load)
+    return load
   },
 
   ensureRecentModels: async (providerId) => {

--- a/src/renderer/src/lib/windowing.ts
+++ b/src/renderer/src/lib/windowing.ts
@@ -1,0 +1,75 @@
+/**
+ * List windowing — which slice of a long list a scroll viewport can see.
+ *
+ * Pure math, no DOM, so the invariant that actually matters ("every row the
+ * user can see is a row we mounted") can be exercised directly instead of
+ * eyeballed in a running app; see test/shared.ts.
+ *
+ * This exists for the model picker. Gateway providers report 300-600 models
+ * each and the picker lists every connected provider at once, so it mounted
+ * ~450 rows — roughly 5,000 DOM nodes and ~250ms of blocking work — in the same
+ * frame that its open animation started. Windowing makes the cost a function of
+ * the VIEWPORT (~20 rows) rather than the catalog.
+ *
+ * The design constraint is that row heights must be known WITHOUT measuring:
+ * measuring means mounting, and mounting everything is the thing we're avoiding.
+ * So callers pass a height per row and we prefix-sum it once.
+ */
+
+/**
+ * Rows to render beyond each edge of the viewport.
+ *
+ * Enough that a flick-scroll doesn't expose blank space before the next render
+ * lands; small enough to stay a rounding error on the mount cost.
+ */
+export const OVERSCAN = 6
+
+/**
+ * Cumulative row offsets: `offsets[i]` is the top of row `i`, and the last
+ * entry is the total height. One entry longer than `heights`.
+ */
+export function rowOffsets(heights: ArrayLike<number>): Float64Array {
+  const acc = new Float64Array(heights.length + 1)
+  for (let i = 0; i < heights.length; i++) acc[i + 1] = acc[i] + heights[i]
+  return acc
+}
+
+/** Index of the row containing `y` (the first row whose bottom is past it). */
+function rowAt(offsets: Float64Array, count: number, y: number): number {
+  let lo = 0
+  let hi = count
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (offsets[mid + 1] <= y) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
+/**
+ * The half-open range `[first, last)` of rows to mount for a viewport showing
+ * `[scrollTop, scrollTop + viewportHeight)`, widened by `overscan` each way.
+ *
+ * Guaranteed: every row intersecting the viewport is inside the range, and the
+ * range is bounded by the viewport size rather than the list length. Render it
+ * between two spacer elements of `offsets[first]` and `total - offsets[last]`
+ * so the scrollbar still describes the whole list.
+ */
+export function visibleRange(
+  offsets: Float64Array,
+  count: number,
+  scrollTop: number,
+  viewportHeight: number,
+  overscan: number = OVERSCAN
+): { first: number; last: number } {
+  if (count <= 0) return { first: 0, last: 0 }
+  // A negative scrollTop is real: macOS rubber-banding reports it, and it must
+  // clamp to the top rather than index out of the array.
+  const top = Math.max(0, scrollTop)
+  const first = Math.max(0, rowAt(offsets, count, top) - overscan)
+  const last = Math.min(
+    count,
+    rowAt(offsets, count, top + Math.max(0, viewportHeight)) + 1 + overscan
+  )
+  return { first, last }
+}

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -224,6 +224,8 @@ import {
   MAX_MENU_H,
   type Rect
 } from '../src/renderer/src/lib/anchor'
+import { rowOffsets, visibleRange, OVERSCAN } from '../src/renderer/src/lib/windowing'
+import { buildModelIndex, buildModelRows } from '../src/renderer/src/lib/modelRows'
 import {
   contextMenuItems as clipboardMenuItems,
   hasUsableItems,
@@ -4264,6 +4266,212 @@ async function main(): Promise<void> {
     }
   }
   check('menu: height cap is bounded on every viewport', overTall === 0, String(overTall))
+
+  // ---- list windowing (renderer/lib/windowing) -------------------------------
+  //
+  // The regression this exists for: the model picker mounted EVERY model of
+  // every connected provider at once. A gateway provider reports 300-600 models
+  // and the menu lists them all, so opening it built ~450 rows / ~5,000 DOM
+  // nodes in one commit - measured at ~200ms of React commit plus ~60ms of
+  // layout, in the same frame its open animation started. That is what "the
+  // model picker feels laggy" was.
+  //
+  // The safety property is the one worth pinning: whatever slice we mount, it
+  // must contain every row the viewport can actually see. Miss one and the user
+  // scrolls into a hole.
+  const ROW_H = 28
+  const HEADER_H = 28
+  let holes = 0
+  let unbounded = 0
+  let badSpacers = 0
+  let ranges = 0
+  for (const count of [0, 1, 5, 14, 30, 200, 463, 3000]) {
+    // Mixed heights: a header every so often, so the prefix-sum path is
+    // exercised rather than a single uniform stride.
+    const heights = Array.from({ length: count }, (_, i) => (i % 37 === 0 ? HEADER_H : ROW_H))
+    const offsets = rowOffsets(heights)
+    const total = count ? offsets[count] : 0
+    for (const viewH of [120, 360, 700]) {
+      const maxTop = Math.max(0, total - viewH)
+      for (let top = 0; top <= maxTop; top += 7) {
+        const { first, last } = visibleRange(offsets, count, top, viewH)
+        ranges++
+        if (first < 0 || last > count || first > last) unbounded++
+        // Every row intersecting the band must be inside [first, last).
+        for (let i = 0; i < count; i++) {
+          if (offsets[i + 1] > top && offsets[i] < top + viewH && !(i >= first && i < last)) {
+            holes++
+            break
+          }
+        }
+        // Spacers + mounted rows must reconstruct the full scroll height, or
+        // the scrollbar lies about how much list there is.
+        const rebuilt = offsets[first] + (offsets[last] - offsets[first]) + (total - offsets[last])
+        if (Math.abs(rebuilt - total) > 1e-9) badSpacers++
+        // The whole point: mount count follows the VIEWPORT, not the catalog.
+        if (last - first > Math.ceil(viewH / ROW_H) + 2 * OVERSCAN + 2) unbounded++
+      }
+    }
+  }
+  check(`windowing: ${ranges} ranges produced (grid is non-trivial)`, ranges > 400)
+  check('windowing: never skips a row the viewport can see', holes === 0, `${holes} holes`)
+  check('windowing: mount count is bounded by the viewport', unbounded === 0, `${unbounded}`)
+  check('windowing: spacers preserve the total scroll height', badSpacers === 0, `${badSpacers}`)
+
+  // An empty list must not produce a range to render (or the spacers would be
+  // NaN-height divs).
+  const emptyRange = visibleRange(rowOffsets([]), 0, 0, 360)
+  check('windowing: an empty list mounts nothing', emptyRange.first === 0 && emptyRange.last === 0)
+
+  // Rubber-band scrolling reports a NEGATIVE scrollTop on macOS; it must clamp
+  // to the top rather than index out of the offsets array.
+  const rubber = visibleRange(rowOffsets(new Array(50).fill(ROW_H)), 50, -120, 360)
+  check(
+    'windowing: a negative scrollTop clamps to the top',
+    rubber.first === 0 && rubber.last > 0 && rubber.last <= 50,
+    JSON.stringify(rubber)
+  )
+
+  // The real shape from a 4-provider setup (30 + 399 + 6 + 6 models, plus the
+  // Latest/provider headers): 463 rows, and opening must mount ~20 of them.
+  const realHeights: number[] = []
+  for (const n of [5, 30, 5, 399, 2, 6, 2, 6]) {
+    realHeights.push(HEADER_H)
+    for (let i = 0; i < n; i++) realHeights.push(ROW_H)
+  }
+  const realOffsets = rowOffsets(realHeights)
+  const opened = visibleRange(realOffsets, realHeights.length, 0, 360)
+  check(
+    `windowing: a 463-row picker mounts ${opened.last - opened.first} rows on open`,
+    realHeights.length > 400 && opened.last - opened.first < 30,
+    `${opened.last - opened.first} of ${realHeights.length}`
+  )
+  // Scrolled to the very bottom it must still terminate exactly on the last row.
+  const bottom = visibleRange(
+    realOffsets,
+    realHeights.length,
+    realOffsets[realHeights.length] - 360,
+    360
+  )
+  check('windowing: the last row is reachable', bottom.last === realHeights.length)
+
+  // ---- model picker rows (renderer/lib/modelRows) ----------------------------
+  //
+  // The regression this exists for: rows were keyed by `provider:model`, which
+  // LOOKS unique and is not. The same model shows up in up to three sections at
+  // once - Pinned, its provider's Latest, and that provider's full catalog - so
+  // sibling rows collided on their React key. Combined with windowing (which
+  // remounts a different slice on every scroll) React reused the wrong DOM node
+  // and rows visibly duplicated and stuck to the viewport while scrolling.
+  //
+  // Keys are cheap to get wrong and invisible in review, so assert them.
+  const mkModel = (id: string, name: string) => ({ id, name, reasoning: true, toolCall: true })
+  const pickerProviders = [
+    { id: 'github-copilot', name: 'GitHub Copilot' },
+    { id: 'roxy', name: 'Roxy.gg Inference' }
+  ]
+  const pickerCatalogs = {
+    'github-copilot': [
+      mkModel('claude-opus-5', 'Claude Opus 5'),
+      mkModel('gpt-5.6-sol', 'GPT-5.6 Sol'),
+      mkModel('gemini-3.6-flash', 'Gemini 3.6 Flash')
+    ],
+    roxy: [mkModel('anthropic/claude-opus-5', 'Claude Opus 5'), mkModel('x/other', 'Other Model')]
+  }
+  // Exactly the shape of the real bug report: the recents are also in the
+  // catalog, and one of them is pinned too.
+  const pickerRecent = {
+    'github-copilot': [{ model: 'claude-opus-5' }, { model: 'gpt-5.6-sol' }],
+    roxy: [{ model: 'anthropic/claude-opus-5' }]
+  }
+  const pickerPinned = [{ providerId: 'github-copilot', model: 'claude-opus-5' }]
+  const pickerIndex = buildModelIndex(pickerCatalogs)
+
+  const rowsFor = (query: string) =>
+    buildModelRows({
+      providers: pickerProviders,
+      catalogs: pickerCatalogs,
+      recent: pickerRecent,
+      pinned: pickerPinned,
+      index: pickerIndex,
+      query
+    })
+
+  let dupeKeys = ''
+  for (const query of ['', 'claude', 'opus 5', 'gpt', 'zzz', '  ']) {
+    const keys = rowsFor(query).map((r) => r.key)
+    const seen = new Set<string>()
+    for (const k of keys) {
+      if (seen.has(k)) {
+        dupeKeys = `"${query}" -> ${k}`
+        break
+      }
+      seen.add(k)
+    }
+    if (dupeKeys) break
+  }
+  check('picker rows: every React key is unique', dupeKeys === '', dupeKeys)
+
+  // The duplicate-key case must still RENDER the model in each section - the
+  // fix is a unique key, not dropping the row.
+  const baseRows = rowsFor('')
+  const opusRows = baseRows.filter((r) => r.kind === 'model' && r.modelId === 'claude-opus-5')
+  check(
+    'picker rows: a pinned+recent+catalog model still appears in each section',
+    opusRows.length === 2, // pinned + catalog; suppressed under Latest because pinned
+    String(opusRows.length)
+  )
+
+  // A pinned model must not ALSO be repeated under Latest - it is already shown
+  // at the top, and a 5-row shortcut section should not waste a row on it.
+  const latestIdx = baseRows.findIndex(
+    (r) => r.kind === 'header' && r.key === 'h:latest:github-copilot'
+  )
+  const copilotIdx = baseRows.findIndex((r) => r.kind === 'header' && r.key === 'h:github-copilot')
+  const latestSection = baseRows.slice(latestIdx + 1, copilotIdx)
+  check(
+    'picker rows: a pinned model is not repeated under Latest',
+    latestSection.every((r) => r.kind === 'model' && r.modelId !== 'claude-opus-5')
+  )
+
+  // Searching collapses the shortcuts: repeating Pinned/Latest above the
+  // matches would show the same model three times in a short result list.
+  const searched = rowsFor('opus')
+  check(
+    'picker rows: a query drops the Pinned and Latest sections',
+    !searched.some(
+      (r) => r.kind === 'header' && (r.key === 'h:pinned' || r.key.startsWith('h:latest:'))
+    )
+  )
+  check(
+    'picker rows: a query still matches on name across providers',
+    searched.filter((r) => r.kind === 'model').length === 2
+  )
+  check('picker rows: a non-matching query yields nothing', rowsFor('zzzz').length === 0)
+
+  // A pin whose provider was disconnected (or whose model left the catalog)
+  // would otherwise render an unselectable row.
+  const staleRows = buildModelRows({
+    providers: pickerProviders,
+    catalogs: pickerCatalogs,
+    recent: {},
+    pinned: [{ providerId: 'deleted-provider', model: 'ghost' }],
+    index: pickerIndex,
+    query: ''
+  })
+  check(
+    'picker rows: a pin for a disconnected provider is dropped',
+    !staleRows.some((r) => r.kind === 'header' && r.key === 'h:pinned')
+  )
+
+  // Every model row must carry its capability flags, or the Brain/Wrench icons
+  // silently stop rendering.
+  check(
+    'picker rows: model rows keep their catalog info',
+    baseRows
+      .filter((r) => r.kind === 'model')
+      .every((r) => r.kind === 'model' && r.info !== undefined)
+  )
 
   // ---- context menus open AT THE CURSOR (sidebar right-click) --------------
   //


### PR DESCRIPTION
Opening the model picker blocked the main thread for ~260ms, which read as a lag of a second or two because it lands in the same frame the popover's own 150ms open animation starts - so the animation drops most of its frames too.

Measured with the real component against real catalog sizes (github-copilot 30 models, roxy 399, plus two subscription providers):

  before   open 196ms commit / 262ms to painted, 463 rows, ~5,300 DOM nodes
           keystroke 100ms
  after    open  12ms commit /  15ms to painted, 17 rows, 258 DOM nodes
           keystroke 8ms

Three causes, in order of weight:

1. No virtualization. The menu is capped at 360px (~14 visible rows) but mounted every row of every connected provider.
2. Quadratic lookups. Each row ran `models[provider].find(...)` two or three times to resolve its own label and capabilities.
3. Nothing memoized. Every keystroke re-lowercased every model name and re-rendered the whole list.

The windowing math moves to lib/windowing.ts and the list building to lib/modelRows.ts - both pure, so their invariants are asserted directly in test/shared.ts rather than eyeballed in a running app.

Row keys are prefixed with the section that produced them. The same model appears in up to three sections at once (Pinned, its provider's Latest, and that provider's catalog), so keying by provider:model gave sibling rows duplicate keys. That was harmless while every row mounted once and never moved, but a windowed list remounts a different slice on each scroll, and React then reused the wrong DOM nodes - rows duplicated and stuck to the viewport mid-scroll. Verified in a browser across 242 scroll stops: with the old key, 333 stops had duplicate keys and up to 180 orphaned nodes.

Also fixed while in here:

- Selecting a model awaited two IPC round trips before closing the menu, so the click looked dropped. Close first, persist after.
- `loading` was all-or-nothing, blanking the whole menu (including already loaded pinned entries) behind whichever provider answered last. Adds `modelsTried` to tell "still fetching" from "genuinely has no models".
- `ensureModels` now shares one in-flight promise per provider. The picker fired 1+2N IPC calls on mount racing InferenceControls, and for a subscription provider models:list can spawn the sidecar.
- The pin toggle was a role="button" nested inside a real <button>, which is invalid HTML the browser may discard.
- The picker subscribed to the whole chats array to read one session's config, re-rendering the open menu on every sidebar tick and streamed title update.

A pinned model is no longer repeated under Latest; it is already shown above.