### PR TITLE
feat(track): report what a turn actually did, not just that one happened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.87",
+      "version": "0.0.88",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",

--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -66,6 +66,14 @@ import {
 import { startSubagentRun } from '../services/subagent-stream'
 import { startToolRun } from '../services/tool-runs'
 import {
+  recordRetry,
+  recordStep,
+  recordSubagent,
+  recordTool,
+  recordTrim
+} from '../services/turn-metrics'
+import { trackFeature } from '../services/track'
+import {
   messagesHaveImages,
   openAiContent,
   openAiReasoning,
@@ -237,6 +245,16 @@ function describeModelError(e: unknown): string {
 interface StreamTurnDeps {
   runOnce?: typeof streamOnce
   delay?: (ms: number, signal: AbortSignal) => Promise<void>
+  /**
+   * Called once per transient failure that this function decides to ride out.
+   *
+   * Not a test seam - this one is used in production, by turn metrics. Retries
+   * are invisible to the user by design (that is the entire point of the retry
+   * loop), which is exactly why they are worth counting: a provider silently
+   * costing three retries per turn is degrading badly, and nothing else in the
+   * app would ever show it.
+   */
+  onRetry?: () => void
 }
 
 /**
@@ -301,6 +319,9 @@ export async function streamTurn(
       const transient = isTransientModelError(e)
       if (!transient && attempt + 1 >= MODEL_FATAL_ATTEMPTS) throw e
       const ms = nextRetryDelay(attempt)
+      // Counted here rather than at the catch, so it reflects retries we actually
+      // took - not failures that were about to be rethrown.
+      deps.onRetry?.()
       console.warn(
         `[agent] model turn failed (${describeModelError(e)}); ` +
           `retrying in ${Math.round(ms / 1000)}s (attempt ${attempt + 1}${
@@ -1054,7 +1075,8 @@ export async function runAgentTurn(opts: RunTurnOptions): Promise<void> {
     reasoning,
     effort: reasoningEffort,
     contextLimit,
-    depth: 0
+    depth: 0,
+    metricsId: chatId
   })
 }
 
@@ -1094,6 +1116,16 @@ interface LoopOptions {
   /** Token budget for the rolling conversation (drops oldest tool results to fit). */
   contextLimit?: number
   depth: number
+  /**
+   * The TOP-level session this loop's work belongs to, for turn metrics only.
+   *
+   * Distinct from `sessionId`, which a subagent overrides with its own sub-chat
+   * id so its spend lands in the right usage row. Metrics need the opposite: a
+   * subagent's steps and tokens are part of the turn the USER started, and
+   * attributing them to a sub-session (which has no collector) would silently
+   * drop the most expensive half of any delegating turn.
+   */
+  metricsId?: string
 }
 
 /**
@@ -1106,13 +1138,15 @@ function recordCall(
   model: string,
   sessionId: string | undefined,
   usage: TokenUsage | null
-): void {
-  if (!usage) return
+): number {
+  if (!usage) return 0
   try {
     const cost = usageCost(usage, modelCost(providerId, model))
     repo.recordUsage({ chatId: sessionId ?? null, providerId, model, usage, cost })
+    return cost
   } catch {
     // ignore — never let usage accounting interfere with the actual turn
+    return 0
   }
 }
 
@@ -1139,7 +1173,8 @@ async function runLoop(o: LoopOptions): Promise<string> {
     reasoning,
     effort,
     contextLimit,
-    depth
+    depth,
+    metricsId
   } = o
   let lastText = ''
 
@@ -1162,16 +1197,27 @@ async function runLoop(o: LoopOptions): Promise<string> {
       providerId,
       vision,
       model,
-      trimConvo(convo, contextLimit),
+      trimConvo(convo, contextLimit, metricsId),
       signal,
       reasoning,
       effort,
       liveTools,
       onText,
-      onReasoning
+      onReasoning,
+      { onRetry: () => recordRetry(metricsId) }
     )
     // Record this model call's usage/cost (subagents pass their own sessionId).
-    recordCall(providerId, model, sessionId, usage)
+    const cost = recordCall(providerId, model, sessionId, usage)
+    // ...and the same call's shape into the in-flight turn summary. Attributed
+    // to `metricsId` (the TOP-level session) rather than `sessionId`, so a
+    // subagent's model calls roll up into the turn the user actually started -
+    // its own sub-session has no collector and its work would otherwise vanish.
+    recordStep(
+      metricsId,
+      model,
+      usage ? { input: usage.input, output: usage.output, cacheRead: usage.cacheRead } : null,
+      cost
+    )
     if (text) lastText = text
     if (toolCalls.length === 0) return lastText // model finished with prose
 
@@ -1230,7 +1276,8 @@ async function runLoop(o: LoopOptions): Promise<string> {
           depth,
           mcpTools: liveMcpTools,
           skillTools,
-          skillInfo
+          skillInfo,
+          metricsId
         })
         return { id: tc.id, content: result.slice(0, 12_000) }
       } catch (e) {
@@ -1242,6 +1289,13 @@ async function runLoop(o: LoopOptions): Promise<string> {
     // Started here, not awaited, so the subagents run while the sequential tools
     // below execute. runTask never throws (runSubagent handles its own errors,
     // and the guard inside turns any setup failure into a task_error).
+    // Delegation is one of the strongest signals we have about how Roxy is
+    // really used - a session that fans out to subagents is a different product
+    // from one that answers questions - so count the spawns and flag the
+    // capability once per session.
+    for (let i = 0; i < tasks.length; i++) recordSubagent(metricsId)
+    if (tasks.length > 0) trackFeature(metricsId, 'subagent')
+
     const tasksSettled = runTasksByWriteCapability(tasks, {
       isWriteCapable: (tc) => isWriteCapableSubagent(parseTaskInput(tc.args).subagentType),
       limit: MAX_PARALLEL_SUBAGENTS,
@@ -1317,6 +1371,15 @@ async function runLoop(o: LoopOptions): Promise<string> {
         image: result.image,
         diff: result.diff
       })
+      // Count the call. `recordTool` collapses the name through the closed
+      // vocabulary, so an MCP tool reports as the literal `mcp` and its
+      // server id (which is user-chosen, and often an employer's internal
+      // service name) never leaves the process.
+      recordTool(metricsId, tc.name, result.ok)
+      if (tc.name.startsWith('mcp__')) trackFeature(metricsId, 'mcp_server')
+      else if (tc.name === SKILL_TOOL_NAME) trackFeature(metricsId, 'skill')
+      else if (tc.name.startsWith('browser_')) trackFeature(metricsId, 'browser')
+      else if (tc.name.startsWith('loop_')) trackFeature(metricsId, 'loop')
       // Full output still streams to the UI (tool-end above); for the model's
       // rolling context, spill oversized results to disk and keep a head/tail
       // preview + a read-tool pointer instead of a blind 8k cut (Phase 9.3).
@@ -1374,6 +1437,12 @@ interface SubagentOptions {
   skillTools?: ToolSchema[]
   /** The discovered-skills prompt block to inject into the subagent's system prompt. */
   skillInfo?: string
+  /**
+   * The TOP-level session this delegation belongs to, for turn metrics only.
+   * Inherited verbatim from the parent loop so a subagent's model steps, tokens
+   * and cost roll up into the turn the user actually started.
+   */
+  metricsId?: string
 }
 
 /** Spawn a subagent: a focused child run of the same loop, returned as a `task` result. */
@@ -1396,7 +1465,8 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
     depth,
     mcpTools,
     skillTools,
-    skillInfo
+    skillInfo,
+    metricsId
   } = o
   const { description, prompt, subagentType, background } = input
   const fail = (msg: string): string => {
@@ -1545,7 +1615,10 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
         reasoning,
         effort,
         contextLimit,
-        depth: depth + 1
+        depth: depth + 1,
+        // Inherited, not re-derived: every level of delegation reports into the
+        // one turn the user started.
+        metricsId
       })
       // A cancel lands BETWEEN steps, where runLoop returns normally with a
       // partial report — so reaching here says nothing about whether the work
