### PR TITLE
copilot: route Responses-only GPT models off /chat/completions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.88",
+      "version": "0.0.89",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",

--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -45,6 +45,16 @@ import * as repo from '../db/repo'
 import { runTool } from './tools'
 import { boundToolOutput } from '../services/tool-output-store'
 import { modelCost } from '../services/models'
+import {
+  applyResponsesEvent,
+  isChatUnsupported,
+  isResponsesOnly,
+  markResponsesOnly,
+  toResponsesInput,
+  toResponsesReasoning,
+  toResponsesTools,
+  type ResponsesEvent
+} from '../services/responses'
 import { usageCost } from '../../shared/cost'
 import {
   ensureMcpConnected,
@@ -1868,7 +1878,7 @@ async function streamOnce(
     })
   }
 
-  const payload = JSON.stringify({
+  const chatPayload = JSON.stringify({
     model,
     messages,
     tools,
@@ -1881,17 +1891,48 @@ async function streamOnce(
     // that ignore it just don't send one — we fall back to an estimate below.
     stream_options: { include_usage: true }
   })
+  // Responses-only models (the GPT-5.x family on Copilot) reject
+  // /chat/completions outright, so they need the other wire: `input` instead of
+  // `messages`, flattened tool schemas, nested reasoning effort. Claude and the
+  // chat-completions GPT models are untouched by this.
+  const responsesPayload = (): string =>
+    JSON.stringify({
+      model,
+      input: toResponsesInput(messages),
+      tools: toResponsesTools(tools),
+      tool_choice: 'auto',
+      ...toResponsesReasoning(reasoning, effort),
+      stream: true
+    })
   // Resolve a FRESH endpoint + auth on EVERY model call. For GitHub Copilot this
   // re-exchanges the short-lived Copilot token as it nears expiry, so a long
   // agent loop (many tool calls) never sends a stale token — the root cause of
   // the intermittent "IDE token expired" 401.
+  let useResponses = isResponsesOnly(providerId, model)
   const send = async (): Promise<Response> => {
-    const { url, headers } = await openaiEndpoint(providerId, { vision })
-    return fetch(url, { method: 'POST', headers, body: payload, signal })
+    const { url, headers } = await openaiEndpoint(providerId, { vision, responses: useResponses })
+    const body = useResponses ? responsesPayload() : chatPayload
+    return fetch(url, { method: 'POST', headers, body, signal })
   }
   // On a 401 the token was rejected (expiry race / clock skew) — drop it, wait,
   // and retry a few times before surfacing the error.
-  const res = await withCopilotRetry(providerId === 'github-copilot', send, signal)
+  let res = await withCopilotRetry(providerId === 'github-copilot', send, signal)
+  // A Responses-only model answers /chat/completions with exactly one error:
+  // 400 unsupported_api_for_model. Remember it (so later calls in this loop go
+  // straight there) and replay the turn on the Responses API.
+  if (!res.ok && !useResponses) {
+    const errBody = await res.text().catch(() => '')
+    if (isChatUnsupported(res.status, errBody)) {
+      markResponsesOnly(providerId, model)
+      useResponses = true
+      res = await withCopilotRetry(providerId === 'github-copilot', send, signal)
+    } else {
+      throw new ModelHttpError(
+        res.status,
+        `Model request failed (${res.status}). ${errBody.slice(0, 300)}`
+      )
+    }
+  }
   if (!res.ok || !res.body) {
     const body = await res.text().catch(() => '')
     throw new ModelHttpError(
@@ -1926,10 +1967,39 @@ async function streamOnce(
     return { text, toolCalls: toolCalls.filter((c) => c.name), usage: usage ?? estimateUsage() }
   }
 
-  // Parse one SSE line. Returns true on the `[DONE]` sentinel so the caller can
-  // stop. Shared by the streaming loop and the final drain below so the last
-  // frame is handled identically whichever way the stream ends.
-  const handleLine = (line: string): boolean => {
+  // The Responses wire carries the same information as semantic events rather
+  // than delta chunks, so it accumulates into the same `text`/`calls`/`usage`
+  // and the agent loop below stays wire-agnostic.
+  const handleResponsesLine = (line: string): boolean => {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('data:')) return false
+    const raw = trimmed.slice(5).trim()
+    if (raw === '[DONE]') return true
+    let ev: ResponsesEvent
+    try {
+      ev = JSON.parse(raw) as ResponsesEvent
+    } catch {
+      return false
+    }
+    return applyResponsesEvent(ev, {
+      onText: (d) => {
+        text += d
+        onText(d)
+      },
+      onReasoning,
+      onToolCall: (i, patch) => {
+        if (!calls[i]) calls[i] = { id: '', name: '', args: '' }
+        if (patch.id) calls[i].id = patch.id
+        if (patch.name) calls[i].name = patch.name
+        if (patch.args) calls[i].args += patch.args
+      },
+      onUsage: (u) => {
+        usage = u
+      }
+    })
+  }
+
+  const handleChatLine = (line: string): boolean => {
     const trimmed = line.trim()
     if (!trimmed.startsWith('data:')) return false
     const payload = trimmed.slice(5).trim()
@@ -1968,6 +2038,13 @@ async function streamOnce(
     }
     return false
   }
+
+  // Parse one SSE line on whichever wire this model speaks. Returns true on the
+  // terminal event so the caller can stop. Shared by the streaming loop and the
+  // final drain below so the last frame is handled identically whichever way the
+  // stream ends.
+  const handleLine = (line: string): boolean =>
+    useResponses ? handleResponsesLine(line) : handleChatLine(line)
 
   for (;;) {
     const { done, value } = await reader.read()

--- a/src/main/services/llm.ts
+++ b/src/main/services/llm.ts
@@ -14,9 +14,19 @@ import type { ChatMessage } from '../../shared/api'
 import type { ReasoningEffort } from '../../shared/types'
 import { isCliProxyProvider } from '../../shared/cliproxy'
 import { ensureRunning as ensureCliProxy, localApiKey as cliProxyKey } from './cliproxy'
+import {
+  applyResponsesEvent,
+  isChatUnsupported,
+  isResponsesOnly,
+  markResponsesOnly,
+  toResponsesInput,
+  toResponsesReasoning,
+  type ResponsesEvent
+} from './responses'
 
 const COPILOT_TOKEN_URL = 'https://api.github.com/copilot_internal/v2/token'
 const COPILOT_CHAT_URL = 'https://api.githubcopilot.com/chat/completions'
+const COPILOT_RESPONSES_URL = 'https://api.githubcopilot.com/responses'
 export const COPILOT_EDITOR_HEADERS = {
   'User-Agent': 'GitHubCopilotChat/0.26.7',
   'Editor-Version': 'vscode/1.99.3',
@@ -197,13 +207,21 @@ async function resolveBaseUrl(providerId: string, stored: string | undefined): P
   return live.replace(/\/+$/, '')
 }
 
-/** Resolve the OpenAI-compatible chat endpoint + headers (Copilot or openai-chat). */
+/**
+ * Resolve the OpenAI-compatible chat endpoint + headers (Copilot or openai-chat).
+ *
+ * `responses: true` targets the Responses API instead, for the models that are
+ * only served there (see services/responses.ts).
+ */
 export async function openaiEndpoint(
   providerId: string,
-  opts: { vision?: boolean } = {}
+  opts: { vision?: boolean; responses?: boolean } = {}
 ): Promise<{ url: string; headers: Record<string, string> }> {
   if (providerId === 'github-copilot') {
-    return { url: COPILOT_CHAT_URL, headers: copilotHeaders(await getCopilotToken(), opts.vision) }
+    return {
+      url: opts.responses ? COPILOT_RESPONSES_URL : COPILOT_CHAT_URL,
+      headers: copilotHeaders(await getCopilotToken(), opts.vision)
+    }
   }
   const provider = repo.listConnectedProviders().find((p) => p.id === providerId)
   if (!provider) throw new Error(`Provider "${providerId}" is not connected.`)
@@ -214,7 +232,7 @@ export async function openaiEndpoint(
     : repo.getProviderToken(providerId)
   const base = await resolveBaseUrl(providerId, provider.baseURL)
   return {
-    url: `${base}/chat/completions`,
+    url: opts.responses ? `${base}/responses` : `${base}/chat/completions`,
     headers: {
       'Content-Type': 'application/json',
       ...(key ? { Authorization: `Bearer ${key}` } : {})
@@ -309,8 +327,30 @@ export async function streamChat(opts: StreamChatOptions): Promise<void> {
         body,
         signal
       })
-    const res = await withCopilotRetry(true, send, signal)
-    return readSse(res, (j) => emitOpenAi(j, onDelta))
+    // Responses-only models (GPT-5.x) 400 on /chat/completions. Skip straight to
+    // the Responses API once we've learned that for this model; otherwise try
+    // chat and fall back on that specific error. Claude stays on chat throughout.
+    if (!isResponsesOnly(providerId, model)) {
+      const res = await withCopilotRetry(true, send, signal)
+      if (res.ok) return readSse(res, (j) => emitOpenAi(j, onDelta))
+      const errBody = await res.text().catch(() => '')
+      if (!isChatUnsupported(res.status, errBody)) {
+        throw new ModelHttpError(
+          res.status,
+          `Model request failed (${res.status}). ${errBody.slice(0, 300)}`
+        )
+      }
+      markResponsesOnly(providerId, model)
+    }
+    return streamCopilotResponses({
+      model,
+      messages,
+      vision,
+      signal,
+      onDelta,
+      reasoning,
+      reasoningEffort
+    })
   }
 
   const provider = repo.listConnectedProviders().find((p) => p.id === providerId)
@@ -382,6 +422,79 @@ export async function streamChat(opts: StreamChatOptions): Promise<void> {
       })
       return readSse(res, (j) => emitOpenAi(j, onDelta))
     }
+  }
+}
+
+/**
+ * Stream a plain chat turn from Copilot's Responses API.
+ *
+ * Same job as the chat branch above, different wire: `input` instead of
+ * `messages`, nested `reasoning.effort`, and semantic SSE events.
+ */
+async function streamCopilotResponses(opts: {
+  model: string
+  messages: ChatMessage[]
+  vision: boolean
+  signal: AbortSignal
+  onDelta: (t: string) => void
+  reasoning?: boolean
+  reasoningEffort?: ReasoningEffort
+}): Promise<void> {
+  const body = JSON.stringify({
+    model: opts.model,
+    input: toResponsesInput(
+      opts.messages.map((m) => ({ role: m.role, content: openAiContent(m) }))
+    ),
+    ...toResponsesReasoning(opts.reasoning, opts.reasoningEffort),
+    stream: true
+  })
+  const send = async (): Promise<Response> =>
+    fetch(COPILOT_RESPONSES_URL, {
+      method: 'POST',
+      headers: copilotHeaders(await getCopilotToken(), opts.vision),
+      body,
+      signal: opts.signal
+    })
+  const res = await withCopilotRetry(true, send, opts.signal)
+  return readResponsesSse(res, opts.onDelta)
+}
+
+/** Read a Responses SSE body, forwarding text deltas. */
+async function readResponsesSse(res: Response, onDelta: (t: string) => void): Promise<void> {
+  if (!res.ok || !res.body) {
+    const body = await res.text().catch(() => '')
+    throw new ModelHttpError(
+      res.status,
+      `Model request failed (${res.status}). ${body.slice(0, 300)}`
+    )
+  }
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  const handleLine = (line: string): boolean => {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('data:')) return false
+    const payload = trimmed.slice(5).trim()
+    if (payload === '[DONE]') return true
+    try {
+      return applyResponsesEvent(JSON.parse(payload) as ResponsesEvent, { onText: onDelta })
+    } catch {
+      return false
+    }
+  }
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split('\n')
+    buffer = lines.pop() ?? ''
+    for (const line of lines) {
+      if (handleLine(line)) return
+    }
+  }
+  buffer += decoder.decode()
+  for (const line of buffer.split('\n')) {
+    if (handleLine(line)) return
   }
 }
 

--- a/src/main/services/responses.ts
+++ b/src/main/services/responses.ts
@@ -1,0 +1,223 @@
+/**
+ * OpenAI **Responses API** translation.
+ *
+ * Some models are served ONLY on `/responses` and reject `/chat/completions`
+ * with a 400 `unsupported_api_for_model` - notably the GPT-5.x family on GitHub
+ * Copilot (`gpt-5.6-sol` and friends). Claude on Copilot is unaffected: it is a
+ * chat-completions model and keeps the existing path.
+ *
+ * Rather than pattern-matching model names (the `gpt-5.6-sol` naming already
+ * broke the `gpt-5` prefix assumption, and the next model will break whatever we
+ * write), detection is DYNAMIC: the caller tries chat, and on that specific 400
+ * records the model here and retries on `/responses`. The result is cached per
+ * provider+model, so the fallback costs one wasted round-trip per model per
+ * process and nothing thereafter.
+ *
+ * This module owns the wire differences, which are not just a URL swap:
+ * `messages` -> `input`, flattened tool schemas, `reasoning_effort` -> nested
+ * `reasoning.effort`, and a semantic-event SSE stream instead of delta chunks.
+ */
+import type { OpenAiContentPart } from './llm'
+import type { ReasoningEffort } from '../../shared/types'
+
+/** The API-code Copilot/OpenAI return when a model is Responses-only. */
+const UNSUPPORTED_API = 'unsupported_api_for_model'
+
+/**
+ * True when a failed response says the model cannot be served on
+ * `/chat/completions`. Deliberately narrow: only this exact code triggers the
+ * fallback, so an unrelated 400 (bad request body, content filter) still
+ * surfaces to the user instead of being retried on the wrong endpoint.
+ */
+export function isChatUnsupported(status: number, body: string): boolean {
+  return status === 400 && body.includes(UNSUPPORTED_API)
+}
+
+/** provider+model pairs known to require `/responses`. Process-lifetime cache. */
+const responsesOnly = new Set<string>()
+
+const key = (providerId: string, model: string): string => `${providerId}:${model}`
+
+export function markResponsesOnly(providerId: string, model: string): void {
+  responsesOnly.add(key(providerId, model))
+}
+
+export function isResponsesOnly(providerId: string, model: string): boolean {
+  return responsesOnly.has(key(providerId, model))
+}
+
+// ---- Request translation -----------------------------------------------------
+
+/** The OpenAI-chat message shape both callers already build. */
+export interface ChatLikeMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content: string | OpenAiContentPart[] | null
+  tool_calls?: { id: string; type: 'function'; function: { name: string; arguments: string } }[]
+  tool_call_id?: string
+}
+
+/** A chat-style tool schema: `{ type: 'function', function: {...} }`. */
+export interface ChatToolSchema {
+  type: 'function'
+  function: Record<string, unknown>
+}
+
+/** Flatten one content value to plain text (assistant items take no parts). */
+function flattenText(content: string | OpenAiContentPart[] | null): string {
+  if (!content) return ''
+  if (typeof content === 'string') return content
+  return content
+    .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+    .map((p) => p.text)
+    .join('')
+}
+
+/** Responses input content: `input_text` / `input_image` parts (image_url is a bare string). */
+function inputContent(content: string | OpenAiContentPart[] | null): unknown {
+  if (!content) return ''
+  if (typeof content === 'string') return content
+  return content.map((p) =>
+    p.type === 'text'
+      ? { type: 'input_text', text: p.text }
+      : { type: 'input_image', image_url: p.image_url.url }
+  )
+}
+
+/**
+ * Convert chat `messages` into Responses `input` items.
+ *
+ * Tool calls and their results are separate top-level items here rather than
+ * fields on an assistant message, so an assistant turn that both spoke and
+ * called tools expands into several items.
+ */
+export function toResponsesInput(messages: ChatLikeMessage[]): unknown[] {
+  const input: unknown[] = []
+  for (const m of messages) {
+    if (m.role === 'tool') {
+      input.push({
+        type: 'function_call_output',
+        call_id: m.tool_call_id ?? '',
+        output: flattenText(m.content)
+      })
+      continue
+    }
+    if (m.role === 'assistant') {
+      const text = flattenText(m.content)
+      if (text) input.push({ role: 'assistant', content: text })
+      for (const tc of m.tool_calls ?? []) {
+        input.push({
+          type: 'function_call',
+          call_id: tc.id,
+          name: tc.function.name,
+          arguments: tc.function.arguments
+        })
+      }
+      continue
+    }
+    input.push({ role: m.role, content: inputContent(m.content) })
+  }
+  return input
+}
+
+/** Flatten chat tool schemas into the shape Responses expects (no `function` wrapper). */
+export function toResponsesTools(tools: ChatToolSchema[]): unknown[] {
+  return tools.map((t) => ({ type: 'function', ...t.function }))
+}
+
+/** Responses nests effort under `reasoning` instead of a flat `reasoning_effort`. */
+export function toResponsesReasoning(
+  reasoning?: boolean,
+  effort?: ReasoningEffort
+): { reasoning?: { effort: ReasoningEffort } } {
+  if (!reasoning || !effort) return {}
+  return { reasoning: { effort } }
+}
+
+// ---- Stream translation ------------------------------------------------------
+
+/** A Responses SSE event (only the fields we consume). */
+export interface ResponsesEvent {
+  type?: string
+  delta?: string
+  output_index?: number
+  item?: { type?: string; call_id?: string; name?: string; arguments?: string }
+  response?: {
+    usage?: {
+      input_tokens?: number
+      output_tokens?: number
+      input_tokens_details?: { cached_tokens?: number }
+      output_tokens_details?: { reasoning_tokens?: number }
+    }
+  }
+  message?: string
+}
+
+export interface ResponsesUsage {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  reasoning: number
+  estimated: false
+}
+
+export interface ResponsesHandlers {
+  onText: (delta: string) => void
+  onReasoning?: (delta: string) => void
+  /** Called as tool-call items arrive; `index` is the item's output_index. */
+  onToolCall?: (index: number, patch: { id?: string; name?: string; args?: string }) => void
+  onUsage?: (usage: ResponsesUsage) => void
+}
+
+/**
+ * Apply one Responses event to the handlers. Returns true on a terminal event so
+ * the reader can stop (the stream has no `[DONE]` sentinel of its own).
+ */
+export function applyResponsesEvent(ev: ResponsesEvent, h: ResponsesHandlers): boolean {
+  switch (ev.type) {
+    case 'response.output_text.delta':
+      if (ev.delta) h.onText(ev.delta)
+      return false
+    // Reasoning arrives as summary text on current models and as raw reasoning
+    // text on others; both are surfaced the same way.
+    case 'response.reasoning_summary_text.delta':
+    case 'response.reasoning_text.delta':
+      if (ev.delta) h.onReasoning?.(ev.delta)
+      return false
+    case 'response.output_item.added':
+      if (ev.item?.type === 'function_call') {
+        h.onToolCall?.(ev.output_index ?? 0, {
+          id: ev.item.call_id,
+          name: ev.item.name,
+          args: ev.item.arguments
+        })
+      }
+      return false
+    case 'response.function_call_arguments.delta':
+      if (ev.delta) h.onToolCall?.(ev.output_index ?? 0, { args: ev.delta })
+      return false
+    case 'response.completed': {
+      const u = ev.response?.usage
+      if (u) {
+        const cached = u.input_tokens_details?.cached_tokens ?? 0
+        h.onUsage?.({
+          // `input_tokens` INCLUDES cached tokens, so subtract them out to match
+          // how the chat path reports fresh vs. cached input.
+          input: Math.max(0, (u.input_tokens ?? 0) - cached),
+          output: u.output_tokens ?? 0,
+          cacheRead: cached,
+          cacheWrite: 0,
+          reasoning: u.output_tokens_details?.reasoning_tokens ?? 0,
+          estimated: false
+        })
+      }
+      return true
+    }
+    case 'response.failed':
+    case 'response.incomplete':
+    case 'error':
+      return true
+    default:
+      return false
+  }
+}

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -284,6 +284,14 @@ import {
   hasUsableItems,
   type ClickContext
 } from '../src/shared/context-menu'
+import {
+  applyResponsesEvent,
+  isChatUnsupported,
+  toResponsesInput,
+  toResponsesReasoning,
+  toResponsesTools,
+  type ResponsesEvent
+} from '../src/main/services/responses'
 
 let pass = 0
 const fails: string[] = []
@@ -4919,6 +4927,147 @@ async function main(): Promise<void> {
     }
   }
   check('clipboard menu: no enabled row can ever be a no-op', dishonest === 0, String(dishonest))
