### PR TITLE
mcp: edit a server's raw JSON config from the UI

### DIFF
--- a/src/renderer/src/components/McpServers.tsx
+++ b/src/renderer/src/components/McpServers.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useState } from 'react'
-import { Plug, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { Braces, Plug, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import type { McpServerView } from '@shared/api'
-import type { McpServerConfig } from '@shared/mcp'
+import {
+  parseMcpJson,
+  serializeServerConfig,
+  type McpServerConfig,
+  type ParsedMcpJson
+} from '@shared/mcp'
 import { api } from '../lib/api'
-import { Button, Input, Switch, Badge } from './ui'
+import { Button, Input, Switch, Badge, Textarea } from './ui'
 import { ConfigBackup } from './ConfigBackup'
 
 function configSummary(config: McpServerConfig): string {
@@ -16,6 +21,17 @@ const MCP_STATUS_STYLES: Record<McpServerView['status'], string> = {
   disabled: 'text-text-muted'
 }
 
+/** Sizes the JSON editor to its content so a long config isn't read through a slot. */
+function jsonRows(text: string): number {
+  return Math.min(24, Math.max(6, text.split('\n').length + 1))
+}
+
+const JSON_PLACEHOLDER = `{
+  "type": "local",
+  "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path"],
+  "environment": { "API_KEY": "…" }
+}`
+
 /** List/add/toggle/reconnect/remove external MCP tool servers. Shared by Settings + the MCP page. */
 export function McpServers({ showBackup = false }: { showBackup?: boolean } = {}): JSX.Element {
   const [servers, setServers] = useState<McpServerView[]>([])
@@ -23,9 +39,12 @@ export function McpServers({ showBackup = false }: { showBackup?: boolean } = {}
   const [busy, setBusy] = useState<string | null>(null)
   const [showAdd, setShowAdd] = useState(false)
   const [name, setName] = useState('')
-  const [kind, setKind] = useState<'local' | 'remote'>('local')
+  const [kind, setKind] = useState<'local' | 'remote' | 'json'>('local')
   const [value, setValue] = useState('')
+  const [json, setJson] = useState('')
   const [formErr, setFormErr] = useState('')
+  /** id of the server whose raw JSON is open in the editor (only one at a time). */
+  const [editing, setEditing] = useState<string | null>(null)
 
   const reload = async (): Promise<void> => {
     setServers(await api.mcp.list())
@@ -58,47 +77,103 @@ export function McpServers({ showBackup = false }: { showBackup?: boolean } = {}
     setBusy(id)
     try {
       setServers(await api.mcp.remove(id))
+      if (editing === id) setEditing(null)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  /**
+   * Persist an edited raw config. A pasted `{ "<name>": … }` map whose name
+   * differs from the row's is treated as a rename (write the new entry, drop the
+   * old one) rather than silently ignored — but never one that lands on another
+   * server, since upsert-then-remove would clobber the one already there.
+   *
+   * Resolves to a message for the editor to show, or null when the save stuck.
+   */
+  const saveRaw = async (server: McpServerView, parsed: ParsedMcpJson): Promise<string | null> => {
+    const nextId = parsed.id?.trim() || server.id
+    const enabled = parsed.enabled ?? server.enabled
+    if (nextId !== server.id && servers.some((s) => s.id === nextId)) {
+      return `Renaming to "${nextId}" would overwrite another server. Pick a different name.`
+    }
+    setBusy(server.id)
+    try {
+      await api.mcp.upsert({ id: nextId, config: parsed.config, enabled })
+      if (nextId !== server.id) await api.mcp.remove(server.id)
+      // Reconnect so the edit is validated against the real server right away —
+      // debugging a config whose result you can't see is the problem being fixed.
+      setServers(enabled ? await api.mcp.reconnect(nextId) : await api.mcp.list())
+      setEditing(null)
+      return null
+    } catch (e) {
+      // A rejected upsert (the main process refusing the config) has to surface
+      // here rather than vanish; showing failures is this editor's whole job.
+      await reload()
+      return e instanceof Error ? e.message : 'Failed to save the config.'
     } finally {
       setBusy(null)
     }
   }
 
   const submit = async (): Promise<void> => {
-    const id = name.trim()
-    if (!id) {
-      setFormErr('Enter a name')
-      return
+    let id = name.trim()
+    let config: McpServerConfig
+    let enabled = true
+
+    if (kind === 'json') {
+      const parsed = parseMcpJson(json)
+      if (!parsed.ok) {
+        setFormErr(parsed.error)
+        return
+      }
+      // A named map carries its own name, so pasting a README snippet needs no typing.
+      id = id || (parsed.value.id ?? '')
+      config = parsed.value.config
+      enabled = parsed.value.enabled ?? true
+      if (!id) {
+        setFormErr('Enter a name — the pasted JSON is a bare config, so it has none.')
+        return
+      }
+    } else {
+      if (!id) {
+        setFormErr('Enter a name')
+        return
+      }
+      if (kind === 'remote') {
+        const url = value.trim()
+        if (!/^https?:\/\//i.test(url)) {
+          setFormErr('Enter a valid http(s) URL')
+          return
+        }
+        config = { type: 'remote', url }
+      } else {
+        const argv = value.trim().split(/\s+/).filter(Boolean)
+        if (!argv.length) {
+          setFormErr('Enter a command')
+          return
+        }
+        config = { type: 'local', command: argv }
+      }
     }
+
     if (servers.some((s) => s.id === id)) {
       setFormErr('A server with that name already exists')
       return
     }
-    let config: McpServerConfig
-    if (kind === 'remote') {
-      const url = value.trim()
-      if (!/^https?:\/\//i.test(url)) {
-        setFormErr('Enter a valid http(s) URL')
-        return
-      }
-      config = { type: 'remote', url }
-    } else {
-      const argv = value.trim().split(/\s+/).filter(Boolean)
-      if (!argv.length) {
-        setFormErr('Enter a command')
-        return
-      }
-      config = { type: 'local', command: argv }
-    }
     setBusy('__add__')
     setFormErr('')
     try {
-      await api.mcp.upsert({ id, config, enabled: true })
+      await api.mcp.upsert({ id, config, enabled })
       // Connect immediately so the user sees the live status / any error.
-      setServers(await api.mcp.reconnect(id))
+      setServers(enabled ? await api.mcp.reconnect(id) : await api.mcp.list())
       setShowAdd(false)
       setName('')
       setValue('')
+      setJson('')
       setKind('local')
+    } catch (e) {
+      setFormErr(e instanceof Error ? e.message : 'Failed to add the server.')
     } finally {
       setBusy(null)
     }
@@ -118,55 +193,79 @@ export function McpServers({ showBackup = false }: { showBackup?: boolean } = {}
         servers.map((s) => (
           <div
             key={s.id}
-            className="flex items-center gap-3 sq sq-xl sq-ring rounded-xl border border-border bg-surface p-3.5"
+            className="flex flex-col sq sq-xl sq-ring rounded-xl border border-border bg-surface p-3.5"
           >
-            <div className="flex h-8 w-8 items-center justify-center sq sq-lg sq-ring rounded-lg border border-border bg-surface-2">
-              <Plug className="h-4 w-4 text-text-muted" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="truncate text-sm font-medium text-text">{s.id}</span>
-                <Badge className={MCP_STATUS_STYLES[s.status]}>
-                  {s.status === 'connected'
-                    ? `${s.tools.length} tool${s.tools.length === 1 ? '' : 's'}`
-                    : s.status}
-                </Badge>
+            <div className="flex items-center gap-3">
+              <div className="flex h-8 w-8 items-center justify-center sq sq-lg sq-ring rounded-lg border border-border bg-surface-2">
+                <Plug className="h-4 w-4 text-text-muted" />
               </div>
-              <p
-                className="mt-0.5 truncate text-xs text-text-subtle"
-                title={configSummary(s.config)}
-              >
-                {configSummary(s.config)}
-              </p>
-              {s.status === 'error' && s.error && (
-                <p className="mt-0.5 truncate text-xs text-danger" title={s.error}>
-                  {s.error}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium text-text">{s.id}</span>
+                  <Badge className={MCP_STATUS_STYLES[s.status]}>
+                    {s.status === 'connected'
+                      ? `${s.tools.length} tool${s.tools.length === 1 ? '' : 's'}`
+                      : s.status}
+                  </Badge>
+                </div>
+                <p
+                  className="mt-0.5 truncate text-xs text-text-subtle"
+                  title={configSummary(s.config)}
+                >
+                  {configSummary(s.config)}
                 </p>
-              )}
+                {s.status === 'error' && s.error && (
+                  <p className="mt-0.5 truncate text-xs text-danger" title={s.error}>
+                    {s.error}
+                  </p>
+                )}
+              </div>
+              <Switch
+                checked={s.enabled}
+                disabled={busy === s.id}
+                onChange={(v) => void toggle(s.id, v)}
+              />
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={busy === s.id}
+                onClick={() => setEditing((cur) => (cur === s.id ? null : s.id))}
+                title="Edit raw JSON"
+                aria-expanded={editing === s.id}
+                className={editing === s.id ? 'text-text' : undefined}
+              >
+                <Braces className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={busy === s.id || !s.enabled}
+                onClick={() => void reconnect(s.id)}
+                title="Reconnect"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={busy === s.id}
+                onClick={() => void remove(s.id)}
+                title="Remove"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
             </div>
-            <Switch
-              checked={s.enabled}
-              disabled={busy === s.id}
-              onChange={(v) => void toggle(s.id, v)}
-            />
-            <Button
-              size="sm"
-              variant="ghost"
-              disabled={busy === s.id || !s.enabled}
-              onClick={() => void reconnect(s.id)}
-              title="Reconnect"
-            >
-              <RefreshCw className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              disabled={busy === s.id}
-              onClick={() => void remove(s.id)}
-              title="Remove"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
+            {editing === s.id && (
+              // Keyed by the stored config so an external change (import, the mcp
+              // tool) reseeds the draft instead of leaving stale text on screen.
+              <RawConfigEditor
+                key={configSummary(s.config)}
+                server={s}
+                busy={busy === s.id}
+                onCancel={() => setEditing(null)}
+                onSave={(parsed) => saveRaw(s, parsed)}
+              />
+            )}
           </div>
         ))
       )}
@@ -177,31 +276,52 @@ export function McpServers({ showBackup = false }: { showBackup?: boolean } = {}
             <Input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="name (e.g. filesystem)"
+              placeholder={
+                kind === 'json' ? 'name (optional if in JSON)' : 'name (e.g. filesystem)'
+              }
               className="sm:w-48"
               spellCheck={false}
               autoComplete="off"
             />
             <select
               value={kind}
-              onChange={(e) => setKind(e.target.value as 'local' | 'remote')}
+              onChange={(e) => {
+                setKind(e.target.value as 'local' | 'remote' | 'json')
+                setFormErr('')
+              }}
               className="h-9 sq sq-lg sq-ring rounded-lg border border-border bg-surface-2 px-2 text-sm text-text outline-none"
             >
               <option value="local">local (stdio)</option>
               <option value="remote">remote (http)</option>
+              <option value="json">raw JSON</option>
             </select>
           </div>
-          <Input
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            placeholder={
-              kind === 'remote'
-                ? 'https://example.com/mcp'
-                : 'npx -y @modelcontextprotocol/server-filesystem /path'
-            }
-            spellCheck={false}
-            autoComplete="off"
-          />
+          {kind === 'json' ? (
+            <Textarea
+              value={json}
+              onChange={(e) => {
+                setJson(e.target.value)
+                setFormErr('')
+              }}
+              rows={jsonRows(json || JSON_PLACEHOLDER)}
+              placeholder={JSON_PLACEHOLDER}
+              className="font-mono text-xs leading-relaxed"
+              spellCheck={false}
+              autoComplete="off"
+            />
+          ) : (
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={
+                kind === 'remote'
+                  ? 'https://example.com/mcp'
+                  : 'npx -y @modelcontextprotocol/server-filesystem /path'
+              }
+              spellCheck={false}
+              autoComplete="off"
+            />
+          )}
           {formErr && <p className="text-xs text-danger">{formErr}</p>}
           <div className="flex items-center gap-2">
             <Button variant="primary" disabled={busy === '__add__'} onClick={() => void submit()}>
@@ -217,7 +337,9 @@ export function McpServers({ showBackup = false }: { showBackup?: boolean } = {}
               Cancel
             </Button>
             <span className="ml-auto text-[11px] text-text-subtle">
-              Advanced (env, headers): use <code>.roxy/mcp.json</code>
+              {kind === 'json'
+                ? 'Takes a bare config or an mcpServers / servers wrapper.'
+                : 'Advanced (env, headers, cwd): pick raw JSON.'}
             </span>
           </div>
         </div>
@@ -234,6 +356,109 @@ export function McpServers({ showBackup = false }: { showBackup?: boolean } = {}
           <ConfigBackup onImported={() => void reload()} />
         </div>
       )}
+    </div>
+  )
+}
+
+/**
+ * The raw-config escape hatch: one server's stored JSON, editable in place, with
+ * its last connection error and live tool list underneath. What it shows is the
+ * *normalized* config actually in effect (unknown keys were dropped on the way
+ * in) — which is the point: when a server misbehaves you want to see what Roxy
+ * is really launching, not what you believe you typed.
+ */
+function RawConfigEditor({
+  server,
+  busy,
+  onCancel,
+  onSave
+}: {
+  server: McpServerView
+  busy: boolean
+  onCancel: () => void
+  onSave: (parsed: ParsedMcpJson) => Promise<string | null>
+}): JSX.Element {
+  const stored = serializeServerConfig(server.config)
+  const [text, setText] = useState(stored)
+  const [err, setErr] = useState('')
+
+  const dirty = text !== stored
+  const parsed = parseMcpJson(text)
+  const renameTo =
+    parsed.ok && parsed.value.id && parsed.value.id !== server.id ? parsed.value.id : null
+
+  const save = async (): Promise<void> => {
+    if (!parsed.ok) {
+      setErr(parsed.error)
+      return
+    }
+    setErr(await onSave(parsed.value).then((e) => e ?? ''))
+  }
+
+  return (
+    <div className="mt-3 flex flex-col gap-2 border-t border-border pt-3">
+      <Textarea
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value)
+          setErr('')
+        }}
+        rows={jsonRows(text)}
+        className="font-mono text-xs leading-relaxed"
+        spellCheck={false}
+        autoComplete="off"
+        aria-label={`Raw JSON config for ${server.id}`}
+        onKeyDown={(e) => {
+          // Cmd/Ctrl+Enter saves; a bare Enter has to stay a newline inside JSON.
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault()
+            void save()
+          }
+        }}
+      />
+      {/* One line, in priority order: a failed save, then a parse problem (only
+          once you've typed — the stored config always parses), then a rename. */}
+      {err ? (
+        <p className="text-xs text-danger">{err}</p>
+      ) : !parsed.ok && dirty ? (
+        <p className="text-xs text-warning">{parsed.error}</p>
+      ) : renameTo ? (
+        <p className="text-xs text-text-muted">
+          Saving renames this server to <span className="font-mono text-text">{renameTo}</span>.
+        </p>
+      ) : null}
+      {server.status === 'error' && server.error && (
+        <p className="text-xs text-danger">
+          Last error: <span className="font-mono">{server.error}</span>
+        </p>
+      )}
+      {server.status === 'connected' && (
+        <p className="text-xs text-text-subtle">
+          Tools:{' '}
+          <span className="font-mono text-text-muted">
+            {server.tools.length ? server.tools.join(', ') : '(none exposed)'}
+          </span>
+        </p>
+      )}
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="primary" disabled={busy || !dirty} onClick={() => void save()}>
+          {busy ? 'Saving…' : server.enabled ? 'Save & reconnect' : 'Save'}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={busy || !dirty}
+          onClick={() => {
+            setText(stored)
+            setErr('')
+          }}
+        >
+          Reset
+        </Button>
+        <Button size="sm" variant="ghost" disabled={busy} onClick={onCancel}>
+          Close
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/routes/Mcp.tsx
+++ b/src/renderer/src/routes/Mcp.tsx
@@ -7,7 +7,7 @@ export default function Mcp(): JSX.Element {
   return (
     <PageShell
       title="MCP Servers"
-      subtitle="Connect external Model Context Protocol tool servers (filesystem, GitHub, databases, browsers, …) to expand what Roxy can do. Servers are also read from a workspace .roxy/mcp.json, and the agent can add them itself with the mcp tool."
+      subtitle="Connect external Model Context Protocol tool servers (filesystem, GitHub, databases, browsers, …) to expand what Roxy can do. Edit any server's raw JSON with the { } button to debug it. Servers are also read from a workspace .roxy/mcp.json, and the agent can add them itself with the mcp tool."
       onBack={() => navigate('/')}
     >
       <McpServers showBackup />

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -113,6 +113,112 @@ export function normalizeServerRecords(raw: unknown): McpServerRecord[] {
   return out
 }
 
+// ---------------------------------------------------------------------------
+// Raw JSON editing (Settings' "edit raw config" escape hatch)
+// ---------------------------------------------------------------------------
+
+/** A single server parsed out of hand-written / pasted JSON. */
+export interface ParsedMcpJson {
+  /** Present when the JSON was a named map (`{ "mcpServers": { "<id>": … } }`). */
+  id?: string
+  config: McpServerConfig
+  /** Present only when the JSON explicitly said `enabled` / `disabled`. */
+  enabled?: boolean
+}
+
+export type ParseMcpJsonResult =
+  | { ok: true; value: ParsedMcpJson }
+  | { ok: false; error: string }
+
+/** The canonical, pretty-printed form of a config — what the raw editor shows. */
+export function serializeServerConfig(config: McpServerConfig): string {
+  return JSON.stringify(config, null, 2)
+}
+
+/**
+ * Parse hand-edited/pasted MCP JSON into one server. Deliberately permissive
+ * about the wrapper so a snippet copied from any server's README works:
+ *
+ *   { "type": "local", "command": ["npx", …] }        ← a bare config
+ *   { "mcpServers": { "files": { "command": … } } }   ← Claude Desktop style
+ *   { "servers": { "files": … } }                     ← VS Code style
+ *   { "files": { "command": … } }                     ← a bare one-entry map
+ *
+ * Returns a *message*, never throws: this is the debug path, so the reason a
+ * config was rejected matters more than the rejection.
+ */
+export function parseMcpJson(text: string): ParseMcpJsonResult {
+  const trimmed = text.trim()
+  if (!trimmed) return { ok: false, error: 'Enter some JSON.' }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (e) {
+    return { ok: false, error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, error: 'Expected a JSON object describing one MCP server.' }
+  }
+  const root = parsed as Record<string, unknown>
+
+  // 1. An explicit wrapper always wins — even when empty/broken, so the error
+  //    names the real problem instead of "not a valid config".
+  for (const key of ['mcpServers', 'servers'] as const) {
+    const wrapped = root[key]
+    if (wrapped && typeof wrapped === 'object' && !Array.isArray(wrapped)) {
+      return fromNamedMap(wrapped as Record<string, unknown>, key)
+    }
+  }
+
+  // 2. A bare config object.
+  const direct = normalizeServerConfig(root)
+  if (direct) return { ok: true, value: { config: direct, enabled: readEnabled(root) } }
+
+  // 3. A bare `{ name: config }` map (README snippets often drop the wrapper).
+  const keys = Object.keys(root)
+  if (keys.length && keys.every((k) => isPlainObject(root[k]))) {
+    return fromNamedMap(root, 'object')
+  }
+
+  return {
+    ok: false,
+    error:
+      'Not a valid MCP server config — needs a "command" (local, argv array) or a "url" (remote).'
+  }
+}
+
+/** Pull the single entry out of a `{ name: config }` map. */
+function fromNamedMap(map: Record<string, unknown>, label: string): ParseMcpJsonResult {
+  const entries = Object.entries(map).filter(([id]) => id.trim())
+  if (!entries.length) return { ok: false, error: `"${label}" has no server entries.` }
+  if (entries.length > 1) {
+    return {
+      ok: false,
+      error: `Found ${entries.length} servers (${entries.map(([id]) => id).join(', ')}) — paste one at a time.`
+    }
+  }
+  const [id, raw] = entries[0]
+  const config = normalizeServerConfig(raw)
+  if (!config) {
+    return { ok: false, error: `"${id}" is not a valid config — needs a "command" or a "url".` }
+  }
+  return { ok: true, value: { id: id.trim(), config, enabled: readEnabled(raw) } }
+}
+
+/** `enabled` / `disabled` as written, or undefined when the JSON is silent. */
+function readEnabled(raw: unknown): boolean | undefined {
+  if (!isPlainObject(raw)) return undefined
+  const o = raw as Record<string, unknown>
+  if (o.disabled === true || o.enabled === false) return false
+  if (o.disabled === false || o.enabled === true) return true
+  return undefined
+}
+
+function isPlainObject(v: unknown): boolean {
+  return !!v && typeof v === 'object' && !Array.isArray(v)
+}
+
 function normalizeCommand(command: unknown, args: unknown): string[] {
   if (Array.isArray(command)) {
     return command.filter((x): x is string => typeof x === 'string' && x.length > 0)

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -221,9 +221,11 @@ import {
   mcpToolToSchema,
   normalizeServerConfig,
   normalizeServerRecords,
+  parseMcpJson,
   qualifyToolName,
   renderMcpContent,
   sanitizeNamePart,
+  serializeServerConfig,
   type McpServerSummary
 } from '../src/shared/mcp'
 import {
@@ -2103,6 +2105,76 @@ check(
   'mcp recs: non-object → []',
   normalizeServerRecords(null).length === 0 && normalizeServerRecords([]).length === 0
 )
+
+// parseMcpJson: the Settings raw-JSON editor. Permissive about the wrapper,
+// strict about the config, and it explains itself when it says no.
+const pBare = parseMcpJson('{"type":"local","command":["npx","x"]}')
+check(
+  'mcp json: bare config accepted, no id',
+  pBare.ok && pBare.value.id === undefined && pBare.value.config.type === 'local'
+)
+const pWrapped = parseMcpJson('{"mcpServers":{"files":{"command":["npx","x"]}}}')
+check(
+  'mcp json: mcpServers wrapper yields id + config',
+  pWrapped.ok && pWrapped.value.id === 'files' && pWrapped.value.config.type === 'local'
+)
+check(
+  'mcp json: servers wrapper also works',
+  parseMcpJson('{"servers":{"s":{"url":"https://e.com"}}}').ok
+)
+const pMap = parseMcpJson('{"files":{"url":"https://e.com/mcp"}}')
+check('mcp json: bare {name: config} map', pMap.ok && pMap.value.id === 'files')
+check(
+  'mcp json: disabled:true carried through',
+  (() => {
+    const r = parseMcpJson('{"mcpServers":{"a":{"command":["x"],"disabled":true}}}')
+    return r.ok && r.value.enabled === false
+  })()
+)
+check(
+  'mcp json: silence about enabled stays undefined',
+  (() => {
+    const r = parseMcpJson('{"command":["x"]}')
+    return r.ok && r.value.enabled === undefined
+  })()
+)
+check(
+  'mcp json: syntax error explains itself',
+  (() => {
+    const r = parseMcpJson('{ nope }')
+    return !r.ok && r.error.startsWith('Invalid JSON:')
+  })()
+)
+check('mcp json: empty input rejected', !parseMcpJson('   ').ok && !parseMcpJson('[1,2]').ok)
+check(
+  'mcp json: config with neither command nor url rejected',
+  (() => {
+    const r = parseMcpJson('{"foo":"bar"}')
+    return !r.ok && r.error.includes('command')
+  })()
+)
+check(
+  'mcp json: multi-server paste refused by name',
+  (() => {
+    const r = parseMcpJson('{"mcpServers":{"a":{"command":["x"]},"b":{"url":"https://e.com"}}}')
+    return !r.ok && r.error.includes('a, b')
+  })()
+)
+check(
+  'mcp json: empty wrapper names the wrapper',
+  (() => {
+    const r = parseMcpJson('{"mcpServers":{}}')
+    return !r.ok && r.error.includes('mcpServers')
+  })()
+)
+// Round-trip: what the editor renders must parse back to the same config.
+const rtCfg = normalizeServerConfig({ command: ['npx', 'x'], env: { A: '1' }, timeout: 9000 })!
+const rt = parseMcpJson(serializeServerConfig(rtCfg))
+check(
+  'mcp json: serialize then parse round-trips',
+  rt.ok && JSON.stringify(rt.value.config) === JSON.stringify(rtCfg)
+)
+check('mcp json: serialized form is pretty-printed', serializeServerConfig(rtCfg).includes('\n  '))
 
 // qualifyToolName / isMcpToolName: provider-legal, namespaced, collision-resistant.
 check(


### PR DESCRIPTION
## What

The MCP settings page could only add a server as a name plus one line — an argv string or a URL. Anything with `environment`, `headers`, `cwd`, or `timeout` had to be hand-written into `.roxy/mcp.json`. And once a server was saved, its stored config was invisible from the UI, so debugging a misbehaving server meant deleting it, re-adding it, and hoping.

This adds a raw-JSON escape hatch in both places.

**Per-server editor.** Each row gets a `{ }` toggle that opens the config actually in effect, editable in place, with the server's last connection error and live tool list underneath it. Saving upserts and immediately reconnects, so a bad edit reports itself right there instead of failing quietly on the next turn. `Cmd`/`Ctrl+Enter` saves; Reset restores the stored text.

**Raw JSON add mode.** The transport dropdown gains a third option that takes a pasted config, so the advanced fields no longer require editing a file by hand.

## Parsing

`parseMcpJson` (`src/shared/mcp.ts`) is deliberately permissive about the *wrapper* and strict about the *config*.

All four of these work, so a snippet copied from any server's README pastes in unedited:

```jsonc
{ "type": "local", "command": ["npx", "…"] }        // a bare config
{ "mcpServers": { "files": { "command": … } } }     // Claude Desktop style
{ "servers": { "files": … } }                       // VS Code style
{ "files": { "command": … } }                       // a bare one-entry map
```

It never throws, and it returns a message that names the problem rather than a bare `null` — `Invalid JSON: …`, `needs a "command" or a "url"`, `Found 2 servers (a, b) — paste one at a time`. On the debug path, *why* a config was rejected is the whole product.

Because it lives in `src/shared`, it's covered by `smoke:shared` with no Electron in the loop.

## Two decisions worth a look

- **The editor shows the normalized config, not your literal text.** Unknown keys were already dropped on the way into the DB, so this is what Roxy really launches — which is the point when debugging, but it does mean a stray key won't survive a save.
- **A pasted `{"<name>": …}` whose name differs from the row's is a rename** (write the new entry, drop the old) rather than being silently ignored. A rename *onto an existing server* is refused: upsert-then-remove would otherwise delete the server already sitting there.

## Testing

- `typecheck` clean.
- `smoke:shared`: 891 checks pass, 13 new ones covering wrappers, `disabled`/`enabled` handling, each rejection path, and a serialize → parse round-trip.
- `smoke:app`: all 30 MCP checks pass. One unrelated check fails (`a session without a port does not set PORT`) — it fails identically on `main` with this branch stashed, so it's pre-existing.

**Not verified by me:** the renderer needs the Electron preload bridge, so I couldn't screenshot it — a plain browser hangs on the loading splash. The dev server hot-reloaded the component without errors, but the editor's runtime behavior deserves a click-through before merge.
