### PR TITLE
refactor(tools): remove the Exa-backed websearch tool

### DIFF
--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -460,7 +460,21 @@ export const MIGRATIONS: Migration[] = [
   // their behaviour is bit-for-bit unchanged. See shared/repos.ts.
   (db) => {
     addColumnIfMissing(db, 'chats', 'repos', 'TEXT')
-  }
+  },
+
+  // ---- v22: drop the dead Exa web-search key ----
+  // The `websearch` tool and its optional Exa API key are gone; the browser
+  // tools cover search. Nothing reads `web_search_api_key` any more, so the row
+  // is inert — but it is a CREDENTIAL, and a dead credential sitting in the
+  // settings table is still a credential sitting in the settings table. It
+  // survives in backups and in anything that dumps the DB, for a feature the
+  // user can no longer see or turn off. Delete it.
+  //
+  // Data, not structure, so it belongs here and not in `repairSchema` (which is
+  // deliberately structure-only and runs on every open). One DELETE, once.
+  /* sql */ `
+    DELETE FROM settings WHERE key = 'web_search_api_key';
+  `
 ]
 
 /**

--- a/src/main/db/repo.ts
+++ b/src/main/db/repo.ts
@@ -112,7 +112,6 @@ export function getSettings(): AppSettings {
         : 'high'
     })(),
     contextLimit: map.get('context_limit') ? Number(map.get('context_limit')) : null,
-    webSearchApiKey: map.get('web_search_api_key') ?? null,
     // Defaults ON, so the absence of a row means enabled. Written only when
     // someone turns it OFF ('0'), which keeps existing installs opted in
     // without a migration.
@@ -210,12 +209,6 @@ export function setBranchPrefix(prefix: string): AppSettings {
 export function setAutoWorkstream(enabled: boolean): AppSettings {
   // Store only the OFF state; see getSettings for why.
   setSetting('auto_workstream', enabled ? null : '0')
-  return getSettings()
-}
-
-export function setWebSearchApiKey(key: string | null): AppSettings {
-  const trimmed = key?.trim()
-  setSetting('web_search_api_key', trimmed ? trimmed : null)
   return getSettings()
 }
 

--- a/src/main/harness/agent.ts
+++ b/src/main/harness/agent.ts
@@ -557,15 +557,6 @@ const BASE_SCHEMAS = [
     ['url']
   ),
   fn(
-    'websearch',
-    'Search the web for fresh, current information beyond the training cutoff, and get back the most relevant results with snippets. Use it to find docs, error messages, library versions, or recent events, then webfetch a result URL for the full page.',
-    {
-      query: str('The search query.'),
-      numResults: { type: 'number', description: 'How many results to return (default 8, max 20).' }
-    },
-    ['query']
-  ),
-  fn(
     'bash',
     'Run a shell command in the workspace (PowerShell on Windows). By default each call is a FRESH shell (cwd/env do NOT persist) that returns when the command finishes or after `timeout` seconds. For a LONG-RUNNING process (a dev server, watcher, `npm run dev`), pass background:true — it starts the process and returns immediately with an id; then use bash_output to read its logs and bash_kill to stop it.',
     {
@@ -2148,8 +2139,6 @@ function toolTitle(name: string, input: Record<string, unknown>): string {
       return s(input.url)
     case 'webfetch':
       return s(input.url)
-    case 'websearch':
-      return s(input.query)
     case 'glob':
     case 'grep':
       return s(input.pattern)

--- a/src/main/harness/tools.ts
+++ b/src/main/harness/tools.ts
@@ -12,23 +12,16 @@ import type { ToolDiff, ToolResult, SessionTask } from '../../shared/types'
 import type { WebFetchFormat } from '../../shared/web'
 import {
   BROWSER_UA,
-  EXA_MCP_URL,
   WEBFETCH_MAX_BYTES,
   WEBFETCH_OUTPUT_CAP,
   WEBFETCH_TIMEOUT_DEFAULT,
   WEBFETCH_TIMEOUT_MAX,
-  WEBSEARCH_MAX_BYTES,
-  WEBSEARCH_NO_RESULTS,
-  WEBSEARCH_TIMEOUT,
   acceptHeader,
-  buildExaRequestBody,
-  clampResults,
   convertWebContent,
   isImageMime,
   isTextualMime,
   mimeFromContentType,
-  normalizeFetchUrl,
-  parseExaResponse
+  normalizeFetchUrl
 } from '../../shared/web'
 import * as browser from '../services/browser'
 import * as lsp from '../services/lsp'
@@ -231,13 +224,6 @@ export async function runTool(
           str(input.url),
           str(input.format),
           input.timeout,
-          ctx.onChunk,
-          ctx.signal
-        )
-      case 'websearch':
-        return await runWebSearch(
-          str(input.query),
-          input.numResults ?? input.count,
           ctx.onChunk,
           ctx.signal
         )
@@ -1092,83 +1078,6 @@ function linkAbort(signal: AbortSignal | undefined, controller: AbortController)
   const onAbort = (): void => controller.abort()
   signal.addEventListener('abort', onAbort, { once: true })
   return () => signal.removeEventListener('abort', onAbort)
-}
-
-/**
- * Search the web via Exa's public MCP endpoint. Works keyless (rate-limited);
- * an optional Exa API key (Settings → Web search, or the EXA_API_KEY env var)
- * lifts the limits. Fails gracefully with a clear message when the network or
- * the provider is unavailable.
- */
-async function runWebSearch(
-  query: string,
-  numResults: unknown,
-  onChunk?: (chunk: string) => void,
-  signal?: AbortSignal
-): Promise<ToolResult> {
-  if (!query.trim()) return { ok: false, output: 'websearch: missing "query"' }
-  const count = clampResults(numResults)
-  const apiKey = webSearchApiKey()
-  const endpoint = ((): string => {
-    if (!apiKey) return EXA_MCP_URL
-    const u = new URL(EXA_MCP_URL)
-    u.searchParams.set('exaApiKey', apiKey)
-    return u.toString()
-  })()
-  onChunk?.(`Searching the web for "${query}"…`)
-
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), WEBSEARCH_TIMEOUT * 1000)
-  const unlink = linkAbort(signal, controller)
-  try {
-    const res = await fetch(endpoint, {
-      method: 'POST',
-      signal: controller.signal,
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json, text/event-stream',
-        'User-Agent': BROWSER_UA
-      },
-      body: buildExaRequestBody(query, count)
-    })
-    if (!res.ok) {
-      return {
-        ok: false,
-        output:
-          `Web search failed — HTTP ${res.status} ${res.statusText}`.trim() +
-          (res.status === 429
-            ? '\nRate limited. Add an Exa API key in Settings → Web search to raise the limit.'
-            : '')
-      }
-    }
-    const body = await readCapped(res, WEBSEARCH_MAX_BYTES)
-    const text = parseExaResponse(body)
-    return { ok: true, output: text ? capText(text, WEBFETCH_OUTPUT_CAP) : WEBSEARCH_NO_RESULTS }
-  } catch (e) {
-    if (signal?.aborted) return { ok: false, output: TOOL_ABORTED }
-    if (controller.signal.aborted) {
-      return { ok: false, output: `Web search timed out after ${WEBSEARCH_TIMEOUT}s.` }
-    }
-    return {
-      ok: false,
-      output: `Web search failed — ${e instanceof Error ? e.message : String(e)}`
-    }
-  } finally {
-    clearTimeout(timer)
-    unlink()
-  }
-}
-
-/** The optional Exa key: user setting first, then the EXA_API_KEY env var. */
-function webSearchApiKey(): string | undefined {
-  try {
-    const fromSettings = repo.getSettings().webSearchApiKey
-    if (fromSettings && fromSettings.trim()) return fromSettings.trim()
-  } catch {
-    // repo may be unavailable in non-Electron contexts — fall back to env.
-  }
-  const fromEnv = process.env.EXA_API_KEY
-  return fromEnv && fromEnv.trim() ? fromEnv.trim() : undefined
 }
 
 function clampTimeout(v: unknown): number {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -192,9 +192,6 @@ export function registerIpc(): void {
   ipcMain.handle(CHANNELS.settingsSetBranchPrefix, (_e, prefix: string) =>
     repo.setBranchPrefix(prefix)
   )
-  ipcMain.handle(CHANNELS.settingsSetWebSearchApiKey, (_e, key: string | null) =>
-    repo.setWebSearchApiKey(key)
-  )
   ipcMain.handle(CHANNELS.settingsCompleteOnboarding, () => repo.completeOnboarding())
   ipcMain.handle(CHANNELS.settingsReset, async () => {
     // "Wipes all providers" has to include the subscription tokens held by the

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -27,7 +27,6 @@ const roxy: RoxyApi = {
     setActiveAgent: (agentId) => ipcRenderer.invoke(CHANNELS.settingsSetActiveAgent, agentId),
     setReasoningEffort: (level) => ipcRenderer.invoke(CHANNELS.settingsSetReasoningEffort, level),
     setContextLimit: (limit) => ipcRenderer.invoke(CHANNELS.settingsSetContextLimit, limit),
-    setWebSearchApiKey: (key) => ipcRenderer.invoke(CHANNELS.settingsSetWebSearchApiKey, key),
     setAutoWorkstream: (enabled) => ipcRenderer.invoke(CHANNELS.settingsSetAutoWorkstream, enabled),
     setBranchPrefix: (prefix) => ipcRenderer.invoke(CHANNELS.settingsSetBranchPrefix, prefix),
     completeOnboarding: () => ipcRenderer.invoke(CHANNELS.settingsCompleteOnboarding),

--- a/src/renderer/src/components/ToolCall.tsx
+++ b/src/renderer/src/components/ToolCall.tsx
@@ -40,7 +40,6 @@ const TOOL_ICON: Record<string, LucideIcon> = {
   glob: Search,
   grep: Search,
   webfetch: Globe,
-  websearch: Globe,
   task: Hammer,
   browser_open: Globe,
   browser_screenshot: Camera,

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -204,7 +204,6 @@ interface RoxyStore {
   togglePinnedModel: (providerId: string, model: string, pinned: boolean) => Promise<void>
   setReasoningEffort: (level: ReasoningEffort) => Promise<void>
   setContextLimit: (limit: number | null) => Promise<void>
-  setWebSearchApiKey: (key: string | null) => Promise<void>
   setAutoWorkstream: (enabled: boolean) => Promise<void>
   setTelemetryEnabled: (enabled: boolean) => Promise<void>
   setBranchPrefix: (prefix: string) => Promise<void>
@@ -1477,11 +1476,6 @@ export const useRoxyStore = create<RoxyStore>((set, get) => ({
 
   setBranchPrefix: async (prefix) => {
     const settings = await api.settings.setBranchPrefix(prefix)
-    set({ settings })
-  },
-
-  setWebSearchApiKey: async (key) => {
-    const settings = await api.settings.setWebSearchApiKey(key)
     set({ settings })
   },
 

--- a/src/renderer/src/routes/Settings.tsx
+++ b/src/renderer/src/routes/Settings.tsx
@@ -30,7 +30,6 @@ export default function Settings(): JSX.Element {
   const settings = useRoxyStore((s) => s.settings)
   const refreshProviders = useRoxyStore((s) => s.refreshProviders)
   const reorderProviders = useRoxyStore((s) => s.reorderProviders)
-  const setWebSearchApiKey = useRoxyStore((s) => s.setWebSearchApiKey)
   const setAutoWorkstream = useRoxyStore((s) => s.setAutoWorkstream)
   const telemetryEnabled = useRoxyStore((s) => s.telemetryEnabled)
   const setTelemetryEnabled = useRoxyStore((s) => s.setTelemetryEnabled)
@@ -46,8 +45,6 @@ export default function Settings(): JSX.Element {
   const [update, setUpdate] = useState<UpdateInfo | null>(null)
   const [confirmingReset, setConfirmingReset] = useState(false)
   const [resetting, setResetting] = useState(false)
-  const [searchKey, setSearchKey] = useState('')
-  const [searchKeySaved, setSearchKeySaved] = useState(false)
   const [dragProviderId, setDragProviderId] = useState<string | null>(null)
   const [dragOverProviderId, setDragOverProviderId] = useState<string | null>(null)
   const [dropAfterProvider, setDropAfterProvider] = useState(false)
@@ -78,10 +75,6 @@ export default function Settings(): JSX.Element {
   }
 
   useEffect(() => {
-    setSearchKey(settings?.webSearchApiKey ?? '')
-  }, [settings?.webSearchApiKey])
-
-  useEffect(() => {
     setPrefix(settings?.branchPrefix ?? DEFAULT_BRANCH_PREFIX)
   }, [settings?.branchPrefix])
 
@@ -106,12 +99,6 @@ export default function Settings(): JSX.Element {
     clearActive()
     await bootstrap()
     navigate('/onboarding')
-  }
-
-  const saveSearchKey = async (): Promise<void> => {
-    await setWebSearchApiKey(searchKey.trim() || null)
-    setSearchKeySaved(true)
-    setTimeout(() => setSearchKeySaved(false), 2000)
   }
 
   const us = update?.state
@@ -299,48 +286,6 @@ export default function Settings(): JSX.Element {
             </p>
           </div>
           <CookiePanel className="max-h-[420px]" />
-        </div>
-      </section>
-
-      <section className="mb-8">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">
-          Web search
-        </h2>
-        <div className="flex flex-col gap-3 sq sq-xl sq-ring rounded-xl border border-border bg-surface p-4">
-          <div className="min-w-0">
-            <div className="text-sm font-medium text-text">Exa API key (optional)</div>
-            <p className="mt-0.5 text-xs text-text-muted">
-              The <code>websearch</code> tool works out of the box on Exa&apos;s free public
-              endpoint. Add a key to lift rate limits.{' '}
-              <a
-                href="https://dashboard.exa.ai/api-keys"
-                target="_blank"
-                rel="noreferrer"
-                className="text-accent hover:underline"
-              >
-                Get a key
-              </a>
-            </p>
-          </div>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <input
-              type="password"
-              value={searchKey}
-              onChange={(e) => setSearchKey(e.target.value)}
-              placeholder="exa_…"
-              className="min-w-0 flex-1 sq sq-lg sq-ring rounded-lg border border-border bg-surface-strong px-3 py-2 text-sm text-text outline-none placeholder:text-text-subtle focus:border-border-strong"
-              spellCheck={false}
-              autoComplete="off"
-            />
-            <Button
-              variant="secondary"
-              className="shrink-0"
-              disabled={searchKey.trim() === (settings?.webSearchApiKey ?? '')}
-              onClick={() => void saveSearchKey()}
-            >
-              {searchKeySaved ? 'Saved' : 'Save'}
-            </Button>
-          </div>
         </div>
       </section>
 

--- a/src/shared/agents.ts
+++ b/src/shared/agents.ts
@@ -40,7 +40,7 @@ export const AGENTS: AgentDef[] = [
     mode: 'primary',
     hidden: false,
     color: '#3fb950',
-    tools: ['read', 'grep', 'glob', 'list', 'bash', 'webfetch', 'websearch', 'skill'],
+    tools: ['read', 'grep', 'glob', 'list', 'bash', 'webfetch', 'skill'],
     promptFile: 'plan.txt'
   },
   {
@@ -60,7 +60,7 @@ export const AGENTS: AgentDef[] = [
     mode: 'subagent',
     hidden: false,
     color: '#f0883e',
-    tools: ['grep', 'glob', 'list', 'bash', 'webfetch', 'websearch', 'read', 'skill'],
+    tools: ['grep', 'glob', 'list', 'bash', 'webfetch', 'read', 'skill'],
     promptFile: 'agent-explore.txt'
   },
   {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -689,7 +689,6 @@ export interface RoxyApi {
     setActiveAgent(agentId: string): Promise<AppSettings>
     setReasoningEffort(level: ReasoningEffort): Promise<AppSettings>
     setContextLimit(limit: number | null): Promise<AppSettings>
-    setWebSearchApiKey(key: string | null): Promise<AppSettings>
     setAutoWorkstream(enabled: boolean): Promise<AppSettings>
     setBranchPrefix(prefix: string): Promise<AppSettings>
     completeOnboarding(): Promise<AppSettings>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -5,7 +5,6 @@ export const CHANNELS = {
   settingsSetActiveAgent: 'settings:setActiveAgent',
   settingsSetReasoningEffort: 'settings:setReasoningEffort',
   settingsSetContextLimit: 'settings:setContextLimit',
-  settingsSetWebSearchApiKey: 'settings:setWebSearchApiKey',
   settingsSetAutoWorkstream: 'settings:setAutoWorkstream',
   settingsSetBranchPrefix: 'settings:setBranchPrefix',
   settingsCompleteOnboarding: 'settings:completeOnboarding',

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -352,7 +352,6 @@ const REPORTABLE_TOOLS = new Set<string>([
   'bash_kill',
   // Web
   'webfetch',
-  'websearch',
   // Browser
   'browser_open',
   'browser_screenshot',

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -28,7 +28,7 @@ export interface ToolDef {
    * This gates the per-call cancel button, and the rule is honesty: a button
    * that does nothing is worse than no button. It is true only for the tools
    * whose dispatch actually honors `ctx.signal` — either by killing the work
-   * (`bash` kills the process tree, `webfetch`/`websearch` abort the request,
+   * (`bash` kills the process tree, `webfetch` aborts the request,
    * `grep`/`glob` break out of their scan) or by making the TURN stop waiting on
    * work that cannot itself be interrupted (the `untilAborted` calls: Electron
    * `webContents`, the language server, an MCP round trip).
@@ -142,14 +142,6 @@ export const TOOLS: ToolDef[] = [
     category: 'Web',
     mutates: false,
     // A dead host holds the socket open until the timeout; the fetch takes our signal.
-    interruptible: true
-  },
-  {
-    id: 'websearch',
-    name: 'websearch',
-    description: 'Search the web for fresh context beyond the training cutoff.',
-    category: 'Web',
-    mutates: false,
     interruptible: true
   },
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -396,8 +396,6 @@ export interface AppSettings {
   reasoningEffort: ReasoningEffort
   /** Chosen context-window budget in tokens; null = use the model default. */
   contextLimit: number | null
-  /** Optional Exa API key for `websearch` (empty = use the keyless public endpoint). */
-  webSearchApiKey: string | null
   /**
    * Give every new session in a git repo its own workstream (an isolated
    * worktree on its own branch) instead of running it in the project folder.

--- a/src/shared/web.ts
+++ b/src/shared/web.ts
@@ -1,12 +1,12 @@
 /**
- * Pure, dependency-free web helpers shared by the `webfetch` + `websearch`
- * tools (github.com/sst/opencode's webfetch/websearch, MIT — reimplemented here
- * without the Effect/turndown stack so the logic stays testable in the pure-Node
- * smoke harness and never leaks heavy deps into the renderer bundle).
+ * Pure, dependency-free web helpers shared by the `webfetch` tool
+ * (github.com/sst/opencode's webfetch, MIT — reimplemented here without the
+ * Effect/turndown stack so the logic stays testable in the pure-Node smoke
+ * harness and never leaks heavy deps into the renderer bundle).
  *
  * The main process (src/main/harness/tools.ts) does the actual I/O (native
- * `fetch`); everything here is pure string/URL work: URL normalization, HTML →
- * markdown/text conversion, and Exa MCP request/response shaping.
+ * `fetch`); everything here is pure string/URL work: URL normalization and
+ * HTML → markdown/text conversion.
  */
 
 export type WebFetchFormat = 'markdown' | 'text' | 'html'
@@ -21,14 +21,6 @@ export const WEBFETCH_TIMEOUT_MAX = 120
 /** A real-browser UA — many sites 403 an unknown agent. */
 export const BROWSER_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
-
-/** Exa's public MCP endpoint — works keyless (rate-limited); a key lifts limits. */
-export const EXA_MCP_URL = 'https://mcp.exa.ai/mcp'
-export const WEBSEARCH_MAX_BYTES = 512 * 1024
-export const WEBSEARCH_TIMEOUT = 30
-export const WEBSEARCH_DEFAULT_RESULTS = 8
-export const WEBSEARCH_MAX_RESULTS = 20
-export const WEBSEARCH_NO_RESULTS = 'No search results found. Try a different query.'
 
 /**
  * Validate + normalize a URL for fetching: upgrade bare `http:` to `https:`,
@@ -275,60 +267,4 @@ export function convertWebContent(
   const isHtml = contentType.toLowerCase().includes('html')
   if (!isHtml || format === 'html') return content
   return format === 'markdown' ? htmlToMarkdown(content) : htmlToText(content)
-}
-
-/** The JSON-RPC body for an Exa MCP `web_search_exa` call. */
-export function buildExaRequestBody(query: string, numResults: number): string {
-  return JSON.stringify({
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'tools/call',
-    params: {
-      name: 'web_search_exa',
-      arguments: { query, numResults }
-    }
-  })
-}
-
-/** Clamp a requested result count into the allowed range. */
-export function clampResults(n: unknown): number {
-  const v = typeof n === 'number' ? n : Number(n)
-  if (!Number.isFinite(v) || v <= 0) return WEBSEARCH_DEFAULT_RESULTS
-  return Math.min(Math.floor(v), WEBSEARCH_MAX_RESULTS)
-}
-
-/**
- * Pull the text payload out of an Exa MCP response. The endpoint answers either
- * with a plain JSON body or an SSE stream of `data: {…}` lines; in both cases the
- * useful text lives at `result.content[].text`. Returns undefined when empty.
- */
-export function parseExaResponse(body: string): string | undefined {
-  const fromPayload = (payload: string): string | undefined => {
-    const trimmed = payload.trim()
-    if (!trimmed.startsWith('{')) return undefined
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(trimmed)
-    } catch {
-      return undefined
-    }
-    const content = (parsed as { result?: { content?: unknown } })?.result?.content
-    if (!Array.isArray(content)) return undefined
-    const texts = content
-      .map((item) =>
-        item && typeof item === 'object' ? (item as { text?: unknown }).text : undefined
-      )
-      .filter((t): t is string => typeof t === 'string' && t.length > 0)
-    return texts.length ? texts.join('\n\n') : undefined
-  }
-
-  const direct = fromPayload(body)
-  if (direct) return direct
-
-  for (const line of body.split('\n')) {
-    if (!line.startsWith('data:')) continue
-    const data = fromPayload(line.slice(5))
-    if (data) return data
-  }
-  return undefined
 }

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -123,12 +123,7 @@ import {
   decodeEntities,
   htmlToText,
   htmlToMarkdown,
-  convertWebContent,
-  buildExaRequestBody,
-  clampResults,
-  parseExaResponse,
-  WEBSEARCH_MAX_RESULTS,
-  WEBSEARCH_DEFAULT_RESULTS
+  convertWebContent
 } from '../src/shared/web'
 import { resolveWorktreeCwd } from '../src/shared/workspace'
 import {
@@ -361,9 +356,7 @@ check(
 )
 check(
   'the long-blocking tools are cancellable',
-  ['bash', 'webfetch', 'websearch', 'grep', 'glob', 'lsp', 'browser_open'].every((id) =>
-    isInterruptibleTool(id)
-  )
+  ['bash', 'webfetch', 'grep', 'glob', 'lsp', 'browser_open'].every((id) => isInterruptibleTool(id))
 )
 check(
   'instant local tools offer no cancel button',
@@ -1178,7 +1171,7 @@ check(
   )
 )
 
-// ---- web helpers (Phase 6: webfetch + websearch) ----
+// ---- web helpers (Phase 6: webfetch) ----
 check(
   'normalizeFetchUrl upgrades http→https',
   normalizeFetchUrl('http://example.com/x') === 'https://example.com/x'
@@ -1271,43 +1264,6 @@ check(
 check(
   'convertWebContent html format returns raw html',
   convertWebContent('<p>hi</p>', 'text/html', 'html') === '<p>hi</p>'
-)
-check(
-  'clampResults default when invalid',
-  clampResults('abc') === WEBSEARCH_DEFAULT_RESULTS && clampResults(0) === WEBSEARCH_DEFAULT_RESULTS
-)
-check('clampResults caps at max', clampResults(999) === WEBSEARCH_MAX_RESULTS)
-check('clampResults passes valid through', clampResults(5) === 5)
-check(
-  'buildExaRequestBody is valid JSON-RPC tools/call',
-  (() => {
-    const body = JSON.parse(buildExaRequestBody('roxy harness', 8)) as {
-      jsonrpc: string
-      method: string
-      params: { name: string; arguments: { query: string; numResults: number } }
-    }
-    return (
-      body.jsonrpc === '2.0' &&
-      body.method === 'tools/call' &&
-      body.params.name === 'web_search_exa' &&
-      body.params.arguments.query === 'roxy harness' &&
-      body.params.arguments.numResults === 8
-    )
-  })()
-)
-check(
-  'parseExaResponse reads a direct JSON body',
-  parseExaResponse('{"result":{"content":[{"type":"text","text":"result A"}]}}') === 'result A'
-)
-check(
-  'parseExaResponse reads an SSE data: stream',
-  parseExaResponse(
-    'event: message\ndata: {"result":{"content":[{"type":"text","text":"streamed B"}]}}\n\n'
-  ) === 'streamed B'
-)
-check(
-  'parseExaResponse returns undefined on empty/garbage',
-  parseExaResponse('not json') === undefined
 )
 
 // ---- context management (Phase 9) ----
@@ -4827,8 +4783,7 @@ async function main(): Promise<void> {
     activeModel: 'claude-opus-5',
     activeAgentId: 'plan',
     reasoningEffort: 'max' as const,
-    contextLimit: 1_000_000,
-    webSearchApiKey: null
+    contextLimit: 1_000_000
   }
   const bare = {
     providerId: null,

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -199,11 +199,6 @@ async function main(): Promise<void> {
   check('setContextLimit persists', repo.getSettings().contextLimit === 1_000_000)
   repo.setContextLimit(null)
   check('setContextLimit clears', repo.getSettings().contextLimit === null)
-  check('web search key default null', repo.getSettings().webSearchApiKey === null)
-  repo.setWebSearchApiKey('exa_test_key')
-  check('setWebSearchApiKey persists', repo.getSettings().webSearchApiKey === 'exa_test_key')
-  repo.setWebSearchApiKey('   ')
-  check('setWebSearchApiKey blanks to null', repo.getSettings().webSearchApiKey === null)
 
   // ---- per-session inference config ----
   //
@@ -727,12 +722,6 @@ async function main(): Promise<void> {
     'webfetch rejects a malformed url',
     !badUrl.ok && badUrl.output.toLowerCase().includes('valid'),
     badUrl.output
-  )
-  const emptyQuery = await run('websearch', { query: '' })
-  check(
-    'websearch rejects an empty query',
-    !emptyQuery.ok && emptyQuery.output.includes('missing'),
-    emptyQuery.output
   )
 
   // ---- disk-backed tool-output store (Phase 9.3) ----
@@ -1317,6 +1306,56 @@ async function main(): Promise<void> {
         (db.prepare('PRAGMA table_info(chats)').all() as { name: string }[]).filter(
           (c) => c.name === 'worktree_path'
         ).length === 1
+      )
+      db.close()
+    }
+
+    // ---- v22: the dead Exa key is deleted on upgrade ----
+    // The real scenario, not a synthetic one: someone who actually typed a key
+    // into the old "Web search" settings box, then upgrades. The credential is
+    // for a feature that no longer exists and that they can no longer see, so
+    // leaving it in the settings table (and in every backup of it) is not
+    // acceptable. Drive the ladder exactly as database.ts does.
+    {
+      const db = new Database(path.join(healDir, 'v22.db'))
+      // Stop one rung short, at v21 — the last release that still had the box.
+      const priorSteps = MIGRATIONS.slice(0, MIGRATIONS.length - 1)
+      for (const step of priorSteps) {
+        if (typeof step === 'string') db.exec(step)
+        else step(db)
+      }
+      db.pragma(`user_version = ${priorSteps.length}`)
+      db.prepare('INSERT INTO settings(key, value) VALUES(?, ?)').run(
+        'web_search_api_key',
+        'exa_live_secret'
+      )
+      // A neighbouring row proves the DELETE is aimed, not a blanket wipe.
+      db.prepare('INSERT INTO settings(key, value) VALUES(?, ?)').run('active_model', 'gpt-5')
+      const keyOf = (k: string): string | undefined =>
+        (db.prepare('SELECT value AS v FROM settings WHERE key = ?').get(k) as { v: string })?.v
+      check(
+        'migration v22: the old key is present before upgrading',
+        keyOf('web_search_api_key') === 'exa_live_secret'
+      )
+
+      // The remaining rungs, applied the way database.ts applies them.
+      for (let v = priorSteps.length; v < MIGRATIONS.length; v++) {
+        const step = MIGRATIONS[v]
+        if (typeof step === 'string') db.exec(step)
+        else step(db)
+        db.pragma(`user_version = ${v + 1}`)
+      }
+
+      check(
+        'migration v22: upgrading deletes the stored Exa key',
+        keyOf('web_search_api_key') === undefined
+      )
+      check('migration v22: other settings are untouched', keyOf('active_model') === 'gpt-5')
+      // repairSchema runs on every open and must never resurrect it.
+      repairSchema(db)
+      check(
+        'migration v22: the repair step does not bring it back',
+        keyOf('web_search_api_key') === undefined
       )
       db.close()
     }


### PR DESCRIPTION
`websearch` was one tool call to Exa's public MCP endpoint, plus an optional API key in Settings to lift its rate limits. Both are gone. The browser tools already reach the open web, and this was a third-party dependency and a credential surface carried for a capability we otherwise have.

## What's removed

Removed end to end, so nothing is left half-wired:

- **The tool** — JSON schema, dispatch case, the `runWebSearch` runner, and its entry in the user-facing catalog on the Skills & Tools page.
- **The Exa protocol code** in `shared/web.ts` — `EXA_MCP_URL`, `buildExaRequestBody`, `parseExaResponse`, `clampResults`, and the `WEBSEARCH_*` constants. That module is now just webfetch's URL normalization and HTML conversion.
- **`webSearchApiKey`**, through every layer it touched: DB read/write, the IPC channel and handler, the preload bridge, `RoxyApi`, `AppSettings`, the store action, and the "Web search" section of Settings.
- **The tool from the Plan and Explore agents' allowlists**, and from the telemetry publish list.

## Migration v22 deletes the stored key

The `web_search_api_key` row was already inert once nothing read it — but "inert" is not the standard for a credential. It survives in the DB file and in every backup of it, for a feature the user can no longer see or revoke. So it gets deleted.

It goes in the migration ladder rather than `repairSchema`, which is deliberately structure-only and runs on every open — a `DELETE` there would re-execute forever instead of once.

## Testing

Four checks drive the real upgrade path: migrate to v21 (the last release that still had the settings box), write a key the way a user would have, then apply the remaining rungs exactly as `database.ts` does. They assert:

1. the key is present **before** upgrading — so the test cannot pass vacuously;
2. upgrading removes it;
3. a neighbouring `active_model` setting survives — the `DELETE` is aimed, not a blanket wipe;
4. `repairSchema` afterwards does not resurrect it.

I verified these aren't vacuous by stubbing the `DELETE` out to `SELECT 1;` — checks 2 and 4 fail, and nothing else does. A migration test that passes whether or not the migration exists is worse than no test.

Full suite green: **1001** shared, **654** app, **42** multirepo, **29** live, store guard, cookies. Typecheck, build and `format:check` clean.

## Tradeoff worth naming

`browser_*` is not a drop-in replacement. `websearch` was a single call returning ranked snippets; the browser path is navigate → read → parse, and search engines are actively hostile to automation (CAPTCHAs, bot walls). Agents will spend more turns on this and will sometimes be blocked outright. That's a real cost, weighed against dropping a third-party dependency and an API-key surface.

## Note for reviewers

This does not reach backups already taken, WAL/journal remnants, or the freed SQLite pages themselves — SQLite marks pages reusable rather than zeroing them, so the bytes can linger in the file until overwritten. A `VACUUM` would rewrite the file and drop that residue, but it rewrites the entire DB on next launch (a real startup cost for every user) and can't run inside the migration transaction. Happy to add it if we think the residue matters.