+
+  // ---- Responses API translation (GPT-5.x on Copilot) ----
+  // Only the exact unsupported_api_for_model 400 may flip us to /responses; any
+  // other failure must surface, or a bad body silently retries on the wrong API.
+  check(
+    'responses: detects unsupported_api_for_model',
+    isChatUnsupported(
+      400,
+      '{"error":{"message":"model \\"gpt-5.6-sol\\" is not accessible via the /chat/completions endpoint","code":"unsupported_api_for_model"}}'
+    )
+  )
+  check(
+    'responses: unrelated 400 does not trigger fallback',
+    !isChatUnsupported(400, '{"error":{"message":"bad request","code":"invalid_request_error"}}')
+  )
+  check(
+    'responses: non-400 does not trigger fallback',
+    !isChatUnsupported(500, 'unsupported_api_for_model')
+  )
+
+  // A tool call + its result must survive the round trip as separate items,
+  // keeping call_id paired - that pairing is what Build mode runs on.
+  const respRoundTrip = toResponsesInput([
+    { role: 'system', content: 'be terse' },
+    { role: 'user', content: 'hi' },
+    {
+      role: 'assistant',
+      content: 'checking',
+      tool_calls: [
+        { id: 'call-1', type: 'function', function: { name: 'read', arguments: '{"p":"a.ts"}' } }
+      ]
+    },
+    { role: 'tool', tool_call_id: 'call-1', content: 'file body' }
+  ])
+  check('responses: input item count', respRoundTrip.length === 5, String(respRoundTrip.length))
+  const fc = respRoundTrip[3] as { type?: string; call_id?: string; name?: string }
+  check(
+    'responses: tool call becomes function_call item',
+    fc.type === 'function_call' && fc.call_id === 'call-1' && fc.name === 'read'
+  )
+  const fo = respRoundTrip[4] as { type?: string; call_id?: string; output?: string }
+  check(
+    'responses: tool result becomes function_call_output with matching id',
+    fo.type === 'function_call_output' && fo.call_id === 'call-1' && fo.output === 'file body'
+  )
+
+  // Images use input_image with a bare url string, not chat's nested image_url.
+  const imgInput = toResponsesInput([
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'what is this' },
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,AAA' } }
+      ]
+    }
+  ])
+  const parts = (imgInput[0] as { content?: { type?: string; image_url?: string }[] }).content ?? []
+  check(
+    'responses: image becomes input_image with flat url',
+    parts[0]?.type === 'input_text' &&
+      parts[1]?.type === 'input_image' &&
+      parts[1]?.image_url === 'data:image/png;base64,AAA'
+  )
+
+  // Tools flatten (no nested `function`) and effort nests. Both are 400s if wrong.
+  const flatTools = toResponsesTools([
+    { type: 'function', function: { name: 'bash', description: 'run', parameters: {} } }
+  ]) as { type?: string; name?: string; function?: unknown }[]
+  check(
+    'responses: tool schema flattened',
+    flatTools[0].type === 'function' &&
+      flatTools[0].name === 'bash' &&
+      flatTools[0].function === undefined
+  )
+  check(
+    'responses: reasoning effort nests',
+    toResponsesReasoning(true, 'high').reasoning?.effort === 'high'
+  )
+  check('responses: no reasoning when unsupported', !toResponsesReasoning(false, 'high').reasoning)
+
+  // Replay a realistic event stream and assert we reconstruct text, the tool
+  // call, and usage - and that cached input tokens are not double-counted.
+  let rText = ''
+  const rCalls: { id: string; name: string; args: string }[] = []
+  let rUsage: { input: number; cacheRead: number; output: number } | null = null
+  const events: ResponsesEvent[] = [
+    { type: 'response.created' },
+    { type: 'response.output_text.delta', delta: 'Hel' },
+    { type: 'response.output_text.delta', delta: 'lo' },
+    {
+      type: 'response.output_item.added',
+      output_index: 0,
+      item: { type: 'function_call', call_id: 'c1', name: 'bash', arguments: '' }
+    },
+    { type: 'response.function_call_arguments.delta', output_index: 0, delta: '{"cmd"' },
+    { type: 'response.function_call_arguments.delta', output_index: 0, delta: ':"ls"}' },
+    {
+      type: 'response.completed',
+      response: {
+        usage: { input_tokens: 100, output_tokens: 20, input_tokens_details: { cached_tokens: 30 } }
+      }
+    }
+  ]
+  let terminated = false
+  for (const ev of events) {
+    terminated = applyResponsesEvent(ev, {
+      onText: (d) => {
+        rText += d
+      },
+      onToolCall: (i, p) => {
+        if (!rCalls[i]) rCalls[i] = { id: '', name: '', args: '' }
+        if (p.id) rCalls[i].id = p.id
+        if (p.name) rCalls[i].name = p.name
+        if (p.args) rCalls[i].args += p.args
+      },
+      onUsage: (u) => {
+        rUsage = u
+      }
+    })
+  }
+  check('responses: text deltas accumulate', rText === 'Hello', rText)
+  check(
+    'responses: tool call reassembled',
+    rCalls[0]?.id === 'c1' && rCalls[0]?.name === 'bash' && rCalls[0]?.args === '{"cmd":"ls"}',
+    JSON.stringify(rCalls[0])
+  )
+  check(
+    'responses: usage excludes cached from input',
+    rUsage?.input === 70 && rUsage?.cacheRead === 30 && rUsage?.output === 20,
+    JSON.stringify(rUsage)
+  )
+  check('responses: response.completed terminates the stream', terminated)
+  check(
+    'responses: failure events terminate the stream',
+    applyResponsesEvent({ type: 'response.failed' }, { onText: () => {} }) &&
+      applyResponsesEvent({ type: 'error' }, { onText: () => {} })
+  )
+  check(
+    'responses: unknown events are ignored',
+    !applyResponsesEvent({ type: 'response.in_progress' }, { onText: () => {} })
+  )
 
   if (fails.length) {
     console.error(`\nSHARED FAILED \u2014 ${fails.length} failing: ${fails.join(', ')}`)


### PR DESCRIPTION
## Problem

Selecting a GPT model on GitHub Copilot fails immediately:

```
Model request failed (400). {"error":{"message":"model \"gpt-5.6-sol\" is not
accessible via the /chat/completions endpoint","code":"unsupported_api_for_model"}}
```

The GPT-5.x family is served **only** on `/responses`, but every Copilot call was hardcoded to `/chat/completions` (`llm.ts:19`, `llm.ts:206`, `llm.ts:306`, and `agent.ts` via `openaiEndpoint`). Claude on Copilot was never affected — it *is* a chat-completions model, which is why only the GPT models broke.

The `responsesForGpt5` seed flag (`shared/providers.ts:429`) has documented this need since it was added, but nothing ever read it — the implementation never landed.

## Approach

**Dynamic detection instead of the flag.** I didn't wire up `responsesForGpt5`, and I didn't match on model names: `gpt-5.6-sol` already breaks the `gpt-5` prefix the flag was named for, and the next model would break whatever pattern I wrote. Instead, on the specific `unsupported_api_for_model` 400 the model is recorded and the turn replays on `/responses`, cached per provider+model for the process lifetime.

- One wasted round-trip per model per process, then nothing.
- New Copilot models work with no code change — which matters because the model list comes from the `models.dev` catalog, so GitHub can add a Responses-only model at any time.
- The check is deliberately narrow (`status === 400 && body.includes('unsupported_api_for_model')`), so an unrelated 400 still surfaces instead of silently retrying on the wrong endpoint.

**New `src/main/services/responses.ts`** owns the wire differences, which are not just a URL swap:

| | chat/completions | responses |
|---|---|---|
| messages | `messages` | `input` (tool calls/results become separate items) |
| tools | `{type, function:{…}}` | flattened |
| effort | `reasoning_effort` | nested `reasoning.effort` |
| stream | delta chunks | semantic events |

Both callers go through it, so **Build mode keeps tool calling** — that's where the tool-schema flattening and `call_id` pairing matter.

## Verification

I confirmed the schema against docs *before* writing the SSE parsing, since guessing event names would turn a clean 400 into silent empty replies:

- GitHub docs: GPT-5.6 Sol/Luna/Terra are GA on Copilot.
- OpenAI streaming docs: `response.output_text.delta`, `response.function_call_arguments.delta`, `response.completed`.

`typecheck` (node + web) clean, prettier clean, **878 smoke checks pass** including 15 new ones covering the fallback trigger (and the two negative cases), the tool-call round-trip with `call_id` pairing, image parts, and usage accounting — cached input tokens are subtracted so they aren't double-counted, matching the chat path.

## Still worth a manual check

- **Not exercised against the live API.** Verification above is typecheck + unit level. Worth one real `gpt-5.6-sol` message in chat *and* one tool-using Build turn.
- **Reasoning-effort clamping unchanged.** `FULL_EFFORT_LADDER_PROVIDERS` (`llm.ts:246`) still lets Copilot send `xhigh`/`max`. Correct for Claude, but untested at the top end on the GPT Responses endpoint. If `max` 400s, that set is where to look.
