### PR TITLE
copilot: restore GitHub token exchange

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.85",
+      "version": "0.0.86",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",

--- a/src/main/services/llm.ts
+++ b/src/main/services/llm.ts
@@ -17,6 +17,12 @@ import { ensureRunning as ensureCliProxy, localApiKey as cliProxyKey } from './c
 
 const COPILOT_TOKEN_URL = 'https://api.github.com/copilot_internal/v2/token'
 const COPILOT_CHAT_URL = 'https://api.githubcopilot.com/chat/completions'
+export const COPILOT_EDITOR_HEADERS = {
+  'User-Agent': 'GitHubCopilotChat/0.26.7',
+  'Editor-Version': 'vscode/1.99.3',
+  'Editor-Plugin-Version': 'copilot-chat/0.26.7',
+  'Copilot-Integration-Id': 'vscode-chat'
+} as const
 
 /**
  * A failed model HTTP request that carries the status code, so the agent loop can
@@ -107,16 +113,22 @@ async function getCopilotToken(force = false): Promise<string> {
   const res = await fetch(COPILOT_TOKEN_URL, {
     headers: {
       Authorization: `token ${github}`,
-      'User-Agent': 'Roxy',
-      Accept: 'application/json'
+      Accept: 'application/json',
+      ...COPILOT_EDITOR_HEADERS
     }
   })
   if (!res.ok) {
     const body = await res.text().catch(() => '')
-    if (res.status === 401 || res.status === 403) {
+    if (res.status === 401) {
       throw new ModelHttpError(
         res.status,
-        `Copilot token exchange failed (${res.status}). Your GitHub account may not have an active Copilot subscription.`
+        'GitHub authorization expired. Reconnect GitHub Copilot in Settings and try again.'
+      )
+    }
+    if (res.status === 403) {
+      throw new ModelHttpError(
+        res.status,
+        'GitHub denied Copilot access. Verify that this account has an active Copilot subscription, then reconnect it in Settings.'
       )
     }
     throw new ModelHttpError(
@@ -160,11 +172,8 @@ function copilotHeaders(token: string, vision = false): Record<string, string> {
   return {
     Authorization: `Bearer ${token}`,
     'Content-Type': 'application/json',
-    'Copilot-Integration-Id': 'vscode-chat',
-    'Editor-Version': 'Roxy/0.0.1',
-    'Editor-Plugin-Version': 'Roxy/0.0.1',
+    ...COPILOT_EDITOR_HEADERS,
     'Openai-Intent': 'conversation-panel',
-    'User-Agent': 'Roxy',
     ...(vision ? { 'Copilot-Vision-Request': 'true' } : {})
   }
 }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -101,7 +101,7 @@ import {
   abortableDelay,
   MODEL_FATAL_ATTEMPTS
 } from '../src/main/harness/agent'
-import { ModelHttpError } from '../src/main/services/llm'
+import { COPILOT_EDITOR_HEADERS, ModelHttpError } from '../src/main/services/llm'
 import { getUsageStats } from '../src/main/services/usage'
 import { consumeAiSdkStream } from '../src/main/services/aisdk'
 import { APICallError } from 'ai'
@@ -3661,6 +3661,14 @@ async function main(): Promise<void> {
   // `streamTurn` rides those out. These checks lock in the classification + the
   // retry policy without touching the network (fake model call, skipped backoff).
   try {
+    check(
+      'Copilot requests include the editor identity required by token exchange',
+      COPILOT_EDITOR_HEADERS['Copilot-Integration-Id'] === 'vscode-chat' &&
+        COPILOT_EDITOR_HEADERS['Editor-Version'].startsWith('vscode/') &&
+        COPILOT_EDITOR_HEADERS['Editor-Plugin-Version'].startsWith('copilot-chat/') &&
+        COPILOT_EDITOR_HEADERS['User-Agent'].startsWith('GitHubCopilotChat/')
+    )
+
     const apiErr = (statusCode: number, responseBody = ''): APICallError =>
       new APICallError({
         message: `api ${statusCode}`,


### PR DESCRIPTION
## Summary

- restore GitHub Copilot token exchange by sending the required editor identity headers
- keep token and chat request identity headers synchronized
- clarify authorization errors and add smoke coverage
- bump Roxy to 0.0.86

## Why

GitHub now rejects the internal Copilot token exchange with HTTP 403 when editor identity headers are omitted, even for valid Copilot OAuth credentials.

## Validation

- `npm run build`
- Prettier check for all changed files
- `npm run smoke:app` passed 349 checks before the suite's existing 60-second watchdog timed out