@@ -1595,6 +1668,10 @@ async function runSubagent(o: SubagentOptions): Promise<string> {
 
     // Its own signal — the launching turn ending must NOT cancel it (that's the
     // whole point). Session delete / app quit cancel it via the registry.
+    // A detached background task is the most autonomous thing Roxy does - the
+    // user walks away and it keeps working - so its adoption is worth its own
+    // signal rather than being folded into the subagent count.
+    trackFeature(metricsId, 'background_task')
     const { jobId, signal: bgSignal } = registerBackgroundJob({
       sessionId: parentChatId,
       subChatId,
@@ -1928,9 +2005,19 @@ function msgTokens(m: OpenAiMessage): number {
  * trimmed too. Prevents a long tool-heavy loop from blowing past 100% (the
  * "Tool Results 101%" overflow).
  */
-function trimConvo(convo: OpenAiMessage[], budget = 200_000): OpenAiMessage[] {
+function trimConvo(
+  convo: OpenAiMessage[],
+  budget = 200_000,
+  /** Session whose turn metrics record that a trim happened (telemetry only). */
+  sessionId?: string
+): OpenAiMessage[] {
   const cap = Math.max(8000, budget - 12_000) // leave room for the model's reply
   if (convo.reduce((n, m) => n + msgTokens(m), 0) <= cap) return convo
+  // Past this line the conversation did not fit and something was dropped. Worth
+  // reporting: a turn that trimmed has silently lost context the user believes
+  // the agent still has, which is a leading indicator of "it forgot what I said"
+  // complaints and is otherwise invisible from the outside.
+  recordTrim(sessionId)
   // Stage 1 — prune older tool outputs to a preview before dropping any turn.
   const pruned = pruneToolMessages(convo, { keepRecentTokens: Math.min(KEEP_RECENT_TOKENS, cap) })
   const total = pruned.reduce((n, m) => n + msgTokens(m), 0)

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -75,7 +75,13 @@ import {
   installSkillFromSource
 } from '../services/skills'
 import { runSessionTurn } from '../services/session-turn'
-import { isTrackingEnabled, setTrackingEnabled } from '../services/track'
+import {
+  isTrackingEnabled,
+  markActivation,
+  setTrackingEnabled,
+  track,
+  trackFeature
+} from '../services/track'
 import * as remote from '../services/remote'
 import { buildExport, applyImport } from '../services/portable'
 import { promises as fsp } from 'node:fs'
@@ -207,9 +213,17 @@ export function registerIpc(): void {
 
   // ---- providers ----
   ipcMain.handle(CHANNELS.providersList, () => repo.listConnectedProviders())
-  ipcMain.handle(CHANNELS.providersConnect, (_e, input: ConnectProviderInput) =>
-    repo.connectProvider(input)
-  )
+  ipcMain.handle(CHANNELS.providersConnect, (_e, input: ConnectProviderInput) => {
+    const connected = repo.connectProvider(input)
+    // "What did people set up" is a different question from "what did they end
+    // up using", and the gap between the two is where broken onboarding hides -
+    // a provider connected far more often than it serves a prompt is one whose
+    // auth flow half-works. The id goes through the same seed allow-list as
+    // every other provider field.
+    track('provider_connect', { provider: input.id })
+    markActivation('provider_connected')
+    return connected
+  })
   ipcMain.handle(CHANNELS.providersDisconnect, async (_e, id: string) => {
     // A subscription provider's credential lives in the sidecar, not in
     // `credentials` - so dropping the row alone would leave the OAuth tokens on
@@ -254,6 +268,10 @@ export function registerIpc(): void {
       : null
 
     const chat = repo.forkChat(id, { title: input?.title })
+    // Forking is a power-user move (branch a conversation at a decision point),
+    // so its adoption says something about how deeply people work in Roxy.
+    // Keyed by the NEW session, which is the one whose life just began.
+    trackFeature(chat.id, 'fork')
     if (!wantsWorktree) return chat
     // Parked, not created: like any new session, the worktree is materialized on
     // the first turn, so a fork that is opened and abandoned costs nothing.

--- a/src/main/services/compaction.ts
+++ b/src/main/services/compaction.ts
@@ -7,6 +7,7 @@
  */
 import * as repo from '../db/repo'
 import { streamChat } from './llm'
+import { trackFeature } from './track'
 import { getAgent } from '../../shared/agents'
 import { AGENT_PROMPT_TEXT } from '../../shared/prompt-text'
 import { messagesToCompact } from '../../shared/context'
@@ -55,6 +56,10 @@ export async function compactChat(
 ): Promise<Chat> {
   const existing = repo.getChat(chatId)
   if (!existing) throw new Error('Chat not found')
+  // A session that needed compacting is a session that outgrew its context
+  // window - the clearest signal we have that people run genuinely long,
+  // sustained work rather than one-shot questions.
+  trackFeature(chatId, 'compaction')
   const all = repo.listMessages(chatId).filter((m) => m.role === 'user' || m.role === 'assistant')
   if (all.length === 0) return existing
 

--- a/src/main/services/remote.ts
+++ b/src/main/services/remote.ts
@@ -41,7 +41,7 @@ import * as repo from '../db/repo'
 import { listModels } from './models'
 import { pickDefaultModel } from '../../shared/models'
 import { runSessionTurn } from './session-turn'
-import { track } from './track'
+import { track, trackFeature } from './track'
 import { sessionCwd } from './workspace'
 import {
   MAX_FRAME_BYTES,
@@ -697,6 +697,11 @@ function onFrame(raw: string): void {
       // A pairing actually completed. Counted here rather than at share start:
       // opening a share nobody scans isn't someone using Remote Workspace.
       track('remote_pair')
+      // Also recorded as a capability so it lands in the one feature-adoption
+      // breakdown alongside subagents, MCP and the rest, rather than being the
+      // one surface you have to remember to look up separately. Keyed globally:
+      // pairing is an install-level act, not a session-level one.
+      trackFeature(undefined, 'remote_pair')
       // A phone entered the PIN and paired — send it the workspace session list
       // plus the current session's transcript + live turn state.
       share.guests = typeof frame.guests === 'number' ? frame.guests : share.guests

--- a/src/main/services/session-turn.ts
+++ b/src/main/services/session-turn.ts
@@ -17,7 +17,9 @@ import { protectedSubChatIds } from './subagent-stream'
 import { setLabel as setBrowserLabel } from './browser'
 import { sessionCwd } from './workspace'
 import { materializePendingWorktree } from './worktree'
-import { track } from './track'
+import { markActivation, track, trackFeature, trackToolUse } from './track'
+import { beginTurn, finishTurn } from './turn-metrics'
+import { modelFamily, reportableAgent } from '../../shared/telemetry'
 import path from 'node:path'
 
 /**
@@ -63,26 +65,94 @@ export async function runSessionTurn(
   // Usage tracking wraps the whole turn HERE, not at either caller: this is the
   // one function both the local (renderer) and remote (phone) paths go through,
   // so counting here is the only way the two can't drift. It records that a turn
-  // happened, which backend served it, and how it ended - never what was said,
-  // which model ran, or where.
+  // happened, which backend served it, how hard it worked and how it ended -
+  // never what was said or where.
   //
   // The provider rides along so roxy.gg/stats can show which backends people
-  // actually point Roxy at - the provider only, never the model. Passed raw:
+  // actually point Roxy at - the provider only, never the model id. Passed raw:
   // `track` collapses it to the shipped seed list, which matters here because
   // this fires BEFORE the turn resolves a provider, so an id that isn't even
-  // connected still reaches it.
-  track('prompt', { provider: input.providerId })
+  // connected still reaches it. The agent mode goes through its own classifier.
+  const agent = reportableAgent(input.agentId)
+  track('prompt', { provider: input.providerId, agent })
+  markActivation('first_prompt')
+  // Plan mode is a distinct way of using the product (read-only, no edits), and
+  // its share is the difference between "people trust it to write code" and
+  // "people use it to read code". Deduped per session by `trackFeature`.
+  if (agent === 'plan') trackFeature(input.sessionId, 'plan_mode')
+
+  // Open a collector for this session. The harness accumulates into it as the
+  // turn runs (model steps, tool calls, tokens, cost) and `finishTurn` below
+  // folds the whole thing into ONE event - so a 200-step overnight run costs
+  // the same ingest volume as a one-line question.
+  beginTurn(input.sessionId)
   const startedAt = Date.now()
   try {
     const result = await runTurn(input, emit, signal)
-    track('turn_end', { ok: result.ok, durationMs: Date.now() - startedAt })
+    // An abort is a DIFFERENT fact from an error and must not be flattened into
+    // one: a user pressing Stop usually means the agent went off the rails (our
+    // problem), while an error usually means the provider fell over (theirs).
+    // Reported as `ok:false` in both cases for continuity with the historical
+    // series, with `outcome` carrying the distinction.
+    const outcome = result.ok ? 'ok' : signal.aborted ? 'stopped' : 'error'
+    reportTurn(input, outcome, startedAt, result.error)
+    if (result.ok) markActivation('first_turn_ok')
     return result
   } catch (e) {
     // runTurn maps its own failures, so reaching here means an unexpected one.
     // Count it as a failed turn and rethrow untouched - tracking never changes
     // behaviour.
-    track('turn_end', { ok: false, durationMs: Date.now() - startedAt })
+    reportTurn(
+      input,
+      signal.aborted ? 'stopped' : 'error',
+      startedAt,
+      e instanceof Error ? e.message : String(e)
+    )
     throw e
+  }
+}
+
+/**
+ * Emit the `turn_end` summary plus this turn's per-tool events.
+ *
+ * Wrapped in its own try/catch and never awaited: telemetry sits directly on
+ * the turn's return path, and the one thing it must never do is turn a
+ * successful answer into a thrown error because a counter misbehaved.
+ *
+ * The error TEXT is passed only to the classifier, which returns one of a fixed
+ * set of kinds - the message itself never reaches the queue. Provider errors
+ * routinely embed the request URL, an account id, or a partial key.
+ */
+function reportTurn(
+  input: LlmStartInput,
+  outcome: 'ok' | 'stopped' | 'error',
+  startedAt: number,
+  errorText?: string
+): void {
+  try {
+    const done = finishTurn(input.sessionId, outcome, { text: errorText })
+    if (!done) {
+      // No collector (the turn never opened one, e.g. a very early failure).
+      // Still report the bare fact, so a crash before the harness starts can't
+      // silently vanish from the failure rate.
+      track('turn_end', {
+        ok: outcome === 'ok',
+        outcome,
+        durationMs: Date.now() - startedAt,
+        model: modelFamily(input.model)
+      })
+      return
+    }
+    const props = done.errorKind ? { ...done.summary, errorKind: done.errorKind } : done.summary
+    // The collector records the family of the model that actually STREAMED. A
+    // turn that failed before any model call has none, so fall back to the one
+    // the session asked for - otherwise every failed turn reports `other` and
+    // the error breakdown can't be split by model at all.
+    if (props.model === 'other') props.model = modelFamily(input.model)
+    track('turn_end', props)
+    trackToolUse(done.toolCounts.map((t) => ({ tool: t.tool, calls: t.calls, errors: t.errors })))
+  } catch {
+    /* telemetry must never break a turn */
   }
 }
 
@@ -100,6 +170,10 @@ async function runTurn(
   // in its project folder, not a chat that refuses to answer.
   try {
     const materialized = await materializePendingWorktree(input.sessionId)
+    // A session that materialized its own git worktree is running as a
+    // workstream - isolated branch, isolated tree. Counted only on success, so
+    // the number means "sessions that got one", not "sessions that asked".
+    if (materialized.ok) trackFeature(input.sessionId, 'worktree')
     if (materialized.error) emit({ type: 'text', delta: `_${materialized.error}_\n\n` })
   } catch (e) {
     console.warn('[worktree] materialize failed; running in the project folder:', e)

--- a/src/main/services/track.ts
+++ b/src/main/services/track.ts
@@ -7,11 +7,24 @@
  * the id before storing it, so a row cannot be mapped back to the id this client
  * holds.
  *
- * THE ONE EXCEPTION is `prompt`, which carries which PROVIDER served the turn.
- * `sanitize` below maps it through the shipped seed list on the way into the
- * queue, so it can only ever be one of the ~50 ids already public in this repo -
- * a custom endpoint is recorded as `other`. The MODEL is still never sent: it is
- * far higher-cardinality and isn't what the public chart shows.
+ * THE EXCEPTIONS ARE ALL CLOSED VOCABULARIES. Some events carry a little shape:
+ * which PROVIDER served a turn, which model FAMILY, which built-in TOOL ran,
+ * which KIND of error ended it. Every one of those values is produced by a
+ * classifier in `shared/telemetry.ts` that maps ANY input to a fixed set of
+ * strings shipped in this repo, and `sanitize` below re-applies the provider
+ * allow-list at the queue boundary. The wire format therefore cannot express a
+ * model id, an MCP server name, a file path, or an error message - not by
+ * convention, but because no code path can put one there.
+ *
+ * The classifiers fail safe: an id nobody anticipated becomes `other` rather
+ * than leaking. A private endpoint is configured against the shipped
+ * `openai-compatible` seed id (its URL lives in a different column entirely and
+ * is never passed here), so that install is indistinguishable from every other
+ * custom-endpoint install.
+ *
+ * COUNTERS, NOT CONTENT. `turn_end` carries how many model steps a turn took,
+ * how many tools it ran, how many tokens it burned and what it cost. Those are
+ * measures of how much work happened, never of what the work was.
  *
  * WHY IT'S SHAPED LIKE THIS:
  *  - **Never blocks the app.** Every call is fire-and-forget and every failure
@@ -30,6 +43,7 @@
  * dependency on the database being open or mid-migration.
  */
 import { isSeedProviderId } from '../../shared/providers'
+import { isFeatureId, type ActivationMilestone, type FeatureId } from '../../shared/telemetry'
 import { randomUUID } from 'node:crypto'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -46,12 +60,54 @@ export type TrackEvent =
   | 'app_open'
   /**
    * A turn was submitted to the agent. The "real usage" signal. Carries
-   * `{ provider }` - an allow-listed provider id, or `other` for anything
-   * that isn't in the shipped seed list.
+   * `{ provider, agent }` - an allow-listed provider id (or `other`), and
+   * which agent mode was driving (build/plan/subagent).
    */
   | 'prompt'
-  /** An agent turn finished. Carries `{ ok, durationMs }`. */
+  /**
+   * An agent turn finished - the richest event we send, and the one that makes
+   * the difference between "someone pressed enter" and "we know how this
+   * product performs".
+   *
+   * Carries `{ ok, outcome, durationMs, steps, stepBucket, tools, toolErrors,
+   * subagents, inputTokens, outputTokens, cacheReadTokens, costUsd, model,
+   * retries, trimmed }` and, on a failure, `errorKind`. `model` is a coarse
+   * FAMILY (`claude-sonnet`, `gpt-5`, `llama`), never a model id.
+   */
   | 'turn_end'
+  /**
+   * One built-in tool was used during a turn, with how many times and how many
+   * of those failed. Emitted per distinct tool at the END of a turn rather than
+   * per call: a long autonomous run makes hundreds of tool calls, and one event
+   * each would swamp the ingest endpoint with the heaviest sessions - biasing
+   * every chart toward light usage.
+   *
+   * Carries `{ tool, calls, errors }`. `tool` is a built-in name or the literal
+   * `mcp`; an MCP server's own name is never sent.
+   */
+  | 'tool_use'
+  /**
+   * A one-time-per-install activation milestone (`provider_connected`,
+   * `first_prompt`, `first_turn_ok`). Carries `{ milestone }`.
+   *
+   * Sent at most once ever, tracked in the same JSON file as the install id, so
+   * the counts form a real funnel instead of being dominated by whoever
+   * relaunches the app most.
+   */
+  | 'activation'
+  /**
+   * A provider was connected. Carries `{ provider }`. Distinct from `prompt`'s
+   * provider: this is "what did people set up", which is a different question
+   * from "what did they end up using", and the gap between the two is where
+   * broken onboarding hides.
+   */
+  | 'provider_connect'
+  /**
+   * A capability surface was used for the first time in a session. Carries
+   * `{ feature }` from the fixed `FeatureId` set. Deduped per session so one
+   * enthusiastic user can't manufacture a trend.
+   */
+  | 'feature'
   /** Keeps a long-running session counted as active on later days. */
   | 'heartbeat'
   /** Remote Workspace paired with a phone. */
@@ -63,6 +119,14 @@ export type TrackEvent =
 
 /** Only scalars — the server rejects nested objects and arrays anyway. */
 type Props = Record<string, string | number | boolean>
+
+/**
+ * The server caps a batch at 50 events and drops the excess, so a turn that
+ * would emit more `tool_use` events than this reports only its most-used tools.
+ * Well above a normal turn's distinct-tool count; it exists so a pathological
+ * run can't spend the whole batch on one event type.
+ */
+const MAX_TOOL_EVENTS_PER_TURN = 12
 
 /**
  * Collapse a `provider` prop to the shipped seed list, mapping anything else to
@@ -99,6 +163,16 @@ interface StoredState {
   enabled?: boolean
   /** Last version that reported an `app_open`, so we can detect an update. */
   appVersion?: string
+  /**
+   * Activation milestones already reported, so each is sent at most once EVER.
+   *
+   * Stored next to the install id rather than in the settings table for the
+   * same reason the id is: a factory reset wipes settings, and someone whose
+   * `first_prompt` was re-reported after a reset would appear in the funnel
+   * twice, quietly inflating the one number that is supposed to be a count of
+   * distinct people getting through onboarding.
+   */
+  activated?: string[]
 }
 
 const FLUSH_INTERVAL_MS = 30_000
@@ -183,6 +257,66 @@ export function track(name: TrackEvent, props?: Props): void {
   if (!enabled || !deviceId) return
   if (queue.length >= MAX_QUEUE) return // shed rather than grow without bound
   queue.push({ name, clientId: randomUUID(), ts: Date.now(), props: sanitize(props) })
+}
+
+/**
+ * Report an activation milestone, at most once per install, ever.
+ *
+ * The dedupe is persisted rather than in-memory because the milestones span
+ * launches by definition: `first_prompt` usually happens in a different session
+ * from `provider_connected`, and an in-memory guard would re-report every one
+ * of them on every restart - turning a funnel into a launch counter.
+ *
+ * Returns whether it actually reported, which the tests assert on.
+ */
+export function markActivation(milestone: ActivationMilestone): boolean {
+  if (!enabled || !deviceId) return false
+  const state = readState()
+  const seen = Array.isArray(state.activated) ? state.activated : []
+  if (seen.includes(milestone)) return false
+  writeState({ ...state, activated: [...seen, milestone] })
+  track('activation', { milestone })
+  return true
+}
+
+/**
+ * Per-session feature dedupe.
+ *
+ * In memory, unlike activation: the question here is "how many SESSIONS use
+ * subagents", so re-reporting across launches is correct and desirable. What we
+ * must avoid is counting the same session's 200 subagent spawns as 200 signals,
+ * which would make one overnight run look like a fleet-wide trend.
+ *
+ * Bounded so a long-lived process with many sessions can't grow it without
+ * limit; evicting just means a later session re-reports, which is harmless.
+ */
+const featuresSeen = new Set<string>()
+const MAX_FEATURE_KEYS = 500
+
+/** Report that a session used a capability surface, once per session. */
+export function trackFeature(sessionId: string | undefined, feature: FeatureId): void {
+  if (!enabled || !deviceId) return
+  if (!isFeatureId(feature)) return
+  const key = `${sessionId ?? 'global'}\u0000${feature}`
+  if (featuresSeen.has(key)) return
+  if (featuresSeen.size >= MAX_FEATURE_KEYS) featuresSeen.clear()
+  featuresSeen.add(key)
+  track('feature', { feature })
+}
+
+/**
+ * Report per-tool usage for a finished turn.
+ *
+ * Takes the whole map at once so the cap is applied to the turn as a unit -
+ * emitting these one at a time from the caller would make it impossible to
+ * bound a turn's share of the batch.
+ */
+export function trackToolUse(tools: { tool: string; calls: number; errors: number }[]): void {
+  if (!enabled || !deviceId) return
+  // Busiest first, so if a turn exceeds the cap the tools that get dropped are
+  // the ones that ran once, not the one that ran two hundred times.
+  const ranked = [...tools].sort((a, b) => b.calls - a.calls).slice(0, MAX_TOOL_EVENTS_PER_TURN)
+  for (const t of ranked) track('tool_use', { tool: t.tool, calls: t.calls, errors: t.errors })
 }
 
 /**
@@ -299,6 +433,7 @@ export function _resetTracking(): void {
   deviceId = null
   enabled = true
   forcedOff = false
+  featuresSeen.clear()
 }
 
 /** Test-only: how many events are waiting to be sent. */

--- a/src/main/services/turn-metrics.ts
+++ b/src/main/services/turn-metrics.ts
@@ -1,0 +1,294 @@
+/**
+ * Per-turn metric collection.
+ *
+ * A turn is the unit that matters: one prompt in, one answer out, with an
+ * unbounded amount of agent work in between. Everything interesting about how
+ * Roxy performs lives INSIDE that gap - how many model round trips it took, how
+ * many tools ran, how much context it burned, what it cost, whether it worked -
+ * and none of it is visible from either end.
+ *
+ * WHY A COLLECTOR AND NOT `track()` CALLS IN THE LOOP
+ *
+ * The obvious implementation is to call `track()` at each interesting point in
+ * the harness. That produces one event per model call and per tool call, which
+ * for a single overnight run is thousands of events from one user - a fleet of
+ * a few hundred installs would drown the ingest endpoint, and the rate limiter
+ * would start shedding exactly the heaviest sessions, biasing every chart
+ * toward light usage.
+ *
+ * So the harness accumulates into a per-turn collector and emits ONE summary
+ * event when the turn ends. A 200-step overnight run reports the same single
+ * event as a one-line question, with the depth captured as counters. That keeps
+ * the volume proportional to *users* rather than to how hard they work.
+ *
+ * WHAT IT DELIBERATELY DOES NOT HOLD
+ *
+ * No prompt text, no file paths, no model ids, no error strings, no MCP server
+ * names. The collector stores counters plus values already collapsed through
+ * `shared/telemetry.ts`'s closed vocabularies. There is nothing in here that
+ * could identify a person or a codebase, by construction rather than by
+ * convention.
+ *
+ * LIFECYCLE. `beginTurn()` at the top of a session turn, mutations from the
+ * harness as work happens, `finishTurn()` when it ends. The collector is keyed
+ * by session id and held in a module map because the harness is deep and
+ * threading a context object through every frame would touch fifty call sites
+ * for no benefit. A turn that never finishes (process killed) simply leaves a
+ * dead entry, which `beginTurn` overwrites and a size cap bounds.
+ */
+import {
+  bucketCount,
+  classifyTurnError,
+  modelFamily,
+  reportableToolName,
+  roundUsd,
+  safeTokens,
+  type ModelFamily,
+  type TurnErrorKind
+} from '../../shared/telemetry'
+
+/** What one in-flight turn has accumulated so far. */
+interface TurnMetrics {
+  startedAt: number
+  /** Model round trips - the real measure of how hard the agent worked. */
+  steps: number
+  /** Tool executions, and how many of them failed. */
+  tools: number
+  toolErrors: number
+  /**
+   * Per-tool call/error counts, keyed by the already-collapsed safe name.
+   *
+   * Counts rather than a bare set of names: "grep ran 40 times this turn" and
+   * "grep ran once" are different facts about how the agent works, and the
+   * distinction is the whole reason to break tools out by name at all.
+   */
+  toolCounts: Map<string, { calls: number; errors: number }>
+  /** Subagents spawned by this turn. */
+  subagents: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  /** USD, priced from the models.dev catalog at record time. */
+  costUsd: number
+  /** Model family of the LAST model call - what actually served the turn. */
+  family: ModelFamily | null
+  /** Transient provider failures the harness rode out without the user seeing. */
+  retries: number
+  /** Whether the conversation was trimmed to fit the context window. */
+  trimmed: boolean
+}
+
+/**
+ * Live turns, keyed by session id.
+ *
+ * Bounded: a leaked entry (a turn whose process died mid-flight) is ~200 bytes
+ * and would otherwise accumulate for the life of the app. The cap is far above
+ * any plausible number of concurrent sessions, so it only ever evicts garbage.
+ */
+const MAX_LIVE_TURNS = 64
+const live = new Map<string, TurnMetrics>()
+
+function fresh(): TurnMetrics {
+  return {
+    startedAt: Date.now(),
+    steps: 0,
+    tools: 0,
+    toolErrors: 0,
+    toolCounts: new Map(),
+    subagents: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    costUsd: 0,
+    family: null,
+    retries: 0,
+    trimmed: false
+  }
+}
+
+/**
+ * Start collecting for a session's turn. Replaces any previous collector for
+ * the same session, which is correct: a session runs one turn at a time, so an
+ * existing entry is a turn that died without finishing.
+ */
+export function beginTurn(sessionId: string): void {
+  if (live.size >= MAX_LIVE_TURNS && !live.has(sessionId)) {
+    // Evict the oldest rather than refusing to track the new turn - a stuck
+    // entry should never be able to blind us to live traffic.
+    const oldest = [...live.entries()].sort((a, b) => a[1].startedAt - b[1].startedAt)[0]
+    if (oldest) live.delete(oldest[0])
+  }
+  live.set(sessionId, fresh())
+}
+
+/**
+ * Mutate the collector for a session, if one is live.
+ *
+ * Every recorder goes through this so that a metric call from a code path with
+ * no active turn (a background job, a subagent whose parent already finished)
+ * is a silent no-op rather than a crash. Telemetry must never be able to break
+ * a turn - that principle is worth more than the occasional lost counter.
+ */
+function edit(sessionId: string | undefined, fn: (m: TurnMetrics) => void): void {
+  if (!sessionId) return
+  const m = live.get(sessionId)
+  if (!m) return
+  try {
+    fn(m)
+  } catch {
+    /* a metric must never throw into the harness */
+  }
+}
+
+/** One model round trip completed, with whatever usage it reported. */
+export function recordStep(
+  sessionId: string | undefined,
+  model: string,
+  usage: { input: number; output: number; cacheRead: number } | null,
+  costUsd: number
+): void {
+  edit(sessionId, (m) => {
+    m.steps++
+    // Last writer wins: a turn can switch models mid-flight (a subagent may run
+    // a different one), and the model that produced the final answer is the one
+    // the user experienced.
+    m.family = modelFamily(model)
+    if (usage) {
+      m.inputTokens += safeTokens(usage.input)
+      m.outputTokens += safeTokens(usage.output)
+      m.cacheReadTokens += safeTokens(usage.cacheRead)
+    }
+    if (Number.isFinite(costUsd) && costUsd > 0) m.costUsd += costUsd
+  })
+}
+
+/** One tool call finished. `name` is collapsed here so callers can't forget. */
+export function recordTool(sessionId: string | undefined, name: string, ok: boolean): void {
+  edit(sessionId, (m) => {
+    m.tools++
+    if (!ok) m.toolErrors++
+    // Collapsed at the boundary: an MCP tool's qualified name (which embeds a
+    // user-chosen server id) must never reach the map, let alone the wire.
+    const key = reportableToolName(name)
+    const cur = m.toolCounts.get(key)
+    if (cur) {
+      cur.calls++
+      if (!ok) cur.errors++
+      return
+    }
+    // Bounded. The names are already collapsed to a closed set, so this cap is
+    // unreachable in practice - it exists so that a future addition to the
+    // vocabulary can't turn this map into an unbounded allocation.
+    if (m.toolCounts.size < 40) m.toolCounts.set(key, { calls: 1, errors: ok ? 0 : 1 })
+  })
+}
+
+/** A subagent was delegated to. */
+export function recordSubagent(sessionId: string | undefined): void {
+  edit(sessionId, (m) => {
+    m.subagents++
+  })
+}
+
+/**
+ * The harness rode out a transient provider failure.
+ *
+ * Invisible to the user by design - that's the point of the retry logic - which
+ * is exactly why it's worth counting. A provider that silently costs us three
+ * retries per turn is degrading, and this is the only place that shows it.
+ */
+export function recordRetry(sessionId: string | undefined): void {
+  edit(sessionId, (m) => {
+    m.retries++
+  })
+}
+
+/** The rolling conversation was trimmed to fit the model's context window. */
+export function recordTrim(sessionId: string | undefined): void {
+  edit(sessionId, (m) => {
+    m.trimmed = true
+  })
+}
+
+/** The shape handed to `track('turn_end', ...)`. Scalars only. */
+export interface TurnSummary extends Record<string, string | number | boolean> {
+  ok: boolean
+  outcome: string
+  durationMs: number
+  steps: number
+  stepBucket: string
+  tools: number
+  toolErrors: number
+  subagents: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  costUsd: number
+  model: string
+  retries: number
+  trimmed: boolean
+}
+
+/**
+ * Close out a turn and produce its summary, or null if nothing was collected.
+ *
+ * `errorKind` is only present on a failure, so a successful turn's props stay
+ * small. Per-tool counts come back SEPARATELY rather than inside the summary:
+ * they ship as their own `tool_use` events, because folding them into one prop
+ * would mean either an unbounded joined string or a nested object, and the
+ * server accepts neither.
+ */
+export function finishTurn(
+  sessionId: string,
+  outcome: 'ok' | 'stopped' | 'error',
+  error?: { status?: number; text?: string }
+): {
+  summary: TurnSummary
+  errorKind?: TurnErrorKind
+  toolCounts: { tool: string; calls: number; errors: number }[]
+} | null {
+  const m = live.get(sessionId)
+  if (!m) return null
+  live.delete(sessionId)
+
+  const summary: TurnSummary = {
+    // Kept alongside `outcome` for continuity: the server has been receiving
+    // `ok` since the first version of this event, and dropping it would put a
+    // discontinuity through every historical chart at the release boundary.
+    ok: outcome === 'ok',
+    outcome,
+    durationMs: Math.max(0, Date.now() - m.startedAt),
+    steps: m.steps,
+    stepBucket: bucketCount(m.steps),
+    tools: m.tools,
+    toolErrors: m.toolErrors,
+    subagents: m.subagents,
+    inputTokens: m.inputTokens,
+    outputTokens: m.outputTokens,
+    cacheReadTokens: m.cacheReadTokens,
+    costUsd: roundUsd(m.costUsd),
+    model: m.family ?? 'other',
+    retries: m.retries,
+    trimmed: m.trimmed
+  }
+
+  return {
+    summary,
+    errorKind: outcome === 'error' ? classifyTurnError(error?.status, error?.text) : undefined,
+    toolCounts: [...m.toolCounts].map(([tool, c]) => ({
+      tool,
+      calls: c.calls,
+      errors: c.errors
+    }))
+  }
+}
+
+/** Test-only: drop all in-flight collectors. */
+export function _resetTurnMetrics(): void {
+  live.clear()
+}
+
+/** Test-only: how many turns are currently being collected. */
+export function _liveTurnCount(): number {
+  return live.size
+}

--- a/src/renderer/src/routes/Settings.tsx
+++ b/src/renderer/src/routes/Settings.tsx
@@ -389,11 +389,18 @@ export default function Settings(): JSX.Element {
           <div className="min-w-0">
             <div className="text-sm font-medium text-text">Send anonymous usage data</div>
             <p className="mt-0.5 text-xs text-text-muted">
-              Counts of things like app launches and finished turns, tied to a random id generated
-              on this machine. Never your prompts, code, file paths, repo names, or model. It does
-              include which provider served each turn, matched against our built-in list so a custom
-              endpoint is only ever recorded as &ldquo;other&rdquo;. It is the only way we can tell
-              whether a release helped or broke things.
+              Counts and timings &mdash; app launches, finished turns, how many steps and tools a
+              turn took, how many tokens it used and roughly what it cost &mdash; tied to a random
+              id generated on this machine. Never your prompts, your code, file paths, repo names,
+              or any error text.
+            </p>
+            <p className="mt-2 text-xs text-text-muted">
+              A few labels ride along, and each is matched against a fixed list built into the app:
+              which provider served a turn (a custom endpoint is only ever recorded as{' '}
+              &ldquo;other&rdquo;), which model <em>family</em> ran (&ldquo;claude-sonnet&rdquo;,
+              never the exact model id), which built-in tools ran (an MCP server&rsquo;s own name is
+              only ever recorded as &ldquo;mcp&rdquo;), and which <em>kind</em> of error ended a
+              failed turn. It is the only way we can tell whether a release helped or broke things.
             </p>
           </div>
           <Switch checked={telemetryEnabled} onChange={(v) => void setTelemetryEnabled(v)} />

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -1,0 +1,461 @@
+/**
+ * The closed vocabularies behind anonymous usage tracking.
+ *
+ * Every value this app reports about a turn is produced here, and every
+ * function in this file is TOTAL over its input: hand it anything at all and it
+ * returns one of a small, fixed set of strings that ship in this repo. That is
+ * the entire design. Telemetry's privacy risk is not the counters, it is the
+ * strings - a model id, an MCP tool name, or an error message can each carry a
+ * user's private endpoint, their employer's internal service name, or an
+ * absolute path with their name in it, and any of those would act as a
+ * near-unique fingerprint stamped on every event that install ever sends.
+ *
+ * So the rule is: the wire format cannot express those things. Not "we don't
+ * currently send them" - cannot. A classifier that maps to a fixed set is
+ * unbypassable in a way that a code review convention is not, and it fails
+ * safe: an id nobody anticipated lands in `other` rather than leaking.
+ *
+ * Living HERE (shared/, not main/) is deliberate: this module is pure, has no
+ * Electron or database imports, and is therefore exercised directly by the
+ * pure-Node `npm run smoke:shared` suite. The privacy guarantees are the part
+ * that most needs tests, so they are the part that must be trivially testable.
+ */
+
+/**
+ * Coarse model families we report instead of model ids.
+ *
+ * WHY NOT THE MODEL ID. It is the single most requested breakdown and the most
+ * dangerous string in the app. Model ids are unbounded: Ollama and LM Studio
+ * run whatever the user named their local weights (`acme-support-bot-v3`), and
+ * gateways pass through arbitrary vendor strings. Publishing that field would
+ * mean an install running one bespoke finetune is identifiable forever, from a
+ * field we added to draw a pie chart.
+ *
+ * WHY A FAMILY IS ENOUGH. The product question is "which class of model do
+ * people point Roxy at" - frontier Anthropic vs frontier OpenAI vs a local
+ * 8B - and the family answers it exactly. The minor version almost never
+ * changes the answer, and when it does, it changes it for a month.
+ *
+ * The list is intentionally shorter than the set of models that exist. Anything
+ * unmatched is `other`, which is a real and useful bucket rather than a
+ * failure: a rising `other` share is the signal to add a family, and until then
+ * it is honest about being unresolved.
+ */
+export type ModelFamily =
+  | 'claude-opus'
+  | 'claude-sonnet'
+  | 'claude-haiku'
+  | 'gpt-5'
+  | 'gpt-4'
+  | 'openai-reasoning'
+  | 'gpt-oss'
+  | 'gemini-pro'
+  | 'gemini-flash'
+  | 'grok'
+  | 'llama'
+  | 'qwen'
+  | 'deepseek'
+  | 'mistral'
+  | 'kimi'
+  | 'glm'
+  | 'command'
+  | 'gemma'
+  | 'phi'
+  | 'other'
+
+/**
+ * Ordered family patterns. FIRST MATCH WINS, so the order is load-bearing:
+ * `openai-reasoning` (o1/o3/o4) precedes the `gpt-4`/`gpt-5` rules because
+ * several reasoning ids also carry a `gpt` prefix, and `claude-*` tiers precede
+ * any generic vendor rule.
+ *
+ * Patterns match a SUBSTRING of the lowercased id on purpose - real ids arrive
+ * as `anthropic/claude-sonnet-4-5`, `claude-3-5-sonnet-20241022`, and
+ * `bedrock/anthropic.claude-sonnet-4-v1:0`, and all three are the same family.
+ */
+const MODEL_FAMILY_PATTERNS: [RegExp, ModelFamily][] = [
+  // Anthropic tiers. Matched before anything generic so a gateway-prefixed id
+  // still resolves to its tier rather than falling through.
+  [/opus/, 'claude-opus'],
+  [/sonnet/, 'claude-sonnet'],
+  [/haiku/, 'claude-haiku'],
+  // An unrecognised Claude tier is still clearly a Claude; report the modal
+  // tier rather than `other`, which would hide a whole vendor behind a bucket.
+  [/claude/, 'claude-sonnet'],
+
+  // OpenAI reasoning models. BEFORE the gpt rules: `o3` and friends are a
+  // different product line, and some ship under ids that also say "gpt".
+  [/(^|[^a-z0-9])o[1-9](-mini|-preview|-pro)?([^a-z0-9]|$)/, 'openai-reasoning'],
+  // Open-weight OpenAI models run locally - a different story from the API.
+  [/gpt-?oss/, 'gpt-oss'],
+  [/gpt-?5/, 'gpt-5'],
+  [/gpt-?4|chatgpt/, 'gpt-4'],
+
+  [/gemini.*flash|flash.*gemini/, 'gemini-flash'],
+  [/gemini/, 'gemini-pro'],
+  [/grok/, 'grok'],
+
+  // Open-weight families, by weight name rather than by whoever is hosting
+  // them - the same Llama is the same story on Groq, Together, or localhost.
+  [/llama/, 'llama'],
+  [/qwen|qwq/, 'qwen'],
+  [/deepseek/, 'deepseek'],
+  [/mistral|mixtral|codestral|devstral|magistral/, 'mistral'],
+  [/kimi|moonshot/, 'kimi'],
+  [/glm|chatglm/, 'glm'],
+  [/command-?[ar]|cohere/, 'command'],
+  [/gemma/, 'gemma'],
+  [/phi-?\d/, 'phi']
+]
+
+/**
+ * Map a model id to its coarse family, or `other`.
+ *
+ * Total by construction: any string, including a private finetune name, an
+ * empty string, or a 10KB blob, returns one of the shipped families. The input
+ * is never echoed, so nothing about an unmatched id survives this call.
+ */
+export function modelFamily(modelId: string | null | undefined): ModelFamily {
+  if (typeof modelId !== 'string') return 'other'
+  // Bounded before the regex sweep: these patterns run against attacker-ish
+  // input (a gateway can return any id), and an unbounded string is how a
+  // pathological match turns into a stalled turn.
+  const id = modelId.slice(0, 200).toLowerCase()
+  if (!id) return 'other'
+  for (const [re, family] of MODEL_FAMILY_PATTERNS) if (re.test(id)) return family
+  return 'other'
+}
+
+/**
+ * How a turn ended.
+ *
+ * `stopped` is split out from `error` because conflating them destroys the one
+ * signal that matters most: a user pressing Stop is usually the agent going off
+ * the rails, which is a PRODUCT failure, while an error is typically a provider
+ * or network failure. A single `ok: false` boolean reports both as "a turn
+ * failed" and leaves us unable to tell a bad agent from a bad afternoon at
+ * Anthropic.
+ */
+export type TurnOutcome = 'ok' | 'stopped' | 'error'
+
+/**
+ * Why a turn failed, from a fixed set.
+ *
+ * NEVER the error message. Provider error text routinely embeds the request
+ * URL (a private gateway), an account id, a file path, or a partial API key,
+ * and it is unbounded and unpredictable. The kind is what actually drives a
+ * decision - a spike in `billing` means people are hitting credit walls, a
+ * spike in `rate_limit` means we should back off harder - and the message adds
+ * nothing to that while carrying every risk.
+ */
+export type TurnErrorKind =
+  /** 429 / explicit rate-limit. Provider is throttling us. */
+  | 'rate_limit'
+  /** Out of credits, quota exhausted, payment required. The user must act. */
+  | 'billing'
+  /** 401/403, revoked token, provider not connected. */
+  | 'auth'
+  /** Dropped socket, DNS, refused connection, timeout. */
+  | 'network'
+  /** Conversation exceeded the model's context window. */
+  | 'context_overflow'
+  /** Provider 5xx. Their fault, not ours. */
+  | 'provider_error'
+  /** 400-class: we sent something the provider rejected. Usually OUR bug. */
+  | 'bad_request'
+  /** Classified as nothing else. A rising share here means this list needs a row. */
+  | 'unknown'
+
+/**
+ * Phrases that mean "the account is out of money", across providers that
+ * disagree wildly about status codes: OpenAI returns 429 `insufficient_quota`,
+ * Anthropic a 400 "credit balance is too low", others a 402.
+ *
+ * Deliberately narrow, and checked BEFORE rate limits, so a plain
+ * "rate limit reached, try again in 2s" stays a rate limit. Mirrors the
+ * harness's own retry classifier (`QUOTA_BILLING_RE` in main/harness/agent.ts)
+ * because the two answer the same question and must not disagree.
+ */
+const BILLING_RE =
+  /insufficient[_ ]?quota|exceeded your current quota|check your plan and billing|billing[_ ]?hard[_ ]?limit|hard limit (?:has been |was )?reached|out of credits|credit balance is too low|insufficient[_ ]?credits?|not enough credits|no credits (?:remaining|left)|purchase (?:more )?credits|add a payment method|payment required|billing details/i
+
+const CONTEXT_RE =
+  /context[_ ]?length[_ ]?exceeded|maximum context length|context window|too many tokens|prompt is too long|reduce the length of the messages|input length and `max_tokens` exceed/i
+
+const AUTH_RE =
+  /unauthorized|forbidden|invalid[_ ]api[_ ]?key|incorrect api key|authentication|invalid[_ ]?token|expired[_ ]?token|not connected|no credential|permission denied/i
+
+const RATE_LIMIT_RE = /rate[_ ]?limit|too many requests|overloaded|capacity|try again in/i
+
+const NETWORK_RE =
+  /fetch failed|socket hang ?up|network (?:error|timeout)|terminated|other side closed|premature close|stream (?:closed|error|aborted)|connection (?:closed|reset|refused|error)|timed? ?out|econnreset|econnrefused|enotfound|eai_again|und_err/i
+
+/**
+ * Classify a turn failure from its HTTP status and message text.
+ *
+ * Pure and text-in/enum-out so the whole matrix is testable without Electron,
+ * a provider, or a network. The caller (main/services/turn-metrics.ts) is
+ * responsible for extracting the two inputs from whatever error object the
+ * transport threw; keeping that extraction OUT of here is what lets this file
+ * stay dependency-free.
+ *
+ * Order matters and is not the same as the status order:
+ *  1. Billing first, because it arrives as a 429 and a 400 and a 402 and only
+ *     the TEXT distinguishes it from an ordinary throttle.
+ *  2. Context overflow next, because it arrives as a 400 and would otherwise be
+ *     filed as our bug when it is really a conversation that grew too long.
+ *  3. Then status codes, which are reliable once the ambiguous cases are gone.
+ */
+export function classifyTurnError(
+  status: number | undefined,
+  text: string | undefined
+): TurnErrorKind {
+  // Bounded for the same reason as the model id: this is unbounded provider
+  // output being fed to a regex.
+  const t = typeof text === 'string' ? text.slice(0, 2000) : ''
+
+  if (BILLING_RE.test(t)) return 'billing'
+  if (CONTEXT_RE.test(t)) return 'context_overflow'
+
+  if (typeof status === 'number' && status > 0) {
+    if (status === 402) return 'billing'
+    if (status === 401 || status === 403) return 'auth'
+    if (status === 429) return 'rate_limit'
+    if (status === 408) return 'network'
+    if (status >= 500) return 'provider_error'
+    if (status >= 400) {
+      // A 400 whose text names an auth problem is an auth problem; providers
+      // are not consistent about which of the two codes they use.
+      if (AUTH_RE.test(t)) return 'auth'
+      return 'bad_request'
+    }
+  }
+
+  // No usable status: fall back to the text. Network last, because its pattern
+  // is the broadest and would otherwise swallow more specific kinds.
+  if (AUTH_RE.test(t)) return 'auth'
+  if (RATE_LIMIT_RE.test(t)) return 'rate_limit'
+  if (NETWORK_RE.test(t)) return 'network'
+  return 'unknown'
+}
+
+/**
+ * One-time-per-install milestones, reported in order.
+ *
+ * This is the activation funnel, and it is the metric an early-stage product
+ * most often lacks: installs are easy to count and mean almost nothing, while
+ * "installed, connected a provider, sent a prompt, got a working answer" is the
+ * chain that says whether the thing actually onboards anyone. Each step is
+ * reported at most once ever (see `markActivation` in main/services/track.ts),
+ * so the counts are directly comparable as a funnel rather than being dominated
+ * by whoever opened the app most times.
+ */
+export type ActivationMilestone =
+  /** A provider was connected for the first time. Without this nothing can run. */
+  | 'provider_connected'
+  /** The first prompt was submitted. */
+  | 'first_prompt'
+  /** The first turn that actually completed. The real "it worked" moment. */
+  | 'first_turn_ok'
+
+export const ACTIVATION_MILESTONES: ActivationMilestone[] = [
+  'provider_connected',
+  'first_prompt',
+  'first_turn_ok'
+]
+
+/**
+ * Capability surfaces worth counting, as a closed set.
+ *
+ * These answer "what is Roxy actually FOR", which drives what we build next.
+ * An agent that people only ever use to read files is a different product from
+ * one people run overnight with subagents and MCP servers, and the difference
+ * is invisible in DAU.
+ *
+ * Reported at most once per session per feature, so one enthusiastic user
+ * cannot manufacture a trend.
+ */
+export type FeatureId =
+  /** Paired with a phone (Remote Workspace). */
+  | 'remote_pair'
+  /** An MCP server was connected during a turn. */
+  | 'mcp_server'
+  /** A SKILL.md was loaded. */
+  | 'skill'
+  /** The agent delegated to a subagent via `task`. */
+  | 'subagent'
+  /** A detached background task was started. */
+  | 'background_task'
+  /** A session ran in its own git worktree/workstream. */
+  | 'worktree'
+  /** The built-in browser was driven. */
+  | 'browser'
+  /** A scheduled loop was created. */
+  | 'loop'
+  /** The conversation was auto-compacted. */
+  | 'compaction'
+  /** A session was forked. */
+  | 'fork'
+  /** Plan mode (read-only agent) was used. */
+  | 'plan_mode'
+
+export const FEATURE_IDS: FeatureId[] = [
+  'remote_pair',
+  'mcp_server',
+  'skill',
+  'subagent',
+  'background_task',
+  'worktree',
+  'browser',
+  'loop',
+  'compaction',
+  'fork',
+  'plan_mode'
+]
+
+const FEATURE_SET = new Set<string>(FEATURE_IDS)
+
+/** Whether an id is a known feature surface (guards the tracking call). */
+export function isFeatureId(v: string): v is FeatureId {
+  return FEATURE_SET.has(v)
+}
+
+/**
+ * Tool names safe to report, and the rule for everything else.
+ *
+ * The built-in catalog is public and fixed, so those names carry no
+ * information about a user. Two categories are NOT safe and are collapsed:
+ *
+ *  - **MCP tools** arrive as `mcp__<serverId>__<toolName>`, where `serverId` is
+ *    whatever the user called their server. `mcp__acme_internal_billing__query`
+ *    would publish a company's internal service names to a public stats page.
+ *    Every MCP tool reports as the single token `mcp`.
+ *  - **Skills** are user-authored markdown; the name is theirs, not ours.
+ *    Reports as `skill`.
+ *
+ * Kept as an explicit list rather than derived from `TOOLS` so that adding a
+ * tool to the catalog is not silently also a decision to publish its name -
+ * the two are different calls, and this one deserves to be deliberate.
+ */
+const REPORTABLE_TOOLS = new Set<string>([
+  // Files & search
+  'read',
+  'write',
+  'edit',
+  'list',
+  'glob',
+  'grep',
+  // Shell
+  'bash',
+  'bash_list',
+  'bash_output',
+  'bash_kill',
+  // Web
+  'webfetch',
+  'websearch',
+  // Browser
+  'browser_open',
+  'browser_screenshot',
+  'browser_read',
+  'browser_console',
+  'browser_click',
+  'browser_scroll',
+  'browser_type',
+  'browser_tabs',
+  'browser_new_tab',
+  'browser_activate_tab',
+  'browser_close',
+  // Automation
+  'loop_create',
+  'loop_remove',
+  'loop_list',
+  'loop_enable',
+  'loop_disable',
+  'change_session_metadata',
+  // Agents
+  'task',
+  'lsp',
+  // Offered to the model but absent from the user-facing catalog.
+  'mcp',
+  'skill',
+  'skill_manage'
+])
+
+/**
+ * Collapse a tool name to something safe to report.
+ *
+ * Total: any string returns either a built-in name or one of `mcp` / `other`.
+ * An MCP tool is detected by prefix rather than by asking the registry, so this
+ * stays pure and cannot be defeated by a server that connects later.
+ */
+export function reportableToolName(name: string | null | undefined): string {
+  if (typeof name !== 'string') return 'other'
+  const n = name.slice(0, 80)
+  // Prefix check first: `mcp__foo__bar` must never fall through to a lookup
+  // that might one day contain it.
+  if (n.startsWith('mcp__')) return 'mcp'
+  if (REPORTABLE_TOOLS.has(n)) return n
+  return 'other'
+}
+
+/**
+ * Agent modes we report. `build` and `plan` are the shipped primaries; a
+ * subagent type is reported as `subagent` rather than by name so a future
+ * custom-agent feature can't leak user-chosen names through this field.
+ */
+export type AgentMode = 'build' | 'plan' | 'subagent' | 'other'
+
+export function reportableAgent(agentId: string | null | undefined): AgentMode {
+  if (agentId === 'build' || agentId === 'plan') return agentId
+  if (agentId === 'general' || agentId === 'explore' || agentId === 'compaction') return 'subagent'
+  return 'other'
+}
+
+/**
+ * Bucket a count into a small ordinal label.
+ *
+ * Used for the "how deep did this turn go" dimensions. A raw count is fine on
+ * its own, but the bucketed form is what makes a distribution chartable without
+ * shipping a histogram, and it is what makes the headline claim legible: "62%
+ * of turns run 5+ agent steps" is a sentence about a product, where "mean steps
+ * 6.4" is a sentence about a mean, and means lie about long-tailed
+ * distributions.
+ */
+export type CountBucket = '0' | '1' | '2-4' | '5-9' | '10-24' | '25+'
+
+export function bucketCount(n: number): CountBucket {
+  if (!Number.isFinite(n) || n <= 0) return '0'
+  if (n === 1) return '1'
+  if (n < 5) return '2-4'
+  if (n < 10) return '5-9'
+  if (n < 25) return '10-24'
+  return '25+'
+}
+
+/**
+ * Round a USD amount to a sane precision for aggregation.
+ *
+ * Six decimals: a single cheap turn can genuinely cost $0.0001, and truncating
+ * that to two decimals would report the entire cheap-model segment as free.
+ * Bounded above because this is summed across a fleet and a garbage price in
+ * the catalog should not be able to produce an absurd headline.
+ */
+export function roundUsd(v: number): number {
+  if (!Number.isFinite(v) || v <= 0) return 0
+  return Math.round(Math.min(v, 1000) * 1e6) / 1e6
+}
+
+/**
+ * Clamp a token count to a plausible range.
+ *
+ * Mirrors the server's own validator so a broken counter is caught before it
+ * leaves the machine, rather than being silently dropped at ingest where we'd
+ * never know it happened. Non-integers, negatives and absurd values report as
+ * 0 rather than being clamped to the ceiling: a wrong number that looks
+ * plausible is worse than no number.
+ */
+export function safeTokens(v: number | null | undefined): number {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return 0
+  if (!Number.isInteger(v) || v < 0 || v > 100_000_000) return 0
+  return v
+}

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -42,6 +42,54 @@ import {
   upstreamFor
 } from '../src/shared/cliproxy'
 import { pickDefaultModel } from '../src/shared/models'
+import {
+  ACTIVATION_MILESTONES,
+  FEATURE_IDS,
+  bucketCount,
+  classifyTurnError,
+  isFeatureId,
+  modelFamily,
+  reportableAgent,
+  reportableToolName,
+  roundUsd,
+  safeTokens,
+  type ModelFamily,
+  type TurnErrorKind
+} from '../src/shared/telemetry'
+
+/** Every family/kind the classifiers may return - asserted to be exhaustive. */
+const MODEL_FAMILIES: ModelFamily[] = [
+  'claude-opus',
+  'claude-sonnet',
+  'claude-haiku',
+  'gpt-5',
+  'gpt-4',
+  'openai-reasoning',
+  'gpt-oss',
+  'gemini-pro',
+  'gemini-flash',
+  'grok',
+  'llama',
+  'qwen',
+  'deepseek',
+  'mistral',
+  'kimi',
+  'glm',
+  'command',
+  'gemma',
+  'phi',
+  'other'
+]
+const TURN_ERROR_KINDS: TurnErrorKind[] = [
+  'rate_limit',
+  'billing',
+  'auth',
+  'network',
+  'context_overflow',
+  'provider_error',
+  'bad_request',
+  'unknown'
+]
 import { randomSlug, uniqueSlug, slugToBranchSegment, isGeneratedSlug } from '../src/shared/slugs'
 import { formatInterval } from '../src/shared/format'
 import {
@@ -364,6 +412,182 @@ check(
   'isSeedProviderId is stricter than resolveSeed',
   resolveSeed('__x__').id === '__x__' && !isSeedProviderId('__x__')
 )
+
+// ---- telemetry vocabularies ----
+// Every function under test here is TOTAL: it maps arbitrary input to one of a
+// fixed set of strings that ship in this repo. That property is the entire
+// privacy guarantee of usage tracking, so it is asserted directly rather than
+// inferred from the callers.
+
+// Model FAMILY, never the model id. Real ids arrive gateway-prefixed, dated,
+// and vendor-qualified; all of those are the same family.
+check('modelFamily: bare anthropic id', modelFamily('claude-sonnet-4-5') === 'claude-sonnet')
+check('modelFamily: dated id', modelFamily('claude-3-5-sonnet-20241022') === 'claude-sonnet')
+check(
+  'modelFamily: gateway-prefixed id',
+  modelFamily('anthropic/claude-opus-4-1') === 'claude-opus'
+)
+check(
+  'modelFamily: bedrock-qualified id',
+  modelFamily('bedrock/anthropic.claude-haiku-4-v1:0') === 'claude-haiku'
+)
+check(
+  'modelFamily: an unknown Claude tier still reads as Claude',
+  modelFamily('claude-x') === 'claude-sonnet'
+)
+check('modelFamily: gpt-5', modelFamily('gpt-5-codex') === 'gpt-5')
+check('modelFamily: gpt-4o', modelFamily('gpt-4o-mini') === 'gpt-4')
+// Ordering matters: the reasoning line is a different product from gpt-4/5 and
+// must be matched before them.
+check('modelFamily: o3 is reasoning, not gpt', modelFamily('o3-mini') === 'openai-reasoning')
+check('modelFamily: o1 is reasoning', modelFamily('o1-preview') === 'openai-reasoning')
+// ...but a plain `gpt-oss` must NOT be swallowed by the reasoning pattern.
+check('modelFamily: gpt-oss is its own family', modelFamily('gpt-oss-120b') === 'gpt-oss')
+check(
+  'modelFamily: gemini flash beats gemini pro',
+  modelFamily('gemini-2.5-flash') === 'gemini-flash'
+)
+check('modelFamily: gemini pro', modelFamily('gemini-2.5-pro') === 'gemini-pro')
+check('modelFamily: local llama', modelFamily('llama3.3:70b') === 'llama')
+check('modelFamily: qwen', modelFamily('qwen2.5-coder:32b') === 'qwen')
+// THE case this whole indirection exists for: a private finetune name must not
+// survive, and none of it may appear in the output.
+check('modelFamily: a private finetune is `other`', modelFamily('acme-support-bot-v3') === 'other')
+check(
+  'modelFamily: null/empty are `other`',
+  modelFamily(null) === 'other' && modelFamily('') === 'other'
+)
+check(
+  'modelFamily: output is ALWAYS a shipped family',
+  ['acme-internal', '', 'x'.repeat(5000), '../../etc/passwd', 'gpt-4'].every((id) =>
+    MODEL_FAMILIES.includes(modelFamily(id))
+  )
+)
+
+// Error KIND, never the message. Providers disagree wildly about status codes
+// for the same condition, which is why text is consulted first.
+check(
+  'classifyTurnError: 429 is a rate limit',
+  classifyTurnError(429, 'slow down') === 'rate_limit'
+)
+// ...unless the text says it's really a billing wall, which OpenAI sends as 429.
+check(
+  'classifyTurnError: an out-of-quota 429 is billing, not a rate limit',
+  classifyTurnError(429, 'You exceeded your current quota') === 'billing'
+)
+check(
+  'classifyTurnError: Anthropic sends billing as a 400',
+  classifyTurnError(400, 'Your credit balance is too low') === 'billing'
+)
+check('classifyTurnError: 402 is billing', classifyTurnError(402, '') === 'billing')
+check('classifyTurnError: 401 is auth', classifyTurnError(401, '') === 'auth')
+check(
+  'classifyTurnError: a 400 naming auth is auth, not bad_request',
+  classifyTurnError(400, 'invalid api key') === 'auth'
+)
+check(
+  'classifyTurnError: context overflow beats bad_request',
+  classifyTurnError(400, "This model's maximum context length is 200000 tokens") ===
+    'context_overflow'
+)
+check('classifyTurnError: 500 is the provider', classifyTurnError(503, '') === 'provider_error')
+check(
+  'classifyTurnError: a plain 400 is our bug',
+  classifyTurnError(400, 'bad field') === 'bad_request'
+)
+check(
+  'classifyTurnError: a status-less socket drop is network',
+  classifyTurnError(undefined, 'fetch failed: ECONNRESET') === 'network'
+)
+check(
+  'classifyTurnError: nothing recognizable is unknown',
+  classifyTurnError(undefined, 'weird') === 'unknown'
+)
+check(
+  'classifyTurnError: no input at all is unknown',
+  classifyTurnError(undefined, undefined) === 'unknown'
+)
+check(
+  'classifyTurnError: output is ALWAYS a shipped kind',
+  [undefined, 0, 200, 418, 999].every((s) =>
+    TURN_ERROR_KINDS.includes(
+      classifyTurnError(s as number | undefined, 'https://secret.internal/v1 failed')
+    )
+  )
+)
+
+// Tool names: built-ins are public and safe; an MCP server's id is the user's
+// (often their employer's) and must never survive.
+check('reportableToolName: a built-in passes through', reportableToolName('bash') === 'bash')
+check(
+  'reportableToolName: an MCP tool collapses to `mcp`',
+  reportableToolName('mcp__github__list_prs') === 'mcp'
+)
+check(
+  'reportableToolName: a private MCP server name cannot survive',
+  reportableToolName('mcp__acme_internal_billing__query') === 'mcp'
+)
+check(
+  'reportableToolName: an unknown name is `other`',
+  reportableToolName('rm_rf_everything') === 'other'
+)
+check('reportableToolName: null is `other`', reportableToolName(null) === 'other')
+// The catalog and the reportable set must agree, or a tool ships and silently
+// reports as `other` forever.
+check(
+  'reportableToolName: every catalog tool is reportable',
+  TOOLS.every((t) => reportableToolName(t.id) === t.id),
+  TOOLS.filter((t) => reportableToolName(t.id) !== t.id)
+    .map((t) => t.id)
+    .join(',')
+)
+
+// Agent mode: the shipped primaries by name, everything else bucketed, so a
+// future custom-agent feature can't leak user-chosen names.
+check('reportableAgent: build', reportableAgent('build') === 'build')
+check('reportableAgent: plan', reportableAgent('plan') === 'plan')
+check('reportableAgent: a subagent type is bucketed', reportableAgent('explore') === 'subagent')
+check('reportableAgent: an unknown id is `other`', reportableAgent('my-custom-agent') === 'other')
+check('reportableAgent: undefined is `other`', reportableAgent(undefined) === 'other')
+
+// Buckets, for the distribution headline ("62% of turns run 5+ steps").
+check('bucketCount: zero', bucketCount(0) === '0')
+check(
+  'bucketCount: boundaries',
+  bucketCount(1) === '1' && bucketCount(4) === '2-4' && bucketCount(5) === '5-9'
+)
+check('bucketCount: top bucket', bucketCount(25) === '25+' && bucketCount(10_000) === '25+')
+check('bucketCount: garbage is zero', bucketCount(NaN) === '0' && bucketCount(-5) === '0')
+
+// Token counts mirror the server's validator, so a broken counter is caught
+// before it leaves the machine rather than silently dropped at ingest.
+check('safeTokens: a real count passes', safeTokens(12_000) === 12_000)
+check('safeTokens: zero is a real measurement', safeTokens(0) === 0)
+check('safeTokens: negative is rejected', safeTokens(-1) === 0)
+check('safeTokens: fractional is rejected', safeTokens(1.5) === 0)
+check('safeTokens: absurd is rejected', safeTokens(1e12) === 0)
+check(
+  'safeTokens: NaN/undefined are rejected',
+  safeTokens(NaN) === 0 && safeTokens(undefined) === 0
+)
+
+// Cost keeps enough precision that cheap models don't round to free.
+check('roundUsd: a sub-cent turn is not free', roundUsd(0.000123) === 0.000123)
+check('roundUsd: garbage is zero', roundUsd(NaN) === 0 && roundUsd(-1) === 0)
+check('roundUsd: absurd is capped', roundUsd(1e9) === 1000)
+
+// The activation funnel is ordered, and each step is reported at most once, so
+// the counts are directly comparable as a funnel.
+check(
+  'activation: the funnel is ordered',
+  ACTIVATION_MILESTONES.join(',') === 'provider_connected,first_prompt,first_turn_ok'
+)
+check('features: ids are unique', new Set(FEATURE_IDS).size === FEATURE_IDS.length)
+check(
+  'features: isFeatureId accepts every shipped id',
+  FEATURE_IDS.every((f) => isFeatureId(f))
+)
+check('features: isFeatureId rejects anything else', !isFeatureId('rm -rf'))
 
 // ---- subscription providers (CLIProxyAPI sidecar) ----
 // Both are seeded the same way, so assert them the same way rather than writing

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -116,6 +116,18 @@ import {
   _resetTracking,
   _queueDepth
 } from '../src/main/services/track'
+import { markActivation, trackFeature, trackToolUse } from '../src/main/services/track'
+import {
+  beginTurn,
+  finishTurn,
+  recordRetry,
+  recordStep,
+  recordSubagent,
+  recordTool,
+  recordTrim,
+  _liveTurnCount,
+  _resetTurnMetrics
+} from '../src/main/services/turn-metrics'
 import { isSeedProviderId } from '../src/shared/providers'
 import { createServer } from 'node:http'
 
@@ -4241,6 +4253,186 @@ async function main(): Promise<void> {
     check(
       'track: the update is not re-reported on the next launch',
       (batches[0]?.events ?? []).every((e) => e.name !== 'update')
+    )
+
+    // 10b. The rich turn summary.
+    //
+    // This is the event the whole product-metrics layer exists for, so the
+    // assertions are about SHAPE and about what must never be in it. Driven
+    // through the real collector rather than by hand-building props: that is
+    // the difference between testing the wire format and testing the pipeline
+    // that fills it.
+    await reset()
+    initTracking()
+    await settled(1)
+    _resetTurnMetrics()
+    batches = []
+    hits = 0
+
+    beginTurn('sess-metrics')
+    recordStep(
+      'sess-metrics',
+      'claude-sonnet-4-5',
+      { input: 10_000, output: 500, cacheRead: 8000 },
+      0.03
+    )
+    recordStep(
+      'sess-metrics',
+      'claude-sonnet-4-5',
+      { input: 12_000, output: 300, cacheRead: 0 },
+      0.02
+    )
+    recordTool('sess-metrics', 'bash', true)
+    recordTool('sess-metrics', 'bash', false)
+    recordTool('sess-metrics', 'mcp__acme_internal_billing__query', true)
+    recordSubagent('sess-metrics')
+    recordRetry('sess-metrics')
+    recordTrim('sess-metrics')
+    const done = finishTurn('sess-metrics', 'ok')
+    check('metrics: a finished turn produces a summary', !!done)
+    check('metrics: model steps are counted', done?.summary.steps === 2)
+    check('metrics: tokens sum across steps', done?.summary.inputTokens === 22_000)
+    check('metrics: cache reads are tracked separately', done?.summary.cacheReadTokens === 8000)
+    check(
+      'metrics: cost sums across steps',
+      done?.summary.costUsd === 0.05,
+      String(done?.summary.costUsd)
+    )
+    check(
+      'metrics: tool calls and failures are counted',
+      done?.summary.tools === 3 && done?.summary.toolErrors === 1
+    )
+    check('metrics: subagents are counted', done?.summary.subagents === 1)
+    check('metrics: silent retries are counted', done?.summary.retries === 1)
+    check('metrics: a context trim is flagged', done?.summary.trimmed === true)
+    check('metrics: the model reports as a FAMILY', done?.summary.model === 'claude-sonnet')
+    check('metrics: steps are also bucketed', done?.summary.stepBucket === '2-4')
+    // The collector must not leak: a finished turn is removed, so a long-lived
+    // process doesn't accumulate one entry per turn forever.
+    check('metrics: finishing a turn frees its collector', _liveTurnCount() === 0)
+    check(
+      'metrics: finishing an unknown turn is null, not a crash',
+      finishTurn('nope', 'ok') === null
+    )
+    // Per-tool counts come back separately, already collapsed.
+    const byTool = Object.fromEntries((done?.toolCounts ?? []).map((t) => [t.tool, t]))
+    check(
+      'metrics: per-tool calls are counted',
+      byTool.bash?.calls === 2 && byTool.bash?.errors === 1
+    )
+    check('metrics: an MCP tool is collapsed to `mcp`', !!byTool.mcp)
+    check(
+      'metrics: the MCP server name never reaches the summary',
+      !JSON.stringify(done).includes('acme_internal_billing')
+    )
+
+    // ...and the same summary must survive the wire unchanged.
+    track('turn_end', done!.summary)
+    trackToolUse(done!.toolCounts)
+    await flush()
+    await settled(1)
+    const sent = batches[0]?.events ?? []
+    const turnEnd = sent.find((e) => e.name === 'turn_end')
+    check(
+      'track: turn_end round-trips its counters',
+      turnEnd?.props?.steps === 2 && turnEnd?.props?.inputTokens === 22_000
+    )
+    check('track: turn_end carries the model family', turnEnd?.props?.model === 'claude-sonnet')
+    const toolEvents = sent.filter((e) => e.name === 'tool_use')
+    check(
+      'track: one tool_use event per distinct tool',
+      toolEvents.length === 2,
+      String(toolEvents.length)
+    )
+    check(
+      'track: no MCP server name is publishable',
+      !JSON.stringify(batches).includes('acme_internal_billing')
+    )
+    // Busiest-first ordering matters: if a turn ever exceeds the per-turn cap,
+    // the tools that survive must be the ones that actually ran.
+    check('track: tool_use is ordered busiest-first', toolEvents[0]?.props?.tool === 'bash')
+
+    // A failed turn carries a KIND, never the provider's message - which
+    // routinely embeds a private URL or a partial key.
+    batches = []
+    hits = 0
+    beginTurn('sess-fail')
+    const failed = finishTurn('sess-fail', 'error', {
+      status: 429,
+      text: 'You exceeded your current quota at https://acme.internal/v1 (key sk-abc123)'
+    })
+    check('metrics: an out-of-quota 429 classifies as billing', failed?.errorKind === 'billing')
+    track('turn_end', { ...failed!.summary, errorKind: failed!.errorKind! })
+    await flush()
+    await settled(1)
+    const failEvent = batches[0]?.events?.[0]
+    check('track: a failed turn reports its error KIND', failEvent?.props?.errorKind === 'billing')
+    check(
+      'track: the error message never reaches the wire',
+      !JSON.stringify(batches).includes('acme.internal')
+    )
+    check(
+      'track: an api key in an error never reaches the wire',
+      !JSON.stringify(batches).includes('sk-abc123')
+    )
+
+    // Stop is a DIFFERENT fact from an error: one is usually the agent going
+    // wrong (our problem), the other the provider (theirs). Flattening them
+    // into `ok: false` is exactly what this split exists to prevent.
+    beginTurn('sess-stop')
+    const stopped = finishTurn('sess-stop', 'stopped')
+    check('metrics: a stopped turn is not an error', stopped?.summary.outcome === 'stopped')
+    check('metrics: ...but is still not ok', stopped?.summary.ok === false)
+    check('metrics: a stopped turn has no errorKind', stopped?.errorKind === undefined)
+
+    // 10c. Activation is once per install, EVER - it spans launches by
+    //      definition, so an in-memory guard would re-report on every restart
+    //      and turn a funnel into a launch counter.
+    await reset()
+    initTracking()
+    await settled(1)
+    batches = []
+    hits = 0
+    check('activation: the first report goes through', markActivation('first_prompt') === true)
+    check('activation: a second report is suppressed', markActivation('first_prompt') === false)
+    await flush()
+    await settled(1)
+    const activations = batches
+      .flatMap((b) => b.events ?? [])
+      .filter((e) => e.name === 'activation')
+    check('activation: exactly one event was sent', activations.length === 1)
+    check('activation: it names the milestone', activations[0]?.props?.milestone === 'first_prompt')
+    // The part that matters: it must survive a restart.
+    _resetTracking()
+    initTracking()
+    await settled(1)
+    check('activation: a restart does not re-report it', markActivation('first_prompt') === false)
+    check(
+      'activation: a DIFFERENT milestone still reports',
+      markActivation('first_turn_ok') === true
+    )
+
+    // 10d. Features are deduped per SESSION, not per install: "how many
+    //      sessions use subagents" is the question, so re-reporting across
+    //      sessions is correct and re-reporting within one is not.
+    batches = []
+    hits = 0
+    trackFeature('sess-a', 'subagent')
+    trackFeature('sess-a', 'subagent')
+    trackFeature('sess-a', 'subagent')
+    trackFeature('sess-b', 'subagent')
+    trackFeature('sess-a', 'mcp_server')
+    await flush()
+    await settled(1)
+    const features = batches.flatMap((b) => b.events ?? []).filter((e) => e.name === 'feature')
+    check(
+      'feature: one session reports a feature once',
+      features.length === 3,
+      String(features.length)
+    )
+    check(
+      'feature: a second session reports it again',
+      features.filter((e) => e.props?.feature === 'subagent').length === 2
     )
 
     // 11. The kill switch beats everything, including the stored preference.


### PR DESCRIPTION
## The problem

`turn_end` carried `{ ok, durationMs }`. That answers "did a turn happen" — which we already knew from `prompt` — and nothing else. So every question worth asking about how Roxy performs was unanswerable:

- Is a failure our agent going wrong, or the provider falling over?
- Do people run 2-step turns or 50-step ones?
- Which model families are people actually on?
- Does anyone use subagents? MCP? Skills?
- What does a turn cost?
- Of the people who install it, how many ever get a working answer?

This makes all of that measurable, and pairs with the richer [roxy.gg/stats](https://roxy.gg/stats).

## What's now reported

`turn_end` becomes the turn summary:

| Field | Why it earns its place |
|---|---|
| `outcome` | Splits `stopped` from `error` — see below |
| `steps`, `stepBucket` | Model round trips. "62% of turns run 5+ steps" is a sentence about a product |
| `tools`, `toolErrors` | How much of a turn is tool work, and how much of that fails |
| `subagents` | Delegation depth |
| `inputTokens`, `outputTokens`, `cacheReadTokens` | Real workload. Cache reads split out because they're most of the input and nearly free |
| `costUsd` | What a turn actually costs |
| `model` | Coarse FAMILY, never a model id |
| `retries` | Transient provider failures the harness silently rode out |
| `trimmed` | Whether context was dropped to fit |
| `errorKind` | One of 8 kinds, on failure only |

Plus four new events: `tool_use` (per distinct tool), `activation` (onboarding funnel), `provider_connect`, `feature` (capability adoption).

**Two worth calling out.** `outcome` splits `stopped` from `error`, which `ok:false` flattened — a user pressing Stop usually means the agent went off the rails (our problem), an error usually means the provider fell over (theirs), and one boolean reported them as the same event. `retries` counts failures that are invisible to the user by design, which is exactly why nothing else would ever show a provider quietly degrading.

## Why a collector, not `track()` calls in the loop

The obvious implementation calls `track()` at each interesting point in the harness. For one overnight run that's thousands of events from one user — and the rate limiter would then shed exactly the heaviest sessions, biasing every chart toward light usage.

Instead the harness accumulates into a per-turn collector (`services/turn-metrics.ts`) and emits **one** summary. A 200-step run costs the same ingest as a one-line question.

Subagent work attributes to `metricsId` (the turn the user started) rather than the subagent's own sub-session — otherwise the most expensive half of any delegating turn would vanish.

## Why every label goes through a classifier

Telemetry's privacy risk is not the counters, it's the strings. A model id, an MCP tool name, and an error message can each carry a private endpoint, an employer's internal service name, or a partial API key — and any of those is a near-unique fingerprint stamped on every event an install ever sends.

`shared/telemetry.ts` holds closed vocabularies, and every function in it is **total**: any input returns one of a fixed set of strings shipped in this repo.

```
claude-3-5-sonnet-20241022      → claude-sonnet
acme-support-bot-v3             → other
mcp__acme_internal_billing__q   → mcp
"quota exceeded at https://
 acme.internal/v1 (sk-abc123)"  → billing
```

The wire format **cannot** express the dangerous values — not by convention, but because no code path puts one there — and it fails safe, so an id nobody anticipated lands in `other` rather than leaking. The module is pure and dependency-free specifically so the pure-Node shared suite exercises it directly: the privacy guarantees are the part that most needs tests, so they're the part that must be trivially testable.

## Details worth a second look

- **Activation dedupes against the id file, not memory.** The milestones span launches by definition, so an in-memory guard would re-report on every restart and turn a funnel into a launch counter.
- **Features dedupe per session**, since the question is "how many sessions use subagents" — one enthusiastic user's 200 spawns is one signal.
- **The consent copy is updated in the same commit.** It promised "never ... or model", which the model family would have contradicted. A privacy promise that lags the code by even one release is worse than no promise.

## Tests

+58 shared, +36 app. **862 shared + 647 app checks pass.**

Verified by mutation rather than assumed: deleting the MCP collapse fails exactly the two checks that guard it. An API key planted in an error message is asserted absent from the payload. One check asserts every tool in the catalog is reportable, so a newly added tool can't silently report as `other` forever.

## Notes for the reviewer

- **The app suite's 60s watchdog is already marginal on a slow machine** — clean `main` times out ~3 runs in 4 on mine. These additions make that likelier. Verified green by raising the watchdog locally, then restoring it; worth raising separately rather than smuggling into this PR.
- **Server side needs to land too** — `roxy.gg` must accept the new event names, and its `MAX_PROP_KEYS` had to go from 12 → 24 (the richest event is now 16 keys; at 12 the summary would have arrived silently half-empty rather than rejected, with key order deciding which counters survived).
- Nothing here changes behaviour: every telemetry path is wrapped so it can't throw into a turn, and opt-out still drops everything.

Co-authored-by: Roxy <299891354+roxy-commits@users.noreply.github.com>
