### PR TITLE
fix(picker): show the model, not the vendor, on Roxy inference

### DIFF
--- a/src/renderer/src/components/ModelPicker.tsx
+++ b/src/renderer/src/components/ModelPicker.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Brain, Check, ChevronsUpDown, Clock, Pin, Search, Wrench } from 'lucide-react'
 import { buildModelIndex, buildModelRows } from '../lib/modelRows'
+import { modelLabel } from '@shared/models'
 import { useRoxyStore } from '../lib/store'
 import { resolveSessionConfig } from '@shared/session-config'
 import { ProviderLogo } from '../lib/providerLogos'
@@ -219,10 +220,13 @@ export function ModelPicker(): JSX.Element {
   // behind whichever provider answered last.
   const loading = providers.length > 0 && providers.some((p) => !models[p.id] && !modelsTried[p.id])
 
+  // Stripped the same way as the rows below, so the trigger and the row the
+  // user just clicked read identically instead of the trigger re-adding a vendor.
   const triggerLabel = useMemo(() => {
     if (!activeModel) return 'Select a model'
     if (!activeProvider) return activeModel
-    return index.get(`${activeProvider.id}:${activeModel}`)?.info.name ?? activeModel
+    const name = index.get(`${activeProvider.id}:${activeModel}`)?.info.name
+    return name ? modelLabel(activeProvider.id, name, activeModel) : activeModel
   }, [activeModel, activeProvider, index])
 
   const pick = useCallback(

--- a/src/renderer/src/lib/modelRows.ts
+++ b/src/renderer/src/lib/modelRows.ts
@@ -13,6 +13,7 @@
  * directly in test/shared.ts instead of being eyeballed in a running app.
  */
 import type { ModelInfo } from '../../../shared/api'
+import { modelLabel } from '../../../shared/models'
 
 /** The subset of a connected provider this list needs. */
 export interface RowProvider {
@@ -36,6 +37,7 @@ export interface ModelRow {
   providerId: string
   providerName: string
   modelId: string
+  /** What to render: the catalog name, with any vendor prefix already stripped. */
   label: string
   info: ModelInfo | undefined
   pinned: boolean
@@ -104,7 +106,7 @@ export function buildModelRows(input: {
       providerId,
       providerName,
       modelId,
-      label: label ?? hit?.info.name ?? modelId,
+      label: modelLabel(providerId, label ?? hit?.info.name ?? modelId, modelId),
       info: hit?.info,
       pinned: pinnedKeys.has(`${providerId}:${modelId}`)
     }

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -17,3 +17,57 @@ export function pickDefaultModel(models: ModelInfo[]): string | undefined {
   const toolCapable = models.find((m) => m.toolCall)
   return (toolCapable ?? models[0]).id
 }
+
+/**
+ * Providers whose catalog names arrive with a "Vendor: " prefix we hide.
+ *
+ * Deliberately a set and not "every provider": on a gateway reselling many
+ * vendors that prefix is the ONLY vendor signal a row has, since the logo beside
+ * it is the gateway's and identical on all 300+ rows. Dropping it is a judgement
+ * that the repetition costs more than the signal, and that judgement has been
+ * made for Roxy's own inference only. OpenRouter reports identically shaped
+ * names and is one entry away if the same call gets made for it.
+ */
+const VENDOR_PREFIXED_PROVIDERS = new Set(['roxy'])
+
+/** Lowercase alphanumerics only, so `x-ai`, `xAI` and `X.AI` compare equal. */
+function normalizeVendor(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+/**
+ * What to SHOW for a model: the catalog name, minus the vendor prefix on the
+ * providers that carry one.
+ *
+ * Roxy's gateway proxies OpenRouter, so its names arrive in OpenRouter's shape —
+ * "Anthropic: Claude Opus 4.5", "Google: Gemini 3 Pro". In a 320px menu where
+ * every row already wears the same Roxy mark, that prefix repeats on every line
+ * and truncates away the part that actually differs.
+ *
+ * It is removed only once the model's OWN id vouches for the prefix being a
+ * vendor (`anthropic/claude-opus-4.5`), so a colon belonging to the model name
+ * survives: "Venice: Uncensored" on a `cognitivecomputations/…` id keeps its
+ * full name rather than being silently shortened to something that no longer
+ * identifies it. `meta-llama` vs "Meta" and `mistralai` vs "Mistral" are why
+ * either side may be the longer form, and why the compare ignores punctuation.
+ *
+ * DISPLAY ONLY — the catalog keeps the full name, which matters twice: the
+ * picker's search haystack still matches on the vendor (typing "anthropic"
+ * finds every Claude), and the catalog's name sort still groups the list by
+ * vendor, so the menu stays vendor-ordered while reading as a plain list of
+ * models.
+ */
+export function modelLabel(providerId: string, name: string, modelId: string): string {
+  const full = name.trim()
+  if (!VENDOR_PREFIXED_PROVIDERS.has(providerId)) return full
+  const colon = full.indexOf(':')
+  if (colon <= 0) return full
+  const model = full.slice(colon + 1).trim()
+  if (!model) return full
+  const slash = modelId.indexOf('/')
+  if (slash <= 0) return full
+  const prefix = normalizeVendor(full.slice(0, colon))
+  const vendor = normalizeVendor(modelId.slice(0, slash))
+  if (!prefix || !vendor) return full
+  return prefix.startsWith(vendor) || vendor.startsWith(prefix) ? model : full
+}

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -41,7 +41,7 @@ import {
   sha256For,
   upstreamFor
 } from '../src/shared/cliproxy'
-import { pickDefaultModel } from '../src/shared/models'
+import { modelLabel, pickDefaultModel } from '../src/shared/models'
 import {
   ACTIVATION_MILESTONES,
   FEATURE_IDS,
@@ -888,6 +888,52 @@ check(
 check(
   'pickDefaultModel: first entry wins when it is already tool-capable',
   pickDefaultModel([mkModel('latest', true), mkModel('older', true)]) === 'latest'
+)
+
+// ---- model display names (the vendor prefix on gateway catalogs) ----
+//
+// Roxy's gateway proxies OpenRouter, so its names arrive as "Anthropic: Claude
+// Opus 4.5". Every row in the picker already wears the same Roxy mark, so that
+// prefix repeats on all 300+ rows and truncates away the half that differs.
+// Dropped for DISPLAY only: the search haystack and the catalog's name sort
+// still see the full name, so typing "anthropic" still finds every Claude and
+// the list stays grouped by vendor.
+check(
+  'modelLabel: roxy drops a vendor prefix its own id vouches for',
+  modelLabel('roxy', 'Anthropic: Claude Opus 4.5', 'anthropic/claude-opus-4.5') ===
+    'Claude Opus 4.5'
+)
+check(
+  'modelLabel: the vendor compare ignores punctuation and case (x-ai vs xAI)',
+  modelLabel('roxy', 'xAI: Grok 4', 'x-ai/grok-4') === 'Grok 4'
+)
+check(
+  'modelLabel: either side may be the longer form (meta-llama vs Meta)',
+  modelLabel('roxy', 'Meta: Llama 4 Maverick', 'meta-llama/llama-4-maverick') === 'Llama 4 Maverick'
+)
+// The whole point of checking the id: a colon that belongs to the MODEL's name
+// must survive, or the row is shortened to something that no longer identifies
+// it ("Uncensored" names no model).
+check(
+  'modelLabel: a colon the id does not vouch for is kept',
+  modelLabel('roxy', 'Venice: Uncensored', 'cognitivecomputations/dolphin-mistral-24b') ===
+    'Venice: Uncensored'
+)
+check(
+  'modelLabel: an unprefixed roxy name is untouched',
+  modelLabel('roxy', 'Claude Opus 4.5', 'anthropic/claude-opus-4.5') === 'Claude Opus 4.5'
+)
+check(
+  'modelLabel: a roxy id without a vendor segment keeps the full name',
+  modelLabel('roxy', 'Anthropic: Claude Opus 4.5', 'claude-opus-4.5') ===
+    'Anthropic: Claude Opus 4.5'
+)
+// Every OTHER provider is left alone: its logo already names the vendor, so a
+// colon there is the model's own and stripping it would lose information.
+check(
+  'modelLabel: a non-roxy provider is never stripped',
+  modelLabel('openrouter', 'Anthropic: Claude Opus 4.5', 'anthropic/claude-opus-4.5') ===
+    'Anthropic: Claude Opus 4.5'
 )
 
 // ---- structured tool history (Phase 5) ----
@@ -5262,6 +5308,38 @@ async function main(): Promise<void> {
     searched.filter((r) => r.kind === 'model').length === 2
   )
   check('picker rows: a non-matching query yields nothing', rowsFor('zzzz').length === 0)
+
+  // The vendor prefix is a DISPLAY concern, so it has to hold at the row level
+  // AND must not cost the search: the label loses "Anthropic: ", the haystack
+  // keeps it. Getting that backwards is silent - the menu looks right, and
+  // typing a vendor name quietly returns nothing.
+  const gatewayCatalog = {
+    roxy: [mkModel('anthropic/claude-opus-5', 'Anthropic: Claude Opus 5')]
+  }
+  const gatewayIndex = buildModelIndex(gatewayCatalog)
+  const gatewayRows = (query: string) =>
+    buildModelRows({
+      providers: [{ id: 'roxy', name: 'Roxy.gg Inference' }],
+      catalogs: gatewayCatalog,
+      // Pinned + Latest + catalog at once: the strip has to hold in all three,
+      // and only the catalog section passes the name in explicitly.
+      recent: { roxy: [{ model: 'anthropic/claude-opus-5' }] },
+      pinned: [{ providerId: 'roxy', model: 'anthropic/claude-opus-5' }],
+      index: gatewayIndex,
+      query
+    })
+  const gatewayLabels = gatewayRows('')
+    .filter((r) => r.kind === 'model')
+    .map((r) => (r.kind === 'model' ? r.label : ''))
+  check(
+    'picker rows: the roxy vendor prefix is stripped in every section',
+    gatewayLabels.length === 2 && gatewayLabels.every((l) => l === 'Claude Opus 5'),
+    gatewayLabels.join(' | ')
+  )
+  check(
+    'picker rows: the stripped vendor is still searchable',
+    gatewayRows('anthropic').some((r) => r.kind === 'model')
+  )
 
   // A pin whose provider was disconnected (or whose model left the catalog)
   // would otherwise render an unselectable row.


### PR DESCRIPTION
Every row in the Roxy provider's model list read `Anthropic: Claude Opus 4.5`, `Google: Gemini 3 Pro`, `DeepSeek: DeepSeek V3.2`.

Nothing in the UI was composing that. Roxy's gateway proxies OpenRouter, whose catalog `name` field is literally that string, and it flowed through untouched: `/v1/models` → `models.ts` → store → `modelRows` → the menu.

## Why it reads as a bug

Every row in that list already wears the same Roxy mark, so the vendor half isn't telling you which provider you're on — it's the same claim, restated 50 times, in a 320px menu that then truncates the half that actually differs. Against the live catalog, 49 of 50 names carry a prefix.

**Before**

```
Anthropic: Claude Opus 4.5
Anthropic: Claude Sonnet 5
Anthropic: Claude Haiku 4.5
DeepSeek: DeepSeek V3.2
Google: Gemini 3.7 Flash
OpenAI: GPT-5.6 Luna Pro
```

**After**

```
Claude Opus 4.5
Claude Sonnet 5
Claude Haiku 4.5
DeepSeek V3.2
Gemini 3.7 Flash
GPT-5.6 Luna Pro
```

## What changed

`modelLabel()` in `src/shared/models.ts`, used at the two places a model gets named:

- `modelRows.ts` — the single label factory feeding all three sections (Pinned, Latest, full catalog)
- `ModelPicker.tsx` — the composer trigger, which had to match or it would re-add a vendor the row you just clicked didn't show

## Display only — and that distinction is load-bearing

The catalog keeps the full name, so:

- the search haystack still matches on the vendor (typing `anthropic` still finds every Claude)
- the catalog's name sort still groups the menu by vendor

The list stays vendor-ordered while reading as a plain list of models. Stripping at the source in `models.ts` would have been a smaller diff and would have cost both, silently.

## Two constraints, because `split(':')` would be wrong

**Roxy only.** On a gateway the prefix is redundant with the logo. On a direct provider the logo already names the vendor, so a colon there belongs to the *model* — `Venice: Uncensored` is the model's whole name. Other providers are untouched. OpenRouter reports identically shaped names and is one set entry away if we ever want the same there.

**The model's own id has to vouch for the prefix.** `Anthropic: …` on `anthropic/claude-opus-4.5` strips, because the id agrees the first half is a vendor. `Venice: Uncensored` on a `cognitivecomputations/…` id keeps its full name rather than being shortened to something that names no model. The compare ignores case and punctuation and lets either side be the longer form, since the wild pairs are `x-ai`/"xAI", `meta-llama`/"Meta" and `mistralai`/"Mistral".

## Testing

9 new checks in `test/shared.ts`, covering both constraints and the two ways this fails silently: a row that strips but breaks vendor search, and a model name eaten because it happened to contain a colon.

Also run against the **live roxy.gg catalog** rather than only fixtures — 49 of 50 stripped, and the 1 kept (`anthropic/claude-opus-5`) genuinely has no prefix upstream.

```
npm run typecheck      clean
npm run smoke:shared   991 checks passed
npm run smoke:store    STORE GUARD OK
npm run smoke:multirepo 42 checks passed
prettier --check       clean
```

## Noted, not fixed

`UsageMeter.tsx` ("Top model") renders the raw id slug (`claude-opus-4.5`) rather than a pretty name — it has no catalog access. Pre-existing inconsistency, out of scope here.
