### PR TITLE
feat(track): report which provider served a prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.86",
+      "version": "0.0.87",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",

--- a/src/main/services/session-turn.ts
+++ b/src/main/services/session-turn.ts
@@ -63,8 +63,15 @@ export async function runSessionTurn(
   // Usage tracking wraps the whole turn HERE, not at either caller: this is the
   // one function both the local (renderer) and remote (phone) paths go through,
   // so counting here is the only way the two can't drift. It records that a turn
-  // happened and how it ended - never what was said, which model ran, or where.
-  track('prompt')
+  // happened, which backend served it, and how it ended - never what was said,
+  // which model ran, or where.
+  //
+  // The provider rides along so roxy.gg/stats can show which backends people
+  // actually point Roxy at - the provider only, never the model. Passed raw:
+  // `track` collapses it to the shipped seed list, which matters here because
+  // this fires BEFORE the turn resolves a provider, so an id that isn't even
+  // connected still reaches it.
+  track('prompt', { provider: input.providerId })
   const startedAt = Date.now()
   try {
     const result = await runTurn(input, emit, signal)

--- a/src/main/services/track.ts
+++ b/src/main/services/track.ts
@@ -3,9 +3,15 @@
  *
  * WHAT IT SENDS: a random UUID minted once at install, an event name, and the
  * coarse build facts (platform, arch, app version, stable/dev). No account, no
- * IP, no file paths, no prompt text, no model or provider, no repo names. The
- * server HMACs the id before storing it, so a row can't be mapped back to the
- * id this client holds.
+ * IP, no file paths, no prompt text, no model, no repo names. The server HMACs
+ * the id before storing it, so a row cannot be mapped back to the id this client
+ * holds.
+ *
+ * THE ONE EXCEPTION is `prompt`, which carries which PROVIDER served the turn.
+ * `sanitize` below maps it through the shipped seed list on the way into the
+ * queue, so it can only ever be one of the ~50 ids already public in this repo -
+ * a custom endpoint is recorded as `other`. The MODEL is still never sent: it is
+ * far higher-cardinality and isn't what the public chart shows.
  *
  * WHY IT'S SHAPED LIKE THIS:
  *  - **Never blocks the app.** Every call is fire-and-forget and every failure
@@ -23,6 +29,7 @@
  * who opted out must stay opted out across one. It also means tracking has no
  * dependency on the database being open or mid-migration.
  */
+import { isSeedProviderId } from '../../shared/providers'
 import { randomUUID } from 'node:crypto'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -37,7 +44,11 @@ function endpoint(): string {
 export type TrackEvent =
   /** App launched. The DAU heartbeat — sent exactly once per process start. */
   | 'app_open'
-  /** A turn was submitted to the agent. The "real usage" signal. */
+  /**
+   * A turn was submitted to the agent. The "real usage" signal. Carries
+   * `{ provider }` - an allow-listed provider id, or `other` for anything
+   * that isn't in the shipped seed list.
+   */
   | 'prompt'
   /** An agent turn finished. Carries `{ ok, durationMs }`. */
   | 'turn_end'
@@ -52,6 +63,29 @@ export type TrackEvent =
 
 /** Only scalars — the server rejects nested objects and arrays anyway. */
 type Props = Record<string, string | number | boolean>
+
+/**
+ * Collapse a `provider` prop to the shipped seed list, mapping anything else to
+ * `other`.
+ *
+ * Done HERE rather than at the call site so the guarantee is structural. The
+ * provider is the one identifying-ish field this module sends, and the reason
+ * it's safe to send is that it can only ever be one of ~50 ids already public in
+ * this repo. A private id like `acme-internal-gateway` would be near-unique and
+ * would tag every event this install ever sends - so it must be impossible to
+ * report by construction, not merely absent from the current caller.
+ *
+ * The raw value is REPLACED, not copied alongside, or the allow-list would be
+ * decorative.
+ */
+function sanitize(props?: Props): Props | undefined {
+  if (!props || !('provider' in props)) return props
+  const raw = props.provider
+  return {
+    ...props,
+    provider: typeof raw === 'string' && isSeedProviderId(raw) ? raw : 'other'
+  }
+}
 
 interface QueuedEvent {
   name: TrackEvent
@@ -148,7 +182,7 @@ export function isTrackingEnabled(): boolean {
 export function track(name: TrackEvent, props?: Props): void {
   if (!enabled || !deviceId) return
   if (queue.length >= MAX_QUEUE) return // shed rather than grow without bound
-  queue.push({ name, clientId: randomUUID(), ts: Date.now(), props })
+  queue.push({ name, clientId: randomUUID(), ts: Date.now(), props: sanitize(props) })
 }
 
 /**

--- a/src/renderer/src/routes/Settings.tsx
+++ b/src/renderer/src/routes/Settings.tsx
@@ -390,8 +390,10 @@ export default function Settings(): JSX.Element {
             <div className="text-sm font-medium text-text">Send anonymous usage data</div>
             <p className="mt-0.5 text-xs text-text-muted">
               Counts of things like app launches and finished turns, tied to a random id generated
-              on this machine. Never your prompts, code, file paths, repo names, model, or provider.
-              It is the only way we can tell whether a release helped or broke things.
+              on this machine. Never your prompts, code, file paths, repo names, or model. It does
+              include which provider served each turn, matched against our built-in list so a custom
+              endpoint is only ever recorded as &ldquo;other&rdquo;. It is the only way we can tell
+              whether a release helped or broke things.
             </p>
           </div>
           <Switch checked={telemetryEnabled} onChange={(v) => void setTelemetryEnabled(v)} />

--- a/src/shared/providers.ts
+++ b/src/shared/providers.ts
@@ -524,6 +524,20 @@ export function resolveSeed(providerId: string): SeedProvider {
   return SEED_BY_ID.get(providerId) ?? { ...DEFAULT_SEED, id: providerId, name: providerId }
 }
 
+/**
+ * Whether `id` is one of the ids in this file — i.e. a value from a closed set
+ * we ship, not something that arrived from outside the app.
+ *
+ * Exists for usage tracking. `resolveSeed` deliberately PRESERVES an unknown id
+ * (so a provider we have not seeded still works), which is exactly what makes
+ * `providerId` the wrong thing to report as-is: anything unrecognized would ride
+ * along as a free-form string on an otherwise anonymous event. Callers that
+ * report a provider must funnel it through here and send a constant for a miss.
+ */
+export function isSeedProviderId(id: string): boolean {
+  return SEED_BY_ID.has(id)
+}
+
 /** Human-readable label for an auth method. */
 export const AUTH_LABELS: Record<ProviderAuth, string> = {
   'api-key': 'API key',

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -18,7 +18,12 @@ import {
   SUBAGENTS,
   DEFAULT_AGENT_ID
 } from '../src/shared/agents'
-import { SEED_PROVIDERS, resolveSeed, isConnectableNow } from '../src/shared/providers'
+import {
+  SEED_PROVIDERS,
+  resolveSeed,
+  isConnectableNow,
+  isSeedProviderId
+} from '../src/shared/providers'
 import {
   CLAUDE_PROVIDER_ID,
   CLIPROXY_PROVIDER_IDS,
@@ -345,6 +350,20 @@ check(
   typeof resolveSeed('__x__').wire === 'string'
 )
 check('isConnectableNow returns boolean', typeof isConnectableNow(SEED_PROVIDERS[0]) === 'boolean')
+// The telemetry allow-list. `resolveSeed` answers "what settings does this id
+// imply" and so must accept anything; `isSeedProviderId` answers "did WE ship
+// this id" and so must reject everything else. They deliberately disagree on an
+// unknown id, which is the whole reason the second one exists.
+check(
+  'isSeedProviderId: every shipped id is allow-listed',
+  SEED_PROVIDERS.every((p) => isSeedProviderId(p.id))
+)
+check('isSeedProviderId: an unshipped id is not', !isSeedProviderId('acme-internal-gateway'))
+check('isSeedProviderId: the empty string is not', !isSeedProviderId(''))
+check(
+  'isSeedProviderId is stricter than resolveSeed',
+  resolveSeed('__x__').id === '__x__' && !isSeedProviderId('__x__')
+)
 
 // ---- subscription providers (CLIProxyAPI sidecar) ----
 // Both are seeded the same way, so assert them the same way rather than writing

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -116,6 +116,7 @@ import {
   _resetTracking,
   _queueDepth
 } from '../src/main/services/track'
+import { isSeedProviderId } from '../src/shared/providers'
 import { createServer } from 'node:http'
 
 let pass = 0
@@ -4071,7 +4072,8 @@ async function main(): Promise<void> {
       'track: an event has no fields beyond name/clientId/ts/props',
       Object.keys(first?.events?.[0] ?? {})
         .sort()
-        .join(',') === 'clientId,name,ts'
+        .join(',') === 'clientId,name,ts',
+      Object.keys(first?.events?.[0] ?? {}).join(',')
     )
 
     // 3. The id survives a restart — that is what makes retention measurable.
@@ -4090,6 +4092,63 @@ async function main(): Promise<void> {
     await settled(1)
     const props = batches[0]?.events?.[0]?.props
     check('track: props round-trip', props?.ok === true && props?.durationMs === 1234)
+
+    // 4b. A prompt reports its provider, and NOTHING else. The exact key set is
+    //     the assertion on purpose: this is the guard that fails when someone
+    //     helpfully adds `model` (or `cwd`) alongside the provider.
+    batches = []
+    hits = 0
+    track('prompt', { provider: 'openai' })
+    await flush()
+    await settled(1)
+    const promptProps = batches[0]?.events?.[0]?.props
+    check(
+      'track: a prompt carries props with only a provider key',
+      Object.keys(promptProps ?? {})
+        .sort()
+        .join(',') === 'provider',
+      Object.keys(promptProps ?? {}).join(',')
+    )
+    check('track: the provider round-trips', promptProps?.provider === 'openai')
+
+    // 4c. The allow-list is what stops a private endpoint from becoming a
+    //     near-unique fingerprint. Drive it through track() with a raw id rather
+    //     than pre-mapping it in the test: that is the difference between
+    //     asserting the sanitizer exists and asserting it is actually wired in.
+    check('track: a shipped provider id is allow-listed', isSeedProviderId('github-copilot'))
+    check(
+      'track: an unknown provider id is not allow-listed',
+      !isSeedProviderId('acme-internal-gateway')
+    )
+    batches = []
+    hits = 0
+    track('prompt', { provider: 'acme-internal-gateway' })
+    await flush()
+    await settled(1)
+    check(
+      'track: an unrecognized provider is replaced with "other"',
+      batches[0]?.events?.[0]?.props?.provider === 'other',
+      String(batches[0]?.events?.[0]?.props?.provider)
+    )
+    check(
+      'track: a custom provider id appears nowhere on the wire',
+      !JSON.stringify(batches).includes('acme-internal-gateway')
+    )
+
+    // 4d. A private endpoint is configured against the shipped
+    //     `openai-compatible` id (the URL lives in a separate column and is
+    //     never passed here), so that install reports as `openai-compatible` -
+    //     indistinguishable from every other one. That is the intended outcome,
+    //     not an accident, so pin it.
+    batches = []
+    hits = 0
+    track('prompt', { provider: 'openai-compatible' })
+    await flush()
+    await settled(1)
+    check(
+      'track: a custom-endpoint install reports only its seed id',
+      batches[0]?.events?.[0]?.props?.provider === 'openai-compatible'
+    )
 
     // 5. Opting out is immediate: queued events are dropped and nothing sends.
     batches = []


### PR DESCRIPTION
## What

Sends which **provider** served each turn on the anonymous `prompt` event, so `roxy.gg/stats` can chart provider popularity. The server-side chart and query already shipped (`edc500d`); this is the client half that makes the data exist.

The **model** stays unreported — far higher cardinality, and not what the public chart shows.

## The allow-list runs on the client, not just the server

The original plan mapped the provider through a server-side allow-list on ingest. That is necessary but not sufficient: it means the raw string still leaves the user's machine, and the guarantee holds only for as long as the ingest endpoint remembers to apply it.

Three things make an unvalidated id genuinely reachable here:

- `resolveSeed` deliberately **preserves** an unrecognized id verbatim (`src/shared/providers.ts:524`), so an unseeded provider still works.
- `providers.id` has no `CHECK` constraint.
- `runSessionTurn` fires this event **before** the turn resolves a provider (`src/main/services/session-turn.ts:67`; the "not connected" throw is later, at `src/main/services/llm.ts:316`). So an id that is not connected *at all* still reaches tracking.

So the mapping now lives in `track()` itself (`src/main/services/track.ts`), where events enter the queue. Anything not in the shipped seed list is **replaced** — not copied alongside — with `other`. A private id like `acme-internal-gateway` would otherwise be near-unique and would stamp a stable fingerprint on every event that install ever sends, which is exactly what this pipeline has always refused to store.

Doing it at the chokepoint rather than the call site makes it structural: no future caller can opt out by forgetting.

Keep the server-side allow-list regardless — older clients will keep sending raw ids for as long as they are in the fleet.

## Privacy copy

Two claims in the repo directly contradicted this change and are updated rather than left to rot:

- `src/renderer/src/routes/Settings.tsx` — the consent text attached to the opt-out toggle promised *"Never your prompts, code, file paths, repo names, model, **or provider**."* This is the one users actually read, so it matters more than the stats-page note.
- `src/main/services/track.ts` — the module header claimed *"no model or provider"*.

Both now spell out the carve-out and the `other` fallback explicitly.

## Tests

- A prompt's props must contain **exactly** one key, `provider` — so the next person who adds `model` alongside it still trips the guard.
- An unshipped id round-trips as `other`, and the original string appears nowhere in the payload.
- `isSeedProviderId` is asserted to be strictly narrower than `resolveSeed` — they disagree on an unknown id on purpose, which is the entire reason the second function exists.
- The existing strict `'clientId,name,ts'` assertion is **unchanged**. It covers `app_open`, which still carries no props at all; it did not need widening.

Verified by mutation: deleting the `sanitize` call fails both privacy assertions, so they are load-bearing rather than decorative. Also dropped a draft test that asserted a base URL never appears on the wire — nothing in that test ever supplied one, so it passed unconditionally.

`804` shared + `611` app checks green, plus typecheck and prettier.

> One pre-existing, unrelated failure — `a session without a port does not set PORT` — reproduces on a clean tree when the shell exports `PORT`. Not from this branch.

## Release

Bumps to `0.0.87`. Merging this to `main` changes `package.json`, which **triggers `.github/workflows/release.yml` and publishes a release**. That is intended here — the stats page shows nothing until clients in the field report a provider — but it means this should not be merged casually.
