### PR TITLE
fix(workstream): make the git panel work for multi-repo sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.91",
+      "version": "0.0.92",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -862,6 +862,61 @@ export function registerIpc(): void {
   })
 
   /**
+   * The repos a session's git UI acts on, and where their checkouts live.
+   *
+   * Two sources, and the fallback is the whole point:
+   *
+   *   1. the session's own `repos` links - a materialized composite worktree,
+   *      one child checkout per repo. Authoritative when present.
+   *   2. the PROJECT's repos, discovered on disk.
+   *
+   * (2) covers the state a multi-repo session spends its entire life in before
+   * its first turn: worktrees are materialized lazily, so a session with a
+   * PENDING workstream has no links at all. Returning nothing for it was the
+   * bug - every per-repo status came back empty, which took the repo list, the
+   * count badge and both sync buttons off screen and left a bare "branch
+   * pending" with no way to update or reset anything. Meanwhile the session was
+   * genuinely running in the project folder, so those checkouts were exactly
+   * the ones the user was asking about.
+   *
+   * `pending: true` marks that second case so callers can say which tree they
+   * are about to touch: the project's own checkouts are shared with the user's
+   * editor and every other session, and a reset there is a much bigger claim
+   * than a reset inside a throwaway worktree.
+   */
+  const reposForSession = (
+    sessionId: string
+  ): { name: string; worktreePath: string; branch: string | null; pending: boolean }[] => {
+    const chat = repo.getChat(sessionId)
+    // A sub-session acts on its parent's workstream, exactly as the strip does.
+    const owner = chat?.kind === 'sub' && chat.parentId ? repo.getChat(chat.parentId) : chat
+    if (!owner) return []
+
+    const links = owner.repos
+    if (links?.length) {
+      return links.map((l) => ({
+        name: l.name,
+        worktreePath: l.worktreePath,
+        branch: l.branch,
+        pending: false
+      }))
+    }
+
+    if (!owner.workspacePath) return []
+    const { layout, roots } = discoverRepos(owner.workspacePath)
+    // Only the multi-repo layout: a `single` project is already served by the
+    // plain `git:status` path, and answering here too would give the UI two
+    // sources for one repo that could disagree mid-poll.
+    if (layout !== 'multi') return []
+    return roots.map((root) => ({
+      name: nodePath.basename(root),
+      worktreePath: root,
+      branch: null,
+      pending: true
+    }))
+  }
+
+  /**
    * Per-repo status for a multi-repo session.
    *
    * Takes a SESSION id, not a path: the composite root is not a repository, so
@@ -876,11 +931,8 @@ export function registerIpc(): void {
     CHANNELS.gitStatusMulti,
     async (_e, sessionId: string): Promise<RepoStatusView[]> => {
       if (!sessionId || !(await git.isGitAvailable())) return []
-      const chat = repo.getChat(sessionId)
-      // A sub-session shows its parent's workstream, exactly as the strip does.
-      const owner = chat?.kind === 'sub' && chat.parentId ? repo.getChat(chat.parentId) : chat
-      const links = owner?.repos
-      if (!links?.length) return []
+      const links = reposForSession(sessionId)
+      if (!links.length) return []
 
       return Promise.all(
         links.map(async (link): Promise<RepoStatusView> => {
@@ -888,6 +940,7 @@ export function registerIpc(): void {
             name: link.name,
             worktreePath: link.worktreePath,
             branch: link.branch,
+            pending: link.pending,
             dirty: false,
             changed: 0,
             ahead: 0,
@@ -1042,22 +1095,22 @@ export function registerIpc(): void {
    */
   const syncEveryRepo = async (
     sessionId: string,
-    mode: 'pull' | 'reset'
+    mode: 'pull' | 'reset' | 'push'
   ): Promise<MultiSyncOutcome> => {
     if (!sessionId) return { repos: [], error: 'No session.' }
     if (!(await git.isGitAvailable())) return { repos: [], error: 'Git isn\u2019t installed.' }
 
-    const chat = repo.getChat(sessionId)
-    const owner = chat?.kind === 'sub' && chat.parentId ? repo.getChat(chat.parentId) : chat
-    const links = owner?.repos
-    if (!links?.length) return { repos: [], error: 'This session is not multi-repo.' }
+    // Same resolver the status handler uses, so the buttons act on exactly the
+    // repos the panel just listed - including a PENDING workstream's, which are
+    // the project's own checkouts. Sharing this is the point: a second copy
+    // that only understood links is how "Reset all" silently did nothing on a
+    // session whose worktree had not been created yet.
+    const links = reposForSession(sessionId)
+    if (!links.length) return { repos: [], error: 'This session is not multi-repo.' }
 
     const results: RepoSyncResult[] = []
     for (const link of links) {
-      const r =
-        mode === 'pull'
-          ? await git.pullFastForward(link.worktreePath)
-          : await git.resetToUpstream(link.worktreePath)
+      const r = await syncOneRepo(link.worktreePath, mode)
       results.push({
         name: link.name,
         ok: r.ok,
@@ -1074,6 +1127,38 @@ export function registerIpc(): void {
     return { repos: results }
   }
 
+  /**
+   * One repo's half of a multi-repo sync.
+   *
+   * `push` is not simply `pushBranch`: it has to resolve the branch first and
+   * decide whether this is the repo's first push (`--set-upstream`), which the
+   * single-repo handler does inline. Pulling it out here keeps `syncEveryRepo`
+   * a loop over one uniform operation rather than a switch with three shapes.
+   *
+   * `updated` is reported as false for an already-pushed branch so the summary
+   * can say "already up to date" instead of claiming N repos moved.
+   */
+  const syncOneRepo = async (
+    cwd: string,
+    mode: 'pull' | 'reset' | 'push'
+  ): Promise<git.SyncResult> => {
+    if (mode === 'pull') return git.pullFastForward(cwd)
+    if (mode === 'reset') return git.resetToUpstream(cwd)
+
+    const st = await git.status(cwd)
+    if (!st?.branch) return { ok: false, error: 'Not on a branch (detached HEAD).' }
+    // Nothing local to publish. Reported as a success that changed nothing,
+    // because "push all" across four repos where two are already current is a
+    // normal outcome, not two failures.
+    if (st.hasUpstream && st.ahead === 0) {
+      return { ok: true, upstream: st.upstream ?? undefined, updated: false }
+    }
+    const r = await git.pushBranch(cwd, st.branch, { setUpstream: !st.hasUpstream })
+    return r.ok
+      ? { ok: true, upstream: st.upstream ?? `origin/${st.branch}`, updated: true }
+      : { ok: false, error: r.error }
+  }
+
   ipcMain.handle(
     CHANNELS.forgePullMulti,
     (_e, sessionId: string): Promise<MultiSyncOutcome> => syncEveryRepo(sessionId, 'pull')
@@ -1082,6 +1167,24 @@ export function registerIpc(): void {
   ipcMain.handle(
     CHANNELS.forgeResetMulti,
     (_e, sessionId: string): Promise<MultiSyncOutcome> => syncEveryRepo(sessionId, 'reset')
+  )
+
+  /**
+   * Push EVERY repo of a composite workstream.
+   *
+   * The missing third of the trio. Without it the panel's primary button ran
+   * `forge:push` against ONE repo's path - whichever happened to be first - so
+   * on a four-repo workstream "Push" published a quarter of the work and left
+   * the chip saying the same thing it did before the click.
+   */
+  ipcMain.handle(
+    CHANNELS.forgePushMulti,
+    async (_e, sessionId: string): Promise<MultiSyncOutcome> => {
+      const out = await syncEveryRepo(sessionId, 'push')
+      // The remote just changed, so every cached PR answer is suspect.
+      if (out.repos.some((r) => r.ok && r.updated)) forge.invalidate()
+      return out
+    }
   )
 
   ipcMain.handle(CHANNELS.forgeCreateUrl, async (_e, cwd: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -258,6 +258,7 @@ const roxy: RoxyApi = {
     reset: (cwd) => ipcRenderer.invoke(CHANNELS.forgeReset, cwd),
     pullMulti: (sessionId) => ipcRenderer.invoke(CHANNELS.forgePullMulti, sessionId),
     resetMulti: (sessionId) => ipcRenderer.invoke(CHANNELS.forgeResetMulti, sessionId),
+    pushMulti: (sessionId) => ipcRenderer.invoke(CHANNELS.forgePushMulti, sessionId),
     createUrl: (cwd) => ipcRenderer.invoke(CHANNELS.forgeCreateUrl, cwd),
     listHosts: () => ipcRenderer.invoke(CHANNELS.forgeListHosts),
     setHostKind: (host, kind) => ipcRenderer.invoke(CHANNELS.forgeSetHostKind, host, kind)

--- a/src/renderer/src/components/WorkstreamStrip.tsx
+++ b/src/renderer/src/components/WorkstreamStrip.tsx
@@ -17,6 +17,7 @@ import { workstreamStripView, statusKeyForSession } from '@shared/workstream'
 import { branchNameError } from '@shared/branch'
 import type { RepoStatusView } from '@shared/api'
 import {
+  aggregateLifecycle,
   aggregateRepoStatus,
   aggregateSyncTarget,
   describeRepoStatus,
@@ -393,6 +394,7 @@ function ForgePanel({
   const resetBranch = useRoxyStore((s) => s.resetBranch)
   const pullAllRepos = useRoxyStore((s) => s.pullAllRepos)
   const resetAllRepos = useRoxyStore((s) => s.resetAllRepos)
+  const pushAllRepos = useRoxyStore((s) => s.pushAllRepos)
   const [busy, setBusy] = useState<null | 'action' | 'pull' | 'reset'>(null)
   const [error, setError] = useState<string | null>(null)
   const [note, setNote] = useState<string | null>(null)
@@ -406,12 +408,34 @@ function ForgePanel({
   const pull = view?.pull ?? null
   const action = view?.lifecycle.action ?? null
   const multi = repos.length > 1
+  // True while the workstream is still just an intent: these are the PROJECT's
+  // own checkouts, shared with the user's editor and every other session in the
+  // folder. Everything destructive below says so out loud rather than letting
+  // "Reset all" read like it only touches this session's scratch space.
+  const pendingTrees = multi && repos.some((r) => r.pending)
 
   // A composite workstream has no single upstream, so its sync target is folded
   // from the per-repo ones. Null for single-repo sessions, which keep using
   // `view.syncTarget` exactly as before.
   const composite = useMemo(() => (multi ? aggregateSyncTarget(repos) : null), [multi, repos])
   const sync = multi ? null : (view?.syncTarget ?? null)
+
+  // Whether the repos actually WANT different things. Drives the per-row action
+  // buttons: when every repo is at the same phase the summary buttons already
+  // say it once, and repeating it per row is noise.
+  const lifecycleAgg = useMemo(
+    () =>
+      multi
+        ? aggregateLifecycle(
+            repos.map((r) => ({
+              name: r.name,
+              isRepo: r.isRepo,
+              lifecycle: r.forge?.lifecycle ?? null
+            }))
+          )
+        : null,
+    [multi, repos]
+  )
 
   // One shape for the label/disabled logic regardless of how many repos there
   // are, so the two buttons below are written once rather than forked.
@@ -471,6 +495,15 @@ function ForgePanel({
         return openUrl(url)
       }
       if (action === 'push') {
+        // Multi-repo pushes EVERY repo. Pushing the one the chip happened to be
+        // derived from published a fraction of the work and left the chip
+        // saying exactly what it said before the click.
+        if (multi) {
+          const r = await pushAllRepos(ownerId)
+          if (r.error) return setError(r.error)
+          const s = summarizeSync(r.repos, 'push')
+          return s.failed ? setError(s.text) : setNote(s.text)
+        }
         const r = await pushBranch(ownerId)
         if (!r.ok) setError(r.error ?? 'Push failed.')
         return
@@ -525,6 +558,16 @@ function ForgePanel({
             </span>
           )}
         </div>
+
+        {/* Names the tree before any button acts on it. A composite workstream
+            that hasn't been created yet operates on the PROJECT's checkouts,
+            and "Reset all to origin/main" means something very different there
+            than it does inside a throwaway worktree. */}
+        {pendingTrees && (
+          <div className="border-b border-border px-3 py-1.5 text-[11px] text-warning">
+            Workstream not created yet - these are the project&rsquo;s own checkouts.
+          </div>
+        )}
 
         {pull ? (
           <button
@@ -591,7 +634,7 @@ function ForgePanel({
                     {r.sync?.behind ?? r.behind} behind
                   </span>
                 )}
-                {r.forge?.pull && (
+                {r.forge?.pull ? (
                   <button
                     type="button"
                     onClick={() => openUrl(r.forge!.pull!.url)}
@@ -599,6 +642,15 @@ function ForgePanel({
                   >
                     #{r.forge.pull.number}
                   </button>
+                ) : (
+                  /* The row's OWN next step, when it differs from the panel's.
+                     The summary buttons below act on all N at once, which is the
+                     right default and the wrong tool for the single repo that is
+                     behind while the others are merged - the case a composite
+                     workstream produces constantly. Suppressed when every repo
+                     wants the same thing, so the common case stays one button
+                     rather than a column of identical ones. */
+                  <RepoRowAction repo={r} suppress={!lifecycleAgg?.mixed} onDone={setNote} />
                 )}
                 {r.isRepo ? (
                   r.dirty && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning" />
@@ -676,9 +728,11 @@ function ForgePanel({
               onBlur={() => setConfirmReset(false)}
               disabled={!!busy}
               title={
-                multi
-                  ? `Discard local state in every repo and make each identical to ${target.label}`
-                  : `Discard local state and make this branch identical to ${target.label}`
+                pendingTrees
+                  ? `Discard local state in the PROJECT's own checkouts and make each identical to ${target.label} - this workstream has no worktree of its own yet`
+                  : multi
+                    ? `Discard local state in every repo and make each identical to ${target.label}`
+                    : `Discard local state and make this branch identical to ${target.label}`
               }
               className={cn(
                 'press-scale flex w-full items-center justify-center gap-1.5 sq sq-lg rounded-lg px-3 py-1.5 text-xs disabled:opacity-40',
@@ -691,13 +745,73 @@ function ForgePanel({
               {busy === 'reset'
                 ? 'Resetting...'
                 : confirmReset
-                  ? resetConfirmLabel(target, multi ? composite?.syncable : undefined)
+                  ? resetConfirmLabel(target, multi ? composite?.syncable : undefined, pendingTrees)
                   : `Reset ${multi ? 'all ' : ''}to ${target.label}`}
             </button>
           </div>
         )}
       </div>
     </div>
+  )
+}
+
+/**
+ * One repo's own next step, inside the panel's repo list.
+ *
+ * The panel's big buttons act on every repo at once, which is right when the
+ * repos agree and useless when they don't: a workstream with three merged repos
+ * and one that was never pushed offers "Push all", and the three that are done
+ * make that read like it would republish them. This is the escape hatch - the
+ * one repo that needs something, acted on alone.
+ *
+ * Deliberately only PUSH and VIEW-PR:
+ *   - push is the action a lone repo actually gets stuck needing, and it is
+ *     additive - the worst case is a no-op;
+ *   - update and reset stay on the panel's shared buttons, because reset can
+ *     destroy work and a small unlabelled control at the end of a dense row is
+ *     the last place that belongs.
+ */
+function RepoRowAction({
+  repo,
+  suppress,
+  onDone
+}: {
+  repo: RepoStatusView
+  /** True when every repo wants the same thing, so the panel says it once. */
+  suppress: boolean
+  onDone: (note: string | null) => void
+}): JSX.Element | null {
+  const [busy, setBusy] = useState(false)
+
+  if (suppress || !repo.isRepo) return null
+  const action = repo.forge?.lifecycle.action ?? null
+  if (action !== 'push') return null
+  // Nothing local to publish - the phase is stale or the repo is simply clean.
+  const ahead = repo.sync?.ahead ?? repo.ahead
+  if (repo.hasUpstream && ahead === 0) return null
+
+  const run = async (): Promise<void> => {
+    if (busy) return
+    setBusy(true)
+    onDone(null)
+    try {
+      const r = await api.forge.push(repo.worktreePath)
+      onDone(r.ok ? `Pushed ${repo.name}.` : `${repo.name}: ${r.error ?? 'push failed'}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void run()}
+      disabled={busy}
+      title={`Push ${repo.name} to origin`}
+      className="shrink-0 rounded px-1 text-text-subtle transition hover:bg-white/5 hover:text-text disabled:opacity-40"
+    >
+      {busy ? '...' : 'push'}
+    </button>
   )
 }
 
@@ -723,13 +837,18 @@ function fastForwardHint(sync: SyncTarget): string {
  * are gone for good (well, reflog), edits are merely stashed. "Are you sure?"
  * says nothing; "Discard 2 commits + stash 5 changes" is a decision.
  */
-function resetConfirmLabel(sync: SyncCounts, repoCount?: number): string {
+function resetConfirmLabel(sync: SyncCounts, repoCount?: number, shared?: boolean): string {
   const bits: string[] = []
   if (sync.ahead > 0) bits.push(`discard ${sync.ahead} commit${sync.ahead === 1 ? '' : 's'}`)
   if (sync.changed > 0) bits.push(`stash ${sync.changed} change${sync.changed === 1 ? '' : 's'}`)
+  // The armed click is the last thing between the user and a destroyed tree, so
+  // it names WHOSE tree when the answer is "the one your editor is open in".
+  // Everywhere else the scope is implied by the panel; here it is the whole
+  // difference between discarding a scratch worktree and discarding the project.
+  const where = shared ? ' in the PROJECT' : ''
   // Across repos the counts are SUMS, so say what they are sums of - "discard 3
   // commits" reads like one repo until it names the scope.
-  const scope = repoCount ? ` in ${repoCount} repos` : ''
+  const scope = repoCount ? `${where} in ${repoCount} repos` : where
   if (!bits.length) return `Click again to reset${scope}`
   return `Click again to ${bits.join(' + ')}${scope}`
 }

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -48,7 +48,7 @@ import type {
   SyncOutcome,
   WorktreeView
 } from '@shared/api'
-import { aggregateRepoStatus } from '@shared/repos'
+import { aggregateLifecycle, aggregateRepoStatus, describeCompositeLifecycle } from '@shared/repos'
 import type { ForgeStatusView } from '@shared/forge'
 
 interface RoxyStore {
@@ -306,6 +306,14 @@ interface RoxyStore {
    */
   pullAllRepos: (chatId: string) => Promise<MultiSyncOutcome>
   resetAllRepos: (chatId: string) => Promise<MultiSyncOutcome>
+  /**
+   * Push EVERY repo of a multi-repo session.
+   *
+   * Separate from `pushBranch` for the same reason `pullAllRepos` is separate
+   * from `pullBranch`: four repos produce four outcomes, and there is no single
+   * `ok` that is true when three pushed and one was rejected.
+   */
+  pushAllRepos: (chatId: string) => Promise<MultiSyncOutcome>
   /** Hard-reset onto the upstream, stashing uncommitted work first. */
   resetBranch: (chatId: string) => Promise<SyncOutcome>
   /** Load the worktrees + branches for a project (menu open). */
@@ -508,43 +516,80 @@ async function pollStatusInto(
   set: (fn: (s: RoxyStore) => Partial<RoxyStore>) => void,
   key: string,
   chatId: string,
-  chats: Chat[]
+  chats: Chat[],
+  /** `projectRepos` from the store: which project folders are folders OF repos. */
+  projectRepos: Record<string, boolean>
 ): Promise<void> {
   const chat = chats.find((c) => c.id === chatId)
   const owner =
     chat?.kind === 'sub' && chat.parentId ? chats.find((c) => c.id === chat.parentId) : chat
 
-  if (owner?.repos?.length) {
+  // Asked for every session in a multi-repo PROJECT, not just one whose links
+  // already exist. A workstream is materialized lazily on the first turn, so a
+  // brand-new multi-repo session has no links for the whole pre-turn window -
+  // and answering "not composite" for it was what left the strip with a bare
+  // "branch pending" and no working sync buttons. The main process resolves
+  // that case to the project's own checkouts; an empty array still means "not
+  // multi-repo", so a single-repo session falls straight through.
+  if (owner?.repos?.length || (owner?.workspacePath && projectRepos[owner.workspacePath])) {
     const repos = await api.git.statusMulti(owner.id)
     // Empty means the session isn't composite after all (its links were
     // cleared) - leave the last known state rather than blanking the row.
-    if (!repos.length) return
-    const agg = aggregateRepoStatus(repos)
-    // The PR chip has no single answer across N repos. Show the first repo that
-    // has one and let the panel enumerate the rest; a chip that silently picks
-    // a winner is better than no chip, but the panel is where the truth is.
-    const lead = repos.find((r) => r.isRepo && r.forge)?.forge ?? null
-    set((s) => ({
-      repoStatus: { ...s.repoStatus, [key]: repos },
-      gitStatus: {
-        ...s.gitStatus,
-        [key]: {
-          // The composite directory isn't a repo, but the WORKSTREAM is
-          // repo-backed, and that is what this flag gates in the UI.
-          isRepo: agg.repoCount > 0,
-          root: key,
-          branch: agg.branch,
-          dirty: agg.dirty,
-          changed: agg.changed,
-          ahead: agg.ahead,
-          behind: agg.behind,
-          hasUpstream: repos.some((r) => r.hasUpstream),
-          defaultBranch: repos.find((r) => r.defaultBranch)?.defaultBranch ?? null
-        }
-      },
-      forgeStatus: lead ? { ...s.forgeStatus, [key]: lead } : s.forgeStatus
-    }))
-    return
+    if (repos.length) {
+      const agg = aggregateRepoStatus(repos)
+      // The chip describes the WHOLE workstream, folded from every repo - see
+      // `aggregateLifecycle`. It used to show the first repo that had a forge
+      // answer and let it speak for the rest, so three-pushed-one-local read as
+      // `pushed` and the repo that still needed work was invisible.
+      const composite = aggregateLifecycle(
+        repos.map((r) => ({
+          name: r.name,
+          isRepo: r.isRepo,
+          lifecycle: r.forge?.lifecycle ?? null
+        }))
+      )
+      const lead = composite
+        ? (repos.find((r) => r.isRepo && r.forge?.lifecycle.phase === composite.phase)?.forge ??
+          repos.find((r) => r.isRepo && r.forge)?.forge ??
+          null)
+        : null
+      set((s) => ({
+        repoStatus: { ...s.repoStatus, [key]: repos },
+        gitStatus: {
+          ...s.gitStatus,
+          [key]: {
+            // The composite directory isn't a repo, but the WORKSTREAM is
+            // repo-backed, and that is what this flag gates in the UI.
+            isRepo: agg.repoCount > 0,
+            root: key,
+            branch: agg.branch,
+            dirty: agg.dirty,
+            changed: agg.changed,
+            ahead: agg.ahead,
+            behind: agg.behind,
+            hasUpstream: repos.some((r) => r.hasUpstream),
+            defaultBranch: repos.find((r) => r.defaultBranch)?.defaultBranch ?? null
+          }
+        },
+        forgeStatus:
+          lead && composite
+            ? {
+                ...s.forgeStatus,
+                [key]: {
+                  ...lead,
+                  lifecycle: {
+                    ...lead.lifecycle,
+                    ...describeCompositeLifecycle(composite, lead.lifecycle),
+                    action: composite.action
+                  }
+                }
+              }
+            : s.forgeStatus
+      }))
+      return
+    }
+    // Fall through: the project scan said multi-repo but this session resolved
+    // to no repos at all. The single-repo path below is the honest fallback.
   }
 
   // One round trip for both. `forge.status` is cheap by construction: it
@@ -858,15 +903,18 @@ function syncOwner(get: () => RoxyStore, chatId: string): { chat: Chat } | { err
 async function syncAllRepos(
   get: () => RoxyStore,
   chatId: string,
-  mode: 'pull' | 'reset'
+  mode: 'pull' | 'reset' | 'push'
 ): Promise<MultiSyncOutcome> {
   const owner = syncOwner(get, chatId)
   if ('error' in owner) return { repos: [], error: owner.error }
 
-  const r =
+  const call =
     mode === 'pull'
-      ? await api.forge.pullMulti(owner.chat.id)
-      : await api.forge.resetMulti(owner.chat.id)
+      ? api.forge.pullMulti
+      : mode === 'reset'
+        ? api.forge.resetMulti
+        : api.forge.pushMulti
+  const r = await call(owner.chat.id)
   await get().refreshGitStatus(owner.chat.id)
   return r
 }
@@ -1164,8 +1212,16 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       }
     }
     if (!get().gitAvailable) return
+    // Probe the project's shape before the first poll. `pollStatusInto` needs it
+    // to know a session belongs to a folder OF repos, and a session whose
+    // workstream is still pending has no links to say so on its own - without
+    // this the very first poll takes the single-repo path and the strip shows a
+    // bare "branch pending" until something else happens to probe. Cached after
+    // the first call, so this is one filesystem scan per project per app run.
+    const chatNow = get().chats.find((c) => c.id === chatId)
+    if (chatNow?.workspacePath) await get().ensureProjectRepos(chatNow.workspacePath)
     try {
-      await pollStatusInto(set, key, chatId, get().chats)
+      await pollStatusInto(set, key, chatId, get().chats, get().projectRepos)
     } catch {
       // Best-effort: a transient git failure leaves the last known state.
     }
@@ -1216,9 +1272,20 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
       // anyway, and firing N spawns at once on a machine with a dozen sessions is
       // a visible stall on the very interaction (opening the app) this is meant
       // to be invisible during.
+      // Same probe as `refreshGitStatus`, once per distinct project rather than
+      // per session: the sweep is what keeps the SIDEBAR current, and without
+      // this every multi-repo row there would fold to the single-repo path.
+      for (const workspace of new Set(
+        get()
+          .chats.map((c) => c.workspacePath)
+          .filter((p): p is string => !!p)
+      )) {
+        await get().ensureProjectRepos(workspace)
+      }
+
       for (const [key, chatId] of keys) {
         try {
-          await pollStatusInto(set, key, chatId, get().chats)
+          await pollStatusInto(set, key, chatId, get().chats, get().projectRepos)
         } catch {
           // Best-effort per session: a deleted worktree must not stop the sweep
           // and leave every row below it blank.
@@ -1248,6 +1315,7 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
 
   pullAllRepos: (chatId) => syncAllRepos(get, chatId, 'pull'),
   resetAllRepos: (chatId) => syncAllRepos(get, chatId, 'reset'),
+  pushAllRepos: (chatId) => syncAllRepos(get, chatId, 'push'),
 
   refreshWorktrees: async (workspacePath) => {
     if (!workspacePath || !get().gitAvailable) return

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -173,6 +173,18 @@ export interface RepoStatusView {
   name: string
   /** The repo's own worktree for this session (`<composite>/<name>`). */
   worktreePath: string
+  /**
+   * True when this is the PROJECT's own checkout rather than a worktree of it,
+   * because the session's workstream hasn't been materialized yet.
+   *
+   * Worktrees are created lazily on the first turn, so a multi-repo session
+   * spends the whole pre-turn window with no links of its own - and the repos
+   * it is really sitting in are the project's, shared with the user's editor
+   * and every other session there. The UI has to say so before offering to
+   * reset one: the same button means "throw away this session's scratch work"
+   * in a worktree and "throw away whatever is in my editor" here.
+   */
+  pending: boolean
   isRepo: boolean
   branch: string | null
   dirty: boolean
@@ -1033,6 +1045,14 @@ export interface RoxyApi {
     pullMulti(sessionId: string): Promise<MultiSyncOutcome>
     /** Reset EVERY repo of a multi-repo session. See `pullMulti`. */
     resetMulti(sessionId: string): Promise<MultiSyncOutcome>
+    /**
+     * Push EVERY repo of a multi-repo session.
+     *
+     * The counterpart of `push` for a composite workstream, and not optional:
+     * pushing one repo of four leaves the work unpublished and the chip
+     * unchanged, which reads as a button that did nothing.
+     */
+    pushMulti(sessionId: string): Promise<MultiSyncOutcome>
     /** The host's "create a pull request" URL, pre-filled for this branch. */
     createUrl(cwd: string): Promise<string | null>
     /**

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -239,6 +239,7 @@ export const CHANNELS = {
   /** Multi-repo variants: these take a SESSION id, not a path. */
   forgePullMulti: 'forge:pull-multi',
   forgeResetMulti: 'forge:reset-multi',
+  forgePushMulti: 'forge:push-multi',
   forgeCreateUrl: 'forge:create-url',
   forgeListHosts: 'forge:list-hosts',
   forgeSetHostKind: 'forge:set-host-kind',

--- a/src/shared/repos.ts
+++ b/src/shared/repos.ts
@@ -35,6 +35,7 @@
  * No Node, no Electron, no DB: this file is unit-tested by `npm run smoke:shared`.
  * The filesystem half (`discoverRepos`) lives in `main/services/workspace.ts`.
  */
+import type { LifecycleAction, LifecyclePhase, LifecycleTone, LifecycleView } from './forge'
 
 /** Minimal `path` surface, injected so this module stays platform-agnostic. */
 export interface RepoPathOps {
@@ -403,14 +404,14 @@ export interface SyncResultLite {
  */
 export function summarizeSync(
   results: SyncResultLite[],
-  mode: 'pull' | 'reset'
+  mode: 'pull' | 'reset' | 'push'
 ): { text: string; failed: boolean } {
   if (!results.length) return { text: 'Nothing to sync.', failed: false }
 
   const failed = results.filter((r) => !r.ok)
   const moved = results.filter((r) => r.ok && r.updated)
   const stashed = results.filter((r) => r.ok && r.stashed)
-  const verb = mode === 'pull' ? 'Updated' : 'Reset'
+  const verb = mode === 'pull' ? 'Updated' : mode === 'reset' ? 'Reset' : 'Pushed'
 
   if (failed.length) {
     const names = failed.map((r) => r.name).join(', ')
@@ -422,7 +423,13 @@ export function summarizeSync(
   }
 
   if (!moved.length) {
-    return { text: `All ${results.length} already up to date.`, failed: false }
+    return {
+      text:
+        mode === 'push'
+          ? `All ${results.length} already pushed.`
+          : `All ${results.length} already up to date.`,
+      failed: false
+    }
   }
 
   const scope = moved.length === results.length ? `all ${results.length}` : `${moved.length}`
@@ -432,6 +439,152 @@ export function summarizeSync(
   return {
     text: `${verb} ${scope} ${moved.length === 1 ? 'repo' : 'repos'}.${stash}`,
     failed: false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The chip: N repos, one honest label
+// ---------------------------------------------------------------------------
+
+/** Just enough of a repo's forge state to fold into the composite chip. */
+export interface RepoLifecycleLite {
+  name: string
+  isRepo: boolean
+  /** This repo's own lifecycle, or null when the forge hasn't answered. */
+  lifecycle: { phase: LifecyclePhase; action: LifecycleAction | null } | null
+}
+
+/**
+ * The lifecycle chip for a workstream spanning N repos.
+ *
+ * The old behaviour was to show the FIRST repo that had a forge answer and let
+ * it speak for the rest, which is wrong in the direction that matters: a
+ * workstream with three repos pushed and one still local rendered `pushed`, and
+ * the one repo that actually needed pushing was invisible. Worse, the panel's
+ * primary button then acted on that one repo's `cwd` alone, so "Push" pushed a
+ * quarter of the work and the chip stayed put.
+ *
+ * So the chip reports the LEAST-ADVANCED repo instead. It is the only choice
+ * that keeps the label a promise rather than a sample:
+ *
+ *   - the label answers "is this workstream done?", and the honest answer for
+ *     3-of-4 is "no";
+ *   - the action it offers is therefore always one that has something to do,
+ *     and `pushMulti`/`pullMulti` sweep every repo that needs it;
+ *   - it can only ever under-claim progress, never over-claim it. A chip that
+ *     says `local` when one repo is unpushed costs a redundant click; one that
+ *     says `merged` when a repo never got pushed loses work.
+ *
+ * `count` is what lets the UI say `2/4 local` rather than a bare `local`, which
+ * is the difference between "nothing is pushed" and "most of it is".
+ */
+export interface CompositeLifecycle {
+  /** The least-advanced phase across live repos. */
+  phase: LifecyclePhase
+  /** How many repos sit at that phase. */
+  count: number
+  /** Total live repos, so the UI can render `2/4`. */
+  total: number
+  /** The action for `phase`, or null when there is nothing to offer. */
+  action: LifecycleAction | null
+  /** Repos at `phase`, in display order - named in the tooltip. */
+  repos: string[]
+  /** True when the repos are NOT all at the same phase. */
+  mixed: boolean
+}
+
+/**
+ * Lifecycle phases from least to most advanced.
+ *
+ * This is the order the chip folds over, so it is the definition of "least
+ * advanced" and worth being explicit about rather than deriving from the union.
+ *
+ * `diverged` sorts FIRST - ahead of `unpublished` - because it is the only
+ * phase that cannot be resolved by any button in the panel. A workstream with
+ * one diverged repo needs a human to merge or rebase it, and burying that under
+ * a cheerful `#42` from the other three is how the diverged one gets forgotten
+ * until a push is rejected.
+ */
+const PHASE_ORDER: readonly LifecyclePhase[] = [
+  'diverged',
+  'unpublished',
+  'ahead',
+  'behind',
+  'synced',
+  'draft',
+  'open',
+  'closed',
+  'merged'
+]
+
+/** Where a phase sits on the road to merged. Unknown phases sort last. */
+function phaseRank(phase: LifecyclePhase): number {
+  const i = PHASE_ORDER.indexOf(phase)
+  return i === -1 ? PHASE_ORDER.length : i
+}
+
+/**
+ * Fold N per-repo lifecycles into the one the chip shows.
+ *
+ * Repos the forge hasn't answered for yet are treated as `unpublished` rather
+ * than skipped: that is what git alone knows about them, and skipping would let
+ * a slow lookup briefly promote the chip to `merged` before demoting it again -
+ * exactly the flicker the single-repo chip is written to avoid.
+ *
+ * Returns null when no repo is live, which the caller renders as no chip at all.
+ */
+export function aggregateLifecycle(repos: RepoLifecycleLite[]): CompositeLifecycle | null {
+  const live = repos.filter((r) => r.isRepo)
+  if (!live.length) return null
+
+  const phaseOf = (r: RepoLifecycleLite): LifecyclePhase => r.lifecycle?.phase ?? 'unpublished'
+  let worst = phaseOf(live[0])
+  for (const r of live) {
+    if (phaseRank(phaseOf(r)) < phaseRank(worst)) worst = phaseOf(r)
+  }
+
+  const at = live.filter((r) => phaseOf(r) === worst)
+  // Take the action from a repo actually AT the reported phase, so the button
+  // and the label can never describe different repos.
+  const action = at.find((r) => r.lifecycle?.action)?.lifecycle?.action ?? null
+
+  return {
+    phase: worst,
+    count: at.length,
+    total: live.length,
+    action,
+    repos: at.map((r) => r.name),
+    mixed: at.length !== live.length
+  }
+}
+
+/**
+ * The composite chip's label and tooltip, built from one repo's rendering of the
+ * same phase.
+ *
+ * Reuses the single-repo `LifecycleView` rather than re-deriving the words:
+ * `branchLifecycle` already owns the vocabulary (`local`, `pushed`, `#42`), and
+ * a second copy here would drift the moment one of them gained a phase.
+ *
+ * The label gains a `2/4` prefix ONLY when the repos disagree. A workstream
+ * whose repos are all `local` says `local`, exactly as a single repo does -
+ * the count is there to expose disagreement, not to decorate agreement.
+ */
+export function describeCompositeLifecycle(
+  composite: CompositeLifecycle,
+  base: LifecycleView
+): { label: string; tone: LifecycleTone; title: string } {
+  if (!composite.mixed) {
+    return {
+      label: base.label,
+      tone: base.tone,
+      title: `${base.title} - all ${composite.total} repos`
+    }
+  }
+  return {
+    label: `${composite.count}/${composite.total} ${base.label}`,
+    tone: base.tone,
+    title: `${base.title}: ${composite.repos.join(', ')}`
   }
 }
 

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -132,10 +132,13 @@ import {
 } from '../src/shared/web'
 import { resolveWorktreeCwd } from '../src/shared/workspace'
 import {
+  aggregateLifecycle,
   aggregateRepoStatus,
   aggregateSyncTarget,
+  describeCompositeLifecycle,
   describeSyncRef,
   summarizeSync,
+  type RepoLifecycleLite,
   type RepoSyncLite,
   describeRepoStatus,
   isMultiRepo,
@@ -278,6 +281,7 @@ import {
   branchLifecycle,
   isPullRequestPhase,
   type LifecyclePhase,
+  type LifecycleAction,
   relativeAge,
   FORGE_NAMES,
   type PullRequestView
@@ -3673,6 +3677,103 @@ async function main(): Promise<void> {
     check('summary: a stash is always mentioned', /Stashed work in backend/.test(stashed.text))
     check('summary: and says how to undo it', /git stash pop/.test(stashed.text))
     check('summary: an empty set is inert', summarizeSync([], 'pull').text === 'Nothing to sync.')
+
+    // ---- the chip: N repos, one honest label ----
+    // The rule under test is that the chip reports the LEAST-ADVANCED repo. The
+    // old behaviour took the first repo with a forge answer and let it speak
+    // for the rest, so a workstream with one unpushed repo rendered `pushed`
+    // and the repo that still needed work was invisible.
+    const mkLife = (
+      name: string,
+      phase: LifecyclePhase | null,
+      action: LifecycleAction | null = null,
+      isRepo = true
+    ): RepoLifecycleLite => ({
+      name,
+      isRepo,
+      lifecycle: phase ? { phase, action } : null
+    })
+
+    const lagging = aggregateLifecycle([
+      mkLife('backend', 'merged'),
+      mkLife('frontend', 'merged'),
+      mkLife('shared', 'unpublished', 'push')
+    ])!
+    check('chip: the least-advanced repo sets the phase', lagging.phase === 'unpublished')
+    check('chip: and is counted', lagging.count === 1 && lagging.total === 3)
+    check('chip: and named', lagging.repos.join(',') === 'shared')
+    check('chip: disagreement is flagged', lagging.mixed)
+    check('chip: the action comes from a repo AT that phase', lagging.action === 'push')
+
+    const agreedLife = aggregateLifecycle([
+      mkLife('backend', 'synced', 'open-pr'),
+      mkLife('frontend', 'synced', 'open-pr')
+    ])!
+    check('chip: agreement is not flagged as mixed', !agreedLife.mixed)
+    check('chip: and every repo is counted at that phase', agreedLife.count === 2)
+
+    // `diverged` sorts ahead of everything: it is the only phase no button in
+    // the panel can resolve, so it must not be buried under three merged repos.
+    const divergedChip = aggregateLifecycle([
+      mkLife('backend', 'merged'),
+      mkLife('frontend', 'diverged'),
+      mkLife('shared', 'unpublished', 'push')
+    ])!
+    check('chip: diverged outranks even unpublished', divergedChip.phase === 'diverged')
+
+    // A repo the forge has not answered for yet is `unpublished` - what git
+    // alone knows - rather than skipped, which would let a slow lookup briefly
+    // promote the chip and then demote it.
+    const pendingLookup = aggregateLifecycle([
+      mkLife('backend', 'merged'),
+      mkLife('frontend', null)
+    ])!
+    check('chip: an unanswered repo reads as unpublished', pendingLookup.phase === 'unpublished')
+
+    check(
+      'chip: a missing checkout is excluded',
+      aggregateLifecycle([mkLife('gone', 'merged', null, false)]) === null
+    )
+    check('chip: no live repos yields no chip', aggregateLifecycle([]) === null)
+
+    // The label only gains a count when the repos DISAGREE: an all-`local`
+    // workstream says `local`, exactly as a single repo does.
+    const baseView = {
+      phase: 'unpublished' as LifecyclePhase,
+      label: 'local',
+      tone: 'neutral' as const,
+      title: 'Not pushed yet',
+      pr: null,
+      action: 'push' as LifecycleAction
+    }
+    const mixedLabel = describeCompositeLifecycle(lagging, baseView)
+    check('chip label: disagreement shows a fraction', mixedLabel.label === '1/3 local')
+    check('chip label: and the tooltip names the repos', /shared/.test(mixedLabel.title))
+
+    const agreedLabel = describeCompositeLifecycle(
+      aggregateLifecycle([
+        mkLife('backend', 'unpublished', 'push'),
+        mkLife('frontend', 'unpublished', 'push')
+      ])!,
+      baseView
+    )
+    check('chip label: agreement reads exactly like one repo', agreedLabel.label === 'local')
+    check('chip label: but says how many it speaks for', /all 2 repos/.test(agreedLabel.title))
+
+    // Push joins pull/reset in the summary vocabulary.
+    const pushed = summarizeSync(
+      [
+        { name: 'backend', ok: true, updated: true },
+        { name: 'frontend', ok: true, updated: true }
+      ],
+      'push'
+    )
+    check('summary: push says pushed', pushed.text === 'Pushed all 2 repos.')
+    check(
+      'summary: nothing to push says so in push words',
+      summarizeSync([{ name: 'backend', ok: true, updated: false }], 'push').text ===
+        'All 1 already pushed.'
+    )
 
     // The badge is null below 2 so single-repo sessions render EXACTLY as they
     // did before multi-repo support existed.


### PR DESCRIPTION
A multi-repo session could not update or reset anything. The panel showed `branch pending` and a `local` chip with no working controls, while the same panel in a single-repo session offered **Check origin/main** and **Reset to origin/main**.

Three independent causes, all reachable from that one screenshot.

## 1. A pending workstream reported no repos at all

Worktrees are materialized lazily on the first turn, so a multi-repo session has **no `repos` links** until then. `git:status-multi` returned `[]` for exactly that window, which took the repo list, the count badge and both sync buttons off screen — even though the session was really running in the project's checkouts, which were precisely the trees the user was asking about.

Both the status handler and the sync handlers now resolve repos through one shared `reposForSession`, which falls back to the project's own repos. Sharing it is the point: a second copy that only understood links is how "Reset all" would silently do nothing on a session whose worktree did not exist yet.

Those fallback repos are marked `pending: true`, so the UI can say *which* trees it is about to touch — see §4.

## 2. The chip let repo #1 speak for all N

`repos.find(r => r.forge)` picked the first repo with a forge answer and let it represent the workstream. Three repos pushed and one still local rendered `pushed`, hiding the only repo that needed work — and the primary button then acted on that one repo's `cwd`.

It now folds every repo through `aggregateLifecycle` and reports the **least-advanced** one. That is the only choice that keeps the label a promise rather than a sample:

- the label answers "is this workstream done?", and the honest answer for 3-of-4 is no;
- the action it offers therefore always has something to do;
- it can only ever under-claim progress. A chip reading `local` when one repo is unpushed costs a redundant click; one reading `merged` when a repo never got pushed loses work.

`2/4 local` when the repos disagree, plain `local` when they agree — the count exposes disagreement rather than decorating agreement. `diverged` sorts ahead of everything because it is the one phase no button in the panel can resolve.

## 3. `pushMulti` did not exist

Only `pullMulti` and `resetMulti` were ever added. The primary button ran `forge:push` against a single path, so **Push** published a quarter of a four-repo workstream and left the chip saying exactly what it said before the click.

Adds `forge:push-multi` and routes the multi-repo primary action through it. An already-pushed repo reports as a success that changed nothing, so "push all" across four repos where two are current reads as *"All 4 already pushed"* rather than two failures.

## 4. Saying whose tree is about to be destroyed

For a pending workstream the fallback repos are the **project's own checkouts** — shared with the user's editor and every other session in that folder. Same button, very different blast radius.

The panel now warns `Workstream not created yet — these are the project's own checkouts`, and the armed reset reads `Click again to stash 26 changes in the PROJECT`. "Are you sure?" says nothing; naming the tree is a decision.

I deliberately did **not** add `git checkout main`. There is no `checkout`/`switch` anywhere in this codebase by design — branch switching goes through worktrees, because switching in the default workstream mutates the checkout every other session and the user's editor share. Reset-to-`origin/main` is the equivalent without that side effect.

## Also

A per-row `push` action, so the one repo that is behind while its siblings are merged can be handled without a sweep over all of them. Shown only when the repos disagree — when they all want the same thing the summary buttons already say it once, and repeating it per row is noise. Restricted to push (additive, worst case a no-op); update and reset stay on the shared buttons, because a small unlabelled control at the end of a dense row is the last place a destructive action belongs.

## Verification

Verified against a real 2-repo workspace: `aggregateSyncTarget` previously returned `null` (both buttons hidden); it now resolves `origin/main`, 2 syncable, producing **Check origin/main** / **Reset all to origin/main**.

| Suite | Result |
| --- | --- |
| `smoke:shared` | 999 ✓ (was 982 — **+17 new**) |
| `smoke:store` | ✓ |
| `smoke:multirepo` | 42 ✓ |
| `smoke:live` | 29 ✓ |
| `smoke:cookies` | ✓ |
| `smoke:app` | 654 ✓ |

Plus `typecheck`, `format:check`, and a full `electron-vite build`.

The 17 new checks cover the fold rule directly: that the least-advanced repo sets the phase, that `diverged` outranks `unpublished`, that a repo the forge has not answered for yet reads as `unpublished` rather than being skipped (skipping would let a slow lookup briefly promote the chip and then demote it), that a missing checkout is excluded, and that an all-agreeing workstream renders exactly like a single repo.

Two notes for anyone running the suite locally, neither related to this change:

- `smoke:app` asserts an unported session does not get `PORT` set, so it fails in any shell that has `PORT` exported. Unset it first.
- The suite watchdog is a 60s budget for the *whole* run and is already documented as raisable; CI sets `SMOKE_TIMEOUT_MS=300000` for the same reason.
