### PR TITLE
feat(themes): user-authored theme.json files

### DIFF
--- a/src/main/db/repo.ts
+++ b/src/main/db/repo.ts
@@ -119,7 +119,8 @@ export function getSettings(): AppSettings {
     autoWorkstream: map.get('auto_workstream') !== '0',
     // `?? DEFAULT` and not `|| DEFAULT`: an EMPTY string is a deliberate
     // "no prefix", and must survive a round trip through settings.
-    branchPrefix: map.get('branch_prefix') ?? DEFAULT_BRANCH_PREFIX
+    branchPrefix: map.get('branch_prefix') ?? DEFAULT_BRANCH_PREFIX,
+    activeThemeId: map.get('active_theme_id') ?? null
   }
 }
 
@@ -204,6 +205,11 @@ export function setContextLimit(limit: number | null): AppSettings {
 export function setBranchPrefix(prefix: string): AppSettings {
   // Store even the empty string, so "no prefix" is distinguishable from unset.
   setSetting('branch_prefix', normalizeBranchPrefix(prefix))
+  return getSettings()
+}
+
+export function setActiveThemeId(id: string | null): AppSettings {
+  setSetting('active_theme_id', id)
   return getSettings()
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,15 @@ import { initAutoUpdater } from './services/updater'
 import { initTracking, shutdownTracking } from './services/track'
 import { killAllBackground, setPromptText, setAgentPromptText } from './harness'
 import { PROMPT_TEXT, AGENT_PROMPT_TEXT } from '../shared/prompt-text'
+import {
+  OVERLAY_HEIGHT,
+  applyWindowChrome,
+  chromePlatform,
+  initialBackgroundColor,
+  initialOverlay
+} from './services/window-chrome'
+import { resolveThemeById } from './services/themes'
+import * as repo from './db/repo'
 
 function createWindow(): BrowserWindow {
   const isMac = process.platform === 'darwin'
@@ -30,13 +39,13 @@ function createWindow(): BrowserWindow {
     minHeight: 480,
     show: false,
     autoHideMenuBar: true,
-    backgroundColor: '#0a0a0a',
+    backgroundColor: initialBackgroundColor(),
     title: 'Roxy',
     // Native window controls, themed to match the app (no light OS title bar).
     titleBarStyle: 'hidden',
     ...(isMac
       ? { trafficLightPosition: { x: 16, y: 17 } }
-      : { titleBarOverlay: { color: '#0a0a0a', symbolColor: '#9a9aa3', height: 48 } }),
+      : { titleBarOverlay: initialOverlay(OVERLAY_HEIGHT.main) }),
     ...(isMac ? {} : { icon }),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
@@ -46,6 +55,12 @@ function createWindow(): BrowserWindow {
   })
 
   mainWindow.on('ready-to-show', () => {
+    // Repaint the native window controls from the active theme before the
+    // window is first shown. The constructor can only reach built-in themes
+    // synchronously; this covers a user theme, whose file has to be read.
+    void resolveThemeById(repo.getSettings().activeThemeId, chromePlatform())
+      .then((theme) => applyWindowChrome(mainWindow, theme))
+      .catch(() => undefined)
     mainWindow.show()
   })
 

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -78,6 +78,20 @@ import {
   deleteSkill,
   installSkillFromSource
 } from '../services/skills'
+import {
+  createTheme,
+  deleteTheme,
+  findTheme,
+  listThemes,
+  readThemeSource,
+  refreshThemes,
+  resolveThemeById,
+  themeWarnings,
+  userThemesDir,
+  writeTheme
+} from '../services/themes'
+import { DEFAULT_THEME_ID, type PlatformId, type ResolvedTheme } from '../../shared/theme'
+import { applyWindowChromeAll } from '../services/window-chrome'
 import { runSessionTurn } from '../services/session-turn'
 import {
   isTrackingEnabled,
@@ -402,6 +416,98 @@ export function registerIpc(): void {
       error: res.error,
       skills: await discoverSkillViews(cwd)
     }
+  })
+
+  // ---- themes ----
+  //
+  // The renderer never reads a theme file itself: main resolves an id into the
+  // exact set of CSS custom properties to apply, so validation happens once,
+  // in one place, for every window.
+
+  /** The platform whose system font stack system should expand to. */
+  const themePlatform = (): PlatformId =>
+    process.platform === 'darwin' ? 'darwin' : process.platform === 'linux' ? 'linux' : 'win32'
+
+  const themeList = async (): Promise<{
+    themes: Awaited<ReturnType<typeof listThemes>>
+    activeId: string
+    directory: string
+    warnings: { file: string; message: string }[]
+  }> => {
+    const themes = await listThemes()
+    const stored = repo.getSettings().activeThemeId
+    // Report the theme actually in force. A stored id whose file has since been
+    // deleted resolves to the default, and the picker must agree with what the
+    // window is painting -- otherwise it highlights a theme that isn't applied.
+    const activeId = themes.some((t) => t.id === stored) ? stored! : DEFAULT_THEME_ID
+    return { themes, activeId, directory: userThemesDir(), warnings: themeWarnings() }
+  }
+
+  /** Push the active theme to every window, so a change follows across them. */
+  const broadcastTheme = async (): Promise<ResolvedTheme> => {
+    const resolved = await resolveThemeById(repo.getSettings().activeThemeId, themePlatform())
+    // The window controls (minimise / maximise / close) are drawn by the OS,
+    // above the page, so CSS cannot reach them -- they have to be repainted
+    // here or they keep the old theme's colors in the corner of the window.
+    applyWindowChromeAll(resolved)
+    for (const win of BrowserWindow.getAllWindows()) {
+      try {
+        if (!win.isDestroyed()) win.webContents.send(CHANNELS.themesChanged, resolved)
+      } catch {
+        // window went away mid-send -- ignore
+      }
+    }
+    return resolved
+  }
+
+  ipcMain.handle(CHANNELS.themesList, () => themeList())
+  ipcMain.handle(CHANNELS.themesRefresh, () => {
+    refreshThemes()
+    return themeList()
+  })
+  ipcMain.handle(CHANNELS.themesRead, (_e, id: string) => readThemeSource(id))
+  ipcMain.handle(CHANNELS.themesResolve, (_e, id?: string | null) =>
+    resolveThemeById(id === undefined ? repo.getSettings().activeThemeId : id, themePlatform())
+  )
+  ipcMain.handle(CHANNELS.themesSave, async (_e, id: string, source: string) => {
+    const res = await writeTheme(source, { id })
+    if (!res.ok) return { ok: false, error: res.error }
+    // Re-apply if the theme being edited is the one on screen, so the editor
+    // doubles as a live preview.
+    if (repo.getSettings().activeThemeId === res.id) await broadcastTheme()
+    return { ok: true, id: res.id, warnings: res.warnings, themes: await listThemes() }
+  })
+  ipcMain.handle(CHANNELS.themesCreate, async (_e, input: { name: string; from?: string }) => {
+    const res = await createTheme(input)
+    if (!res.ok) return { ok: false, error: res.error }
+    return { ok: true, id: res.id, themes: await listThemes() }
+  })
+  ipcMain.handle(CHANNELS.themesRemove, async (_e, id: string) => {
+    const res = await deleteTheme(id)
+    if (!res.ok) return { ok: false, error: res.error }
+    // Deleting the active theme has to fall back, or the next launch paints
+    // with an id that no longer resolves to anything.
+    if (repo.getSettings().activeThemeId === id) {
+      repo.setActiveThemeId(null)
+      await broadcastTheme()
+    }
+    return { ok: true, id, themes: await listThemes() }
+  })
+  ipcMain.handle(CHANNELS.themesReveal, async (_e, id: string) => {
+    // An empty id means "just open the themes folder" -- that is the Themes
+    // page's Open folder button, which is about the directory rather than any
+    // one theme. A built-in resolves the same way, having no file of its own.
+    const location = id ? (await listThemes()).find((t) => t.id === id)?.location : null
+    shell.openPath(location ?? userThemesDir())
+  })
+  ipcMain.handle(CHANNELS.themesSetActive, async (_e, id: string) => {
+    // Store null for the default, so a fresh install and an explicit pick of
+    // the default are the same state.
+    const known = id && (await findTheme(id))
+    repo.setActiveThemeId(known && id !== DEFAULT_THEME_ID ? id : null)
+    // Answer the caller with the same object every OTHER window is told about,
+    // so the window that asked cannot end up a frame out of step with the rest.
+    return broadcastTheme()
   })
 
   // ---- system ----

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -18,6 +18,15 @@ import { BrowserView, BrowserWindow } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import {
+  OVERLAY_HEIGHT,
+  applyWindowChrome,
+  initialBackgroundColor,
+  chromePlatform,
+  initialOverlay
+} from './window-chrome'
+import { resolveThemeById } from './themes'
+import { getSettings } from '../db/repo'
 import { CHANNELS } from '../../shared/ipc'
 import type { BrowserState, BrowserTab } from '../../shared/api'
 import { attachNativeContextMenu } from './context-menu'
@@ -126,7 +135,7 @@ function ensureWindow(s: Session): BrowserWindow {
     height: 860,
     show: true,
     title: windowTitle(s),
-    backgroundColor: '#0a0a0a',
+    backgroundColor: initialBackgroundColor(),
     autoHideMenuBar: true,
     ...(isMac || !appIconPath ? {} : { icon: appIconPath }),
     // Hide the native OS title bar â€” our React chrome (tab strip + URL bar) IS
@@ -135,7 +144,7 @@ function ensureWindow(s: Session): BrowserWindow {
     titleBarStyle: 'hidden',
     ...(isMac
       ? { trafficLightPosition: { x: 12, y: 14 } }
-      : { titleBarOverlay: { color: '#0f0f10', symbolColor: '#9a9aa3', height: 40 } }),
+      : { titleBarOverlay: initialOverlay(OVERLAY_HEIGHT.browser) }),
     webPreferences: {
       preload: path.join(__dirname, '../preload/index.js'),
       sandbox: false,
@@ -143,6 +152,13 @@ function ensureWindow(s: Session): BrowserWindow {
     }
   })
   s.win = win
+
+  // A window opened AFTER a theme change would otherwise wear the constructor's
+  // fallback colors, since the theme broadcast only reaches windows that already
+  // existed. Catch it up immediately.
+  void resolveThemeById(getSettings().activeThemeId, chromePlatform()).then((theme) =>
+    applyWindowChrome(win, theme)
+  )
 
   // The chrome (tab strip + URL bar) is a real React app rendered into the
   // WINDOW's OWN webContents â€” not a BrowserView â€” so its title-bar strip is

--- a/src/main/services/themes.ts
+++ b/src/main/services/themes.ts
@@ -1,0 +1,275 @@
+/**
+ * Themes service — user `theme.json` files on disk.
+ *
+ * Mirrors the shape of the skills service: discover from a fixed set of roots,
+ * cache the scan, and degrade gracefully (an unreadable or malformed theme is
+ * skipped and reported, never thrown into the caller). All parsing, validation
+ * and resolution lives in `shared/theme.ts`, so this file only does IO.
+ *
+ * Layout — one folder per theme, so a theme can later carry assets (a font
+ * file, a preview image) without changing the format:
+ *
+ *   <userData>/themes/<id>/theme.json      created by the app
+ *   ~/.roxy/themes/<id>/theme.json         hand-authored / shared / dotfiles
+ *
+ * A bare `<id>.json` is accepted too, since that is what someone dropping a
+ * single file in will naturally write.
+ */
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { app } from 'electron'
+import {
+  DEFAULT_THEME_ID,
+  THEME_FILENAME,
+  BUILT_IN_THEMES,
+  getBuiltInTheme,
+  isBuiltInThemeId,
+  isValidThemeId,
+  parseTheme,
+  resolveTheme,
+  sanitizeThemeId,
+  serializeTheme,
+  starterTheme,
+  toThemeView,
+  type PlatformId,
+  type ResolvedTheme,
+  type ThemeFile,
+  type ThemeView
+} from '../../shared/theme'
+
+/** Where the app writes themes it creates. */
+export function userThemesDir(): string {
+  return path.join(app.getPath('userData'), 'themes')
+}
+
+/**
+ * Every root scanned, nearest-wins first. The userData dir comes first so a
+ * theme edited in the app beats a same-id theme in the dotfiles dir.
+ */
+function themeRoots(): string[] {
+  const home = os.homedir()
+  return [
+    userThemesDir(),
+    path.join(home, '.roxy', 'themes'),
+    path.join(home, '.config', 'roxy', 'themes')
+  ]
+}
+
+/** A theme found on disk: what it says, and exactly which file said it. */
+interface DiscoveredTheme {
+  theme: ThemeFile
+  /** The theme.json (or bare <id>.json) itself — what we read and rewrite. */
+  file: string
+  /** Its containing folder, shown in the UI and used by "Reveal". */
+  location: string
+}
+
+/** Discovered user themes, keyed by id. Warmed lazily; dropped by refresh. */
+let cache: Map<string, DiscoveredTheme> | null = null
+/** Non-fatal problems from the last scan, surfaced in the Themes page. */
+let scanWarnings: { file: string; message: string }[] = []
+
+async function readThemeFile(file: string): Promise<DiscoveredTheme | null> {
+  let raw: string
+  try {
+    raw = await fs.readFile(file, 'utf8')
+  } catch {
+    return null
+  }
+  const parsed = parseTheme(raw)
+  if (!parsed.ok) {
+    scanWarnings.push({ file, message: parsed.error })
+    return null
+  }
+  for (const w of parsed.warnings) scanWarnings.push({ file, message: w })
+  return { theme: parsed.theme, file, location: path.dirname(file) }
+}
+
+/** Candidate theme files in one root: `<id>/theme.json` and bare `<id>.json`. */
+async function themeFilesIn(root: string): Promise<string[]> {
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true })
+  } catch {
+    return [] // missing root is the normal case, not an error
+  }
+  const files: string[] = []
+  for (const entry of entries) {
+    if (entry.isDirectory()) files.push(path.join(root, entry.name, THEME_FILENAME))
+    else if (entry.isFile() && entry.name.endsWith('.json')) files.push(path.join(root, entry.name))
+  }
+  return files
+}
+
+async function scan(): Promise<Map<string, DiscoveredTheme>> {
+  if (cache) return cache
+  scanWarnings = []
+  const found = new Map<string, DiscoveredTheme>()
+  for (const root of themeRoots()) {
+    for (const file of await themeFilesIn(root)) {
+      const entry = await readThemeFile(file)
+      if (!entry) continue
+      const { id } = entry.theme
+      // First root to claim an id wins (roots are ordered by precedence), and a
+      // user theme may not shadow a built-in — that would make the default
+      // impossible to get back to from the UI.
+      if (found.has(id)) continue
+      if (isBuiltInThemeId(id)) {
+        scanWarnings.push({
+          file,
+          message: `"${id}" is the id of a built-in theme — rename it to load this file.`
+        })
+        continue
+      }
+      found.set(id, entry)
+    }
+  }
+  cache = found
+  return found
+}
+
+/** Drop the discovery cache so the next read re-scans. */
+export function refreshThemes(): void {
+  cache = null
+}
+
+/** Built-ins followed by user themes, for the picker. */
+export async function listThemes(): Promise<ThemeView[]> {
+  const user = await scan()
+  return [
+    ...BUILT_IN_THEMES.map((t) => toThemeView(t, 'builtin')),
+    ...[...user.values()].map((e) => toThemeView(e.theme, 'user', e.location))
+  ]
+}
+
+/** Problems found during the last scan (bad JSON, unknown tokens). */
+export function themeWarnings(): { file: string; message: string }[] {
+  return scanWarnings
+}
+
+/** One theme by id — built-in or user. */
+export async function findTheme(id: string): Promise<ThemeFile | null> {
+  const builtin = getBuiltInTheme(id)
+  if (builtin) return builtin
+  const user = await scan()
+  return user.get(id)?.theme ?? null
+}
+
+/** A theme's raw file text, for the built-in editor. */
+export async function readThemeSource(id: string): Promise<string | null> {
+  const builtin = getBuiltInTheme(id)
+  if (builtin) return serializeTheme(builtin)
+  const user = await scan()
+  const entry = user.get(id)
+  if (!entry) return null
+  try {
+    return await fs.readFile(entry.file, 'utf8')
+  } catch {
+    return serializeTheme(entry.theme)
+  }
+}
+
+/**
+ * Resolve a theme id to the custom properties the renderer applies.
+ *
+ * Falls back to the default rather than failing: a theme deleted outside the
+ * app (or a stale id in settings) must still boot into a usable window.
+ */
+export async function resolveThemeById(
+  id: string | null,
+  platform: PlatformId
+): Promise<ResolvedTheme> {
+  const user = await scan()
+  const lookup = (themeId: string): ThemeFile | undefined =>
+    getBuiltInTheme(themeId) ?? user.get(themeId)?.theme
+  const theme = (id ? lookup(id) : undefined) ?? getBuiltInTheme(DEFAULT_THEME_ID)!
+  return resolveTheme(theme, platform, lookup)
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+function themeDir(id: string): string {
+  return path.join(userThemesDir(), id)
+}
+
+/** Write a theme, creating its folder. Returns the id actually used. */
+export async function writeTheme(
+  source: string,
+  options: { id?: string } = {}
+): Promise<{ ok: true; id: string; warnings: string[] } | { ok: false; error: string }> {
+  const parsed = parseTheme(source)
+  if (!parsed.ok) return { ok: false, error: parsed.error }
+  const theme = parsed.theme
+  const id = options.id ?? theme.id
+  if (!isValidThemeId(id)) {
+    return { ok: false, error: 'Invalid theme id — use lowercase letters, digits and dashes.' }
+  }
+  if (isBuiltInThemeId(id)) {
+    return { ok: false, error: `"${id}" is a built-in theme. Duplicate it under a new id instead.` }
+  }
+  // Rewrite a theme where it was found, so editing one that lives in
+  // `~/.roxy/themes` (or is checked into dotfiles) updates that file rather
+  // than silently forking a second copy into userData that then shadows it.
+  const existing = (await scan()).get(id)
+  const target = existing?.file ?? path.join(themeDir(id), THEME_FILENAME)
+  try {
+    await fs.mkdir(path.dirname(target), { recursive: true })
+    // Serialize from the PARSED theme, not the raw text: that strips anything
+    // validation dropped, so what's on disk is exactly what the app applies.
+    await fs.writeFile(target, serializeTheme({ ...theme, id }), 'utf8')
+  } catch (err) {
+    return { ok: false, error: `Could not write the theme: ${(err as Error).message}` }
+  }
+  refreshThemes()
+  return { ok: true, id, warnings: parsed.warnings }
+}
+
+/** Create a new theme, or duplicate an existing one, under a fresh id. */
+export async function createTheme(input: {
+  name: string
+  from?: string
+}): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const name = input.name.trim() || 'My theme'
+  const user = await scan()
+  // Take the first free id, so "Duplicate" twice doesn't overwrite the first.
+  const base = sanitizeThemeId(name)
+  let id = base
+  for (let n = 2; isBuiltInThemeId(id) || user.has(id); n++) id = `${base}-${n}`
+
+  let seed: ThemeFile
+  if (input.from) {
+    const source = await findTheme(input.from)
+    if (!source) return { ok: false, error: `No theme named "${input.from}".` }
+    seed = { ...source, id, name, description: source.description, author: source.author }
+  } else {
+    seed = starterTheme(id, name)
+  }
+  const written = await writeTheme(serializeTheme(seed), { id })
+  if (!written.ok) return written
+  return { ok: true, id }
+}
+
+/** Delete a user theme. Built-ins are not deletable. */
+export async function deleteTheme(id: string): Promise<{ ok: boolean; error?: string }> {
+  if (isBuiltInThemeId(id)) return { ok: false, error: 'Built-in themes cannot be deleted.' }
+  const user = await scan()
+  const entry = user.get(id)
+  if (!entry) return { ok: false, error: `No theme named "${id}".` }
+  // Only remove a folder we own. A bare `<id>.json` dropped in a root has its
+  // own file removed instead of its parent, which is a shared directory.
+  try {
+    const owned = path.resolve(entry.location).startsWith(path.resolve(userThemesDir()))
+    if (owned && path.basename(entry.location) === id) {
+      await fs.rm(entry.location, { recursive: true, force: true })
+    } else {
+      await fs.rm(entry.file, { force: true })
+    }
+  } catch (err) {
+    return { ok: false, error: `Could not delete the theme: ${(err as Error).message}` }
+  }
+  refreshThemes()
+  return { ok: true }
+}

--- a/src/main/services/window-chrome.ts
+++ b/src/main/services/window-chrome.ts
@@ -1,0 +1,144 @@
+/**
+ * Native window chrome — the parts of the window CSS cannot reach.
+ *
+ * On Windows and Linux the minimise / maximise / close buttons are drawn by the
+ * OS into a Window Controls Overlay, not by us. That overlay sits above the
+ * page, so no stylesheet touches it: give it a fixed color and it stays that
+ * color forever, which is exactly the dark block that shows up as a mismatched
+ * rectangle in the corner of a light theme.
+ *
+ * Two other native surfaces have the same problem and are handled here too:
+ *
+ *  - `backgroundColor`, painted before the renderer has drawn anything. Wrong
+ *    value = a flash of the old theme on launch and on resize.
+ *  - The symbol color of the control glyphs, which has to stay legible against
+ *    whatever the theme put behind it.
+ *
+ * The overlay is set TRANSPARENT rather than recolored. The page already paints
+ * that strip (the title bar is our own React header), so letting the app's own
+ * background show through means the controls sit on the real UI — including a
+ * gradient or any other treatment a theme uses that a single flat color could
+ * never match. Only the glyphs are colored, and they follow the theme's text.
+ */
+import { BrowserWindow } from 'electron'
+import {
+  DEFAULT_THEME_ID,
+  getBuiltInTheme,
+  type PlatformId,
+  type ResolvedTheme
+} from '../../shared/theme'
+import { getSettings } from '../db/repo'
+
+/**
+ * Fully-transparent black is special-cased by Electron and falls back to the
+ * default frame color (electron#51014), which is the opaque block we are trying
+ * to remove. A single unit of red is visually identical, is still fully
+ * transparent, and takes the intended code path.
+ */
+const TRANSPARENT = 'rgba(1, 0, 0, 0)'
+
+/** Sensible fallbacks if a theme somehow omits these (it shouldn't). */
+const FALLBACK_BG = '#0a0a0a'
+const FALLBACK_SYMBOL = '#9a9aa3'
+
+/** The window-control heights this app uses, per window kind. */
+export const OVERLAY_HEIGHT = { main: 48, browser: 40 } as const
+
+/**
+ * The glyph color for the window controls.
+ *
+ * Uses the theme's muted text so the buttons read as chrome rather than
+ * content, and stays legible on both polarities because a light theme's muted
+ * text is dark by construction.
+ */
+export function symbolColorFor(theme: ResolvedTheme): string {
+  const muted = theme.vars['--color-text-muted']
+  // The OS parses this itself and understands only literal colors — a `var()`
+  // or `color-mix()` would be dropped and silently revert to the system color.
+  if (muted && /^#|^rgb|^hsl/i.test(muted.trim())) return muted.trim()
+  return theme.appearance === 'light' ? '#5c5c66' : FALLBACK_SYMBOL
+}
+
+/** The opaque color painted before the first frame, and behind the page. */
+export function backgroundColorFor(theme: ResolvedTheme): string {
+  const bg = theme.vars['--color-bg']
+  // Must be opaque and literal: this is what the OS shows during a resize, so a
+  // translucent or unparseable value flashes as black.
+  if (bg && /^#[0-9a-f]{6}$/i.test(bg.trim())) return bg.trim()
+  return theme.appearance === 'light' ? '#ffffff' : FALLBACK_BG
+}
+
+/**
+ * Apply a theme to one window's native chrome.
+ *
+ * Best-effort by design: `setTitleBarOverlay` throws on a window that was not
+ * created with an overlay (every window on macOS, where the traffic lights are
+ * native and already follow the OS), and a window can be destroyed between the
+ * broadcast and this call. Neither is worth failing a theme change over.
+ */
+export function applyWindowChrome(win: BrowserWindow, theme: ResolvedTheme): void {
+  if (win.isDestroyed()) return
+  try {
+    win.setBackgroundColor(backgroundColorFor(theme))
+  } catch {
+    // ignore — cosmetic
+  }
+  // macOS draws its own traffic lights and has no overlay to set.
+  if (process.platform === 'darwin') return
+  try {
+    win.setTitleBarOverlay({
+      color: TRANSPARENT,
+      symbolColor: symbolColorFor(theme)
+    })
+  } catch {
+    // Window has no overlay (or an older Electron): leave it as constructed.
+  }
+}
+
+/** The platform id the theme resolver expects, from the current process. */
+export function chromePlatform(): PlatformId {
+  return process.platform === 'darwin' ? 'darwin' : process.platform === 'linux' ? 'linux' : 'win32'
+}
+
+/** Apply a theme to every open window. */
+export function applyWindowChromeAll(theme: ResolvedTheme): void {
+  for (const win of BrowserWindow.getAllWindows()) applyWindowChrome(win, theme)
+}
+
+/**
+ * The `titleBarOverlay` to construct a window with.
+ *
+ * Transparent from the very first frame, so a window never flashes an opaque
+ * block before the theme arrives. `height` is the one part that is structural
+ * rather than cosmetic — it must match the app's header height or the controls
+ * overlap the UI.
+ */
+export function initialOverlay(height: number): Electron.TitleBarOverlay {
+  return { color: TRANSPARENT, symbolColor: FALLBACK_SYMBOL, height }
+}
+
+/**
+ * The opaque color to construct a window with, read straight from settings.
+ *
+ * Synchronous on purpose. It is needed inside the BrowserWindow constructor,
+ * before any await, because this is the color the OS paints BEFORE the renderer
+ * has drawn a single frame. Resolving it asynchronously would mean every launch
+ * flashes the default palette on the way to the user's actual theme -- the same
+ * flash primeTheme() exists to prevent on the renderer side.
+ */
+export function initialBackgroundColor(): string {
+  try {
+    // Safe to read here: the DB is opened lazily by getDb(), so importing the
+    // repo does not itself touch disk -- this call is the first thing that does.
+    const id = getSettings().activeThemeId
+    // Only built-ins are readable synchronously; a user theme lives on disk and
+    // arrives a moment later over the normal theme broadcast. Falling back to the
+    // default still avoids the jarring flash for everyone on a built-in.
+    const theme = (id ? getBuiltInTheme(id) : null) ?? getBuiltInTheme(DEFAULT_THEME_ID)
+    const bg = theme?.colors?.bg
+    if (bg && /^#[0-9a-f]{6}$/i.test(bg)) return bg
+  } catch {
+    // Settings unreadable this early: the default is the safe answer.
+  }
+  return FALLBACK_BG
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,7 @@ import type {
   UpdateState
 } from '../shared/api'
 import type { CliProxyState } from '../shared/cliproxy'
+import type { ResolvedTheme } from '../shared/theme'
 
 /**
  * The typed bridge exposed to the renderer as `window.roxy`. Every method maps
@@ -83,6 +84,23 @@ const roxy: RoxyApi = {
     update: (input, cwd) => ipcRenderer.invoke(CHANNELS.skillsUpdate, input, cwd),
     remove: (name, cwd) => ipcRenderer.invoke(CHANNELS.skillsRemove, name, cwd),
     install: (source, cwd) => ipcRenderer.invoke(CHANNELS.skillsInstall, source, cwd)
+  },
+  themes: {
+    list: () => ipcRenderer.invoke(CHANNELS.themesList),
+    refresh: () => ipcRenderer.invoke(CHANNELS.themesRefresh),
+    read: (id) => ipcRenderer.invoke(CHANNELS.themesRead, id),
+    resolve: (id) => ipcRenderer.invoke(CHANNELS.themesResolve, id),
+    save: (id, source) => ipcRenderer.invoke(CHANNELS.themesSave, id, source),
+    create: (input) => ipcRenderer.invoke(CHANNELS.themesCreate, input),
+    remove: (id) => ipcRenderer.invoke(CHANNELS.themesRemove, id),
+    reveal: (id) => ipcRenderer.invoke(CHANNELS.themesReveal, id),
+    setActive: (id) => ipcRenderer.invoke(CHANNELS.themesSetActive, id),
+    onChanged: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, theme: ResolvedTheme): void =>
+        callback(theme)
+      ipcRenderer.on(CHANNELS.themesChanged, handler)
+      return () => ipcRenderer.removeListener(CHANNELS.themesChanged, handler)
+    }
   },
   system: {
     getVersions: () => ipcRenderer.invoke(CHANNELS.systemGetVersions),

--- a/src/renderer/browser.html
+++ b/src/renderer/browser.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Roxy Browser</title>
   </head>
-  <body style="background: #0a0a0a">
+  <!-- Painted before the bundle runs, so the window never flashes white. The
+       theme's real background replaces it a moment later (lib/theme.ts), and
+       the window's own backgroundColor covers the gap before this parses. -->
+  <body style="background: var(--color-bg, #0a0a0a)">
     <div id="root"></div>
     <script type="module" src="/src/browser/main.tsx"></script>
   </body>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import Chat from './routes/Chat'
 import Integrations from './routes/Integrations'
 import Skills from './routes/Skills'
 import Mcp from './routes/Mcp'
+import Themes from './routes/Themes'
 import Settings from './routes/Settings'
 
 function Splash(): JSX.Element {
@@ -42,6 +43,7 @@ export default function App(): JSX.Element {
         <Route path="/integrations" element={<Integrations />} />
         <Route path="/skills" element={<Skills />} />
         <Route path="/mcp" element={<Mcp />} />
+        <Route path="/themes" element={<Themes />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -174,7 +174,13 @@
 
 /* On macOS, prefer the native system font (San Francisco) over Geist so the app
    feels at home. Windows/Linux keep Geist. These override the @theme vars, which
-   both `body` and Tailwind's font-sans/font-mono utilities read from. */
+   both `body` and Tailwind's font-sans/font-mono utilities read from.
+
+   A theme that names a font wins over this, because `lib/theme.ts` applies its
+   fonts as INLINE styles on <html>, and those beat any selector. A theme that
+   stays quiet about fonts emits nothing at all, so this rule still decides --
+   which is exactly why resolveTheme() omits font properties rather than
+   defaulting them. */
 [data-platform='darwin'] {
   --font-sans:
     -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', system-ui, sans-serif;
@@ -332,6 +338,10 @@
   --sq-fill: var(--color-elevated);
 }
 .sq-fill-white {
+  /* Deliberately LITERAL white, not the `white` polarity token: its only user
+     is the Remote Workspace QR panel, and a QR code has to stay dark-on-light
+     to be scannable. Inverting it under a light theme would silently break
+     pairing -- a physical scanning target is not themeable chrome. */
   --sq-fill: #fff;
 }
 
@@ -403,7 +413,7 @@ body {
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--color-accent) 30%, transparent);
+  background: var(--theme-selection, color-mix(in srgb, var(--color-accent) 30%, transparent));
 }
 
 /* Scrollbars.
@@ -428,13 +438,18 @@ body {
   height: 10px;
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--color-border-strong);
+  background: var(--theme-scrollbar-thumb, var(--color-border-strong));
   border-radius: 9999px;
   border: 2px solid transparent;
   background-clip: content-box;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: #3d3d43;
+  /* Was a hardcoded #3d3d43, which stayed dark-grey under a light theme.
+     `color-mix` keeps it relative to the palette, so it tracks any theme. */
+  background: var(
+    --theme-scrollbar-thumb-hover,
+    color-mix(in srgb, var(--color-border-strong) 70%, var(--color-text-subtle))
+  );
   background-clip: content-box;
 }
 ::-webkit-scrollbar-track {

--- a/src/renderer/src/browser/main.tsx
+++ b/src/renderer/src/browser/main.tsx
@@ -5,9 +5,16 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserChrome } from './BrowserChrome'
 import { AppContextMenu } from '../components/AppContextMenu'
+import { primeTheme, startTheme } from '../lib/theme'
 
 // Reserve space for the native window-control overlay (same as the main window).
 document.documentElement.dataset.platform = window.electron?.process?.platform ?? 'win32'
+
+// The browser toolbar is a second window of the same app, so it follows the
+// same theme -- and stays in step, because startTheme subscribes to changes
+// broadcast from main rather than reading a value once at launch.
+primeTheme()
+startTheme()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   MonitorSmartphone,
   PanelLeftClose,
   PanelLeftOpen,
+  Palette,
   Plug,
   Plus,
   Settings as SettingsIcon,
@@ -534,6 +535,13 @@ export function Sidebar(): JSX.Element {
             className="press-scale flex h-8 w-8 items-center justify-center sq sq-lg rounded-lg text-text-muted hover:bg-white/5 hover:text-text"
           >
             <Plug className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => navigate('/themes')}
+            title="Themes"
+            className="press-scale flex h-8 w-8 items-center justify-center sq sq-lg rounded-lg text-text-muted hover:bg-white/5 hover:text-text"
+          >
+            <Palette className="h-4 w-4" />
           </button>
           <button
             onClick={() => navigate('/settings')}
@@ -1139,7 +1147,8 @@ function CustomizeNav({
   }[] = [
     { label: 'Remote Workspace', icon: MonitorSmartphone, onClick: onOpenRemote, dot: remoteDot },
     { label: 'Skills', icon: Lightbulb, onClick: () => navigate('/skills'), count: counts.skills },
-    { label: 'MCP Servers', icon: Plug, onClick: () => navigate('/mcp'), count: counts.mcp }
+    { label: 'MCP Servers', icon: Plug, onClick: () => navigate('/mcp'), count: counts.mcp },
+    { label: 'Themes', icon: Palette, onClick: () => navigate('/themes') }
   ]
   return (
     <div className="border-t border-border px-3 py-2">

--- a/src/renderer/src/components/ui.tsx
+++ b/src/renderer/src/components/ui.tsx
@@ -43,7 +43,7 @@ export function Button({
   return (
     <button
       className={cn(
-        'press-scale sq sq-lg inline-flex items-center justify-center rounded-lg font-medium focus:outline-none disabled:cursor-not-allowed disabled:opacity-40',
+        'press-scale sq sq-lg inline-flex items-center justify-center whitespace-nowrap rounded-lg font-medium focus:outline-none disabled:cursor-not-allowed disabled:opacity-40',
         BUTTON_VARIANTS[variant],
         BUTTON_SIZES[size],
         className

--- a/src/renderer/src/lib/theme.ts
+++ b/src/renderer/src/lib/theme.ts
@@ -1,0 +1,133 @@
+/**
+ * Applies a resolved theme to the document.
+ *
+ * The whole mechanism is one line of real work — `setProperty` on the root
+ * element — because Tailwind v4 compiles design tokens to *runtime* `var()`
+ * references. `bg-surface` emits `background-color: var(--color-surface)`, so
+ * re-pointing that property restyles every element using it, live. No
+ * stylesheet is swapped, nothing is re-rendered, and React is not involved.
+ *
+ * Two things make this subtler than it looks:
+ *
+ * 1. Inline styles beat everything. `main.css` sets `--font-sans` under
+ *    `[data-platform='darwin']` to get San Francisco on macOS; if we wrote a
+ *    font here unconditionally we would silently override that. So a theme that
+ *    says nothing about fonts emits no font property at all (see resolveTheme),
+ *    and `clearTheme` removes properties rather than resetting them to defaults.
+ *
+ * 2. The first paint must already be themed. The renderer boots, asks main for
+ *    the theme over async IPC, and only then can apply it — which is at least
+ *    one frame of the DEFAULT palette. On a light theme that is a black flash.
+ *    `primeTheme()` closes that gap using a synchronous localStorage cache.
+ */
+import type { ResolvedTheme } from '@shared/theme'
+import { api } from './api'
+
+/**
+ * Cache of the last applied theme, read synchronously before the first paint.
+ *
+ * localStorage is the only store the renderer can read *synchronously* at
+ * startup — IPC, indexedDB and the filesystem are all async, and any of them
+ * would land after the first frame. It is a cache, never the source of truth:
+ * main still resolves the real theme a moment later and overwrites this.
+ */
+const CACHE_KEY = 'roxy.theme.v1'
+
+/** Custom properties we set, so `clearTheme` can remove exactly those. */
+let applied: string[] = []
+
+/**
+ * Write a resolved theme onto `<html>`.
+ *
+ * Properties are diffed against the previous theme rather than cleared and
+ * re-set: removing a property, even for one frame, makes the UI flash the
+ * default palette on every theme switch.
+ */
+export function applyTheme(theme: ResolvedTheme): void {
+  const root = document.documentElement
+  const next = theme.vars ?? {}
+
+  for (const name of applied) {
+    if (!(name in next)) root.style.removeProperty(name)
+  }
+  for (const [name, value] of Object.entries(next)) {
+    // Only custom properties, only from main's resolver. Belt and braces: the
+    // value was already validated in shared/theme.ts.
+    if (name.startsWith('--')) root.style.setProperty(name, value)
+  }
+  applied = Object.keys(next)
+
+  // Drives the native bits CSS variables can't reach: form controls, the
+  // scrollbar gutter, and the default text color of a page with no styles.
+  root.style.colorScheme = theme.appearance
+  root.dataset.theme = theme.id
+  root.dataset.appearance = theme.appearance
+
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(theme))
+  } catch {
+    // Private mode / quota — the cache is an optimization, not a requirement.
+  }
+}
+
+/** Drop every property this module set, returning to the compiled defaults. */
+export function clearTheme(): void {
+  const root = document.documentElement
+  for (const name of applied) root.style.removeProperty(name)
+  applied = []
+  root.style.colorScheme = ''
+  delete root.dataset.theme
+  delete root.dataset.appearance
+}
+
+/**
+ * Apply the cached theme synchronously, before React mounts.
+ *
+ * Called from the module body of `main.tsx` so it runs during the initial
+ * script evaluation — i.e. before the browser has painted anything. Without it
+ * the window shows one frame of the built-in dark palette regardless of the
+ * user's theme, which is the classic "flash of wrong theme" and is most obvious
+ * on exactly the themes people notice: light ones.
+ */
+export function primeTheme(): void {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return
+    const cached = JSON.parse(raw) as ResolvedTheme
+    if (cached && typeof cached === 'object' && cached.vars) applyTheme(cached)
+  } catch {
+    // A corrupt cache must never stop the app booting — it just means one
+    // frame of the default theme, which is what we had before this existed.
+  }
+}
+
+/**
+ * Fetch the active theme from main, apply it, and keep it in sync.
+ *
+ * Returns an unsubscribe function. The subscription is what makes a theme
+ * change in the Themes page reach the chat window (and any other window)
+ * without either of them polling. Never throws -- see below.
+ */
+export function startTheme(): () => void {
+  // Defensive on purpose. This runs in the module body of the renderer entry,
+  // BEFORE React mounts, so anything thrown here takes the whole app down to a
+  // white screen -- and window.roxy.themes is genuinely absent in two real
+  // situations: a dev session running against a stale preload build, and the
+  // renderer loaded outside Electron. A .catch() alone would not be enough,
+  // because the property access itself is what throws. Theming is cosmetic; it
+  // must never be able to stop the app booting.
+  const themes = api?.themes
+  if (!themes) return () => undefined
+  try {
+    void themes
+      .resolve()
+      .then(applyTheme)
+      .catch(() => {
+        // Main is unreachable, or an older build has no handler: keep the
+        // cached/compiled palette rather than blanking the UI.
+      })
+    return themes.onChanged(applyTheme) ?? (() => undefined)
+  } catch {
+    return () => undefined
+  }
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -7,10 +7,17 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import { AppContextMenu } from './components/AppContextMenu'
 import { installSquircle } from './lib/squircle'
+import { primeTheme, startTheme } from './lib/theme'
 
 // Tag the platform so CSS can reserve room for the native window controls
 // (traffic lights on macOS, control overlay on Windows/Linux).
 document.documentElement.dataset.platform = window.electron?.process?.platform ?? 'win32'
+
+// Paint the user's theme from the synchronous cache BEFORE the first frame, then
+// let main confirm it over IPC. Priming first is what stops the window flashing
+// the built-in dark palette on the way to a light theme.
+primeTheme()
+startTheme()
 
 // Upgrade every `.sq*` corner from a quarter-circle to a superellipse. Async and
 // purely additive -- the first frame paints with the plain `rounded-*` fallback.

--- a/src/renderer/src/routes/Themes.tsx
+++ b/src/renderer/src/routes/Themes.tsx
@@ -1,0 +1,658 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Check,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  Copy,
+  FolderOpen,
+  Palette,
+  Plus,
+  RefreshCw,
+  Trash2
+} from 'lucide-react'
+import type { ThemeListResult } from '@shared/api'
+import {
+  DEFAULT_THEME_ID,
+  FONT_PRESETS,
+  SWATCH_KEYS,
+  THEME_COLOR_TOKENS,
+  buildThemePrompt,
+  serializeTheme,
+  type ThemeView
+} from '@shared/theme'
+import { api } from '../lib/api'
+import { cn } from '../lib/cn'
+import { Button, Textarea } from '../components/ui'
+import { PageShell } from '../components/PageShell'
+
+const SUBTITLE =
+  'A theme is a small JSON file that re-points the app\u2019s design tokens \u2014 surfaces, text, accents, and the fonts for the UI and for code. Pick one below, or duplicate it to make your own. Themes are read from your themes folder, so they can be edited in any editor, checked into dotfiles, and shared as a file.'
+
+export default function Themes(): JSX.Element {
+  const navigate = useNavigate()
+  const [data, setData] = useState<ThemeListResult | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [editing, setEditing] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
+  const [error, setError] = useState('')
+
+  const load = useCallback(async (refresh = false): Promise<void> => {
+    const next = refresh ? await api.themes.refresh() : await api.themes.list()
+    setData(next)
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  /**
+   * Switching theme does NOT wait for this component to re-render: main
+   * broadcasts the resolved theme and `lib/theme.ts` applies it to the document
+   * directly, so the whole window repaints the instant it's picked. The reload
+   * here only refreshes which row shows as active.
+   */
+  const activate = async (id: string): Promise<void> => {
+    setBusy(id)
+    setError('')
+    try {
+      await api.themes.setActive(id)
+      await load()
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const create = async (from?: string): Promise<void> => {
+    setBusy(from ?? '__new__')
+    setError('')
+    try {
+      const source = from ? data?.themes.find((t) => t.id === from) : undefined
+      const res = await api.themes.create({
+        name: source ? `${source.name} copy` : 'My theme',
+        from
+      })
+      if (!res.ok) {
+        setError(res.error ?? 'Could not create the theme.')
+        return
+      }
+      await load(true)
+      // Drop straight into the editor: a new theme with nothing changed is not
+      // a result, it's a starting point.
+      if (res.id) setEditing(res.id)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const remove = async (id: string): Promise<void> => {
+    setBusy(id)
+    setError('')
+    try {
+      const res = await api.themes.remove(id)
+      if (!res.ok) setError(res.error ?? 'Could not delete the theme.')
+      setConfirmDelete(null)
+      if (editing === id) setEditing(null)
+      await load(true)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const themes = data?.themes ?? []
+  const activeId = data?.activeId ?? DEFAULT_THEME_ID
+  const builtins = themes.filter((t) => t.source === 'builtin')
+  const custom = themes.filter((t) => t.source === 'user')
+
+  return (
+    <PageShell title="Themes" subtitle={SUBTITLE} onBack={() => navigate('/')}>
+      {error && <p className="mb-4 text-xs text-danger">{error}</p>}
+
+      <section className="mb-8">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">
+          Built in
+        </h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {builtins.map((t) => (
+            <ThemeCard
+              key={t.id}
+              theme={t}
+              active={t.id === activeId}
+              busy={busy === t.id}
+              onActivate={() => void activate(t.id)}
+              onDuplicate={() => void create(t.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="mb-8">
+        {/* Every action here acts on THIS section -- creating, rescanning and
+            revealing all concern user themes on disk, not the built-ins above.
+            Keeping them on the section header puts them where their effect is. */}
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-text-subtle">
+            Your themes
+          </h2>
+          <div className="flex items-center gap-1">
+            {/* Reveals the FOLDER, not the active theme: this sits under "Your
+                themes" now, and the active theme is often a built-in with no file
+                of its own. An empty id makes main fall back to the themes dir. */}
+            {data?.directory && (
+              <Button
+                size="sm"
+                variant="ghost"
+                title={data.directory}
+                onClick={() => void api.themes.reveal('')}
+              >
+                <FolderOpen className="h-3.5 w-3.5" /> Open folder
+              </Button>
+            )}
+            <Button size="sm" variant="ghost" onClick={() => void load(true)}>
+              <RefreshCw className="h-3.5 w-3.5" /> Rescan
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => void create()}>
+              <Plus className="h-3.5 w-3.5" /> New theme
+            </Button>
+          </div>
+        </div>
+
+        {custom.length === 0 ? (
+          <div className="sq sq-xl sq-ring sq-dashed rounded-xl border border-dashed border-border bg-surface/50 p-5 text-xs text-text-muted">
+            No custom themes yet. Duplicate one above to get a file you can edit, or drop a{' '}
+            <code className="text-text-subtle">theme.json</code> into any of these:
+            <ul className="mt-2 flex flex-col gap-1 text-text-subtle">
+              <li>
+                <code>{data?.directory ?? '\u2026/themes'}</code>
+              </li>
+              <li>
+                <code>~/.roxy/themes/&lt;name&gt;/theme.json</code>
+              </li>
+            </ul>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {custom.map((t) => (
+              <ThemeCard
+                key={t.id}
+                theme={t}
+                active={t.id === activeId}
+                busy={busy === t.id}
+                editable
+                confirmingDelete={confirmDelete === t.id}
+                onActivate={() => void activate(t.id)}
+                onDuplicate={() => void create(t.id)}
+                onEdit={() => setEditing(editing === t.id ? null : t.id)}
+                onDelete={() => setConfirmDelete(t.id)}
+                onCancelDelete={() => setConfirmDelete(null)}
+                onConfirmDelete={() => void remove(t.id)}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {editing && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">
+            Editing {themes.find((t) => t.id === editing)?.name ?? editing}
+          </h2>
+          {/* Editor and reference side by side: the reference is only really
+              actionable with a file open, and you shouldn't have to scroll away
+              from the JSON to remember what "surface-2" paints. Stacks on narrow
+              windows, where two columns would squeeze both. */}
+          <div className="grid grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
+            <ThemeEditor
+              key={editing}
+              id={editing}
+              onClose={() => setEditing(null)}
+              onSaved={() => void load(true)}
+            />
+            <ThemeReference variant="panel" />
+          </div>
+        </section>
+      )}
+
+      {data && data.warnings.length > 0 && (
+        <section className="mb-8">
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-warning">
+            Problems found
+          </h2>
+          <div className="flex flex-col gap-2 sq sq-xl sq-ring rounded-xl border border-border bg-surface p-4">
+            {data.warnings.map((w, i) => (
+              <div key={i} className="text-xs">
+                <div className="text-text-muted">{w.message}</div>
+                <div className="truncate font-mono text-[11px] text-text-subtle" title={w.file}>
+                  {w.file}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {!editing && <ThemeReference />}
+    </PageShell>
+  )
+}
+
+/** A theme's palette, shown as the stack of colors it actually paints with. */
+function Swatches({ theme }: { theme: ThemeView }): JSX.Element {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {SWATCH_KEYS.map((key) => (
+        <span
+          key={key}
+          title={key}
+          className="h-4 w-4 rounded-full border border-border"
+          style={{ background: theme.swatches[key] ?? 'transparent' }}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ThemeCard({
+  theme,
+  active,
+  busy,
+  editable,
+  confirmingDelete,
+  onActivate,
+  onDuplicate,
+  onEdit,
+  onDelete,
+  onCancelDelete,
+  onConfirmDelete
+}: {
+  theme: ThemeView
+  active: boolean
+  busy: boolean
+  editable?: boolean
+  confirmingDelete?: boolean
+  onActivate: () => void
+  onDuplicate: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+  onCancelDelete?: () => void
+  onConfirmDelete?: () => void
+}): JSX.Element {
+  return (
+    <div
+      className={cn(
+        'group flex flex-col gap-3 sq sq-xl sq-ring rounded-xl border bg-surface p-4 transition',
+        active
+          ? 'border-accent/50 [--sq-ring:color-mix(in_srgb,var(--color-accent)_50%,transparent)]'
+          : 'border-border'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center sq sq-lg sq-ring rounded-lg border border-border bg-surface-2">
+          <Palette className="h-4 w-4 text-text-muted" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-text">{theme.name}</span>
+            {active && (
+              <span className="shrink-0 rounded-full bg-success/15 px-2 py-0.5 text-[11px] text-success">
+                Active
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 line-clamp-2 text-xs text-text-muted">
+            {theme.description ?? `${theme.appearance} theme`}
+          </p>
+        </div>
+        <Swatches theme={theme} />
+      </div>
+
+      <div className="flex items-center gap-1">
+        {confirmingDelete ? (
+          <>
+            <span className="mr-auto text-xs text-text-muted">Delete this theme?</span>
+            <Button size="sm" variant="ghost" onClick={onCancelDelete}>
+              Cancel
+            </Button>
+            <Button size="sm" variant="danger" disabled={busy} onClick={onConfirmDelete}>
+              Delete
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              size="sm"
+              variant={active ? 'ghost' : 'secondary'}
+              disabled={active || busy}
+              onClick={onActivate}
+            >
+              {active ? (
+                <>
+                  <Check className="h-3.5 w-3.5" /> Applied
+                </>
+              ) : (
+                'Apply'
+              )}
+            </Button>
+            <Button size="sm" variant="ghost" disabled={busy} onClick={onDuplicate}>
+              <Copy className="h-3.5 w-3.5" /> Duplicate
+            </Button>
+            {editable && (
+              <div className="ml-auto flex items-center gap-1">
+                <Button size="sm" variant="ghost" onClick={onEdit}>
+                  Edit
+                </Button>
+                <button
+                  onClick={onDelete}
+                  title="Delete theme"
+                  className="press-scale flex h-8 w-8 items-center justify-center sq sq-lg rounded-lg text-text-subtle opacity-0 hover:bg-danger/10 hover:text-danger group-hover:opacity-100"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Raw JSON editor.
+ *
+ * Deliberately the file itself rather than a form of color pickers: the file is
+ * the real artifact (it gets shared, diffed and hand-edited), so editing it here
+ * teaches the format instead of hiding it. Saving re-applies the theme
+ * immediately when it's the active one, which makes this a live preview.
+ */
+function ThemeEditor({
+  id,
+  onClose,
+  onSaved
+}: {
+  id: string
+  onClose: () => void
+  onSaved: () => void
+}): JSX.Element {
+  const [source, setSource] = useState<string | null>(null)
+  const [dirty, setDirty] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [status, setStatus] = useState('')
+  const [error, setError] = useState('')
+  const [warnings, setWarnings] = useState<string[]>([])
+  const [expanded, setExpanded] = useState(false)
+  const lineCount = source?.split('\n').length ?? 0
+
+  useEffect(() => {
+    let alive = true
+    void api.themes.read(id).then((text) => {
+      if (alive) setSource(text ?? '')
+    })
+    return () => {
+      alive = false
+    }
+  }, [id])
+
+  const save = async (): Promise<void> => {
+    if (source === null) return
+    setSaving(true)
+    setError('')
+    setStatus('')
+    setWarnings([])
+    try {
+      const res = await api.themes.save(id, source)
+      if (!res.ok) {
+        setError(res.error ?? 'Could not save the theme.')
+        return
+      }
+      setWarnings(res.warnings ?? [])
+      setDirty(false)
+      setStatus('Saved')
+      setTimeout(() => setStatus(''), 2000)
+      onSaved()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (source === null) return <p className="text-xs text-text-subtle">Loading&#8230;</p>
+
+  return (
+    <div className="flex flex-col gap-3 sq sq-xl sq-ring rounded-xl border border-border bg-surface p-4">
+      {/* Compact by default. The JSON is usually authored elsewhere (an AI, an
+          editor) and pasted in, so this is more a drop target than a writing
+          surface -- and at full height it pushed the reference below the fold,
+          which is what people actually need on screen while editing. */}
+      <Textarea
+        value={source}
+        onChange={(e) => {
+          setSource(e.target.value)
+          setDirty(true)
+          setError('')
+        }}
+        onKeyDown={(e) => {
+          // Cmd/Ctrl+S is what anyone editing a config file will reach for.
+          if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+            e.preventDefault()
+            void save()
+          }
+        }}
+        rows={expanded ? Math.min(30, Math.max(12, lineCount + 1)) : 4}
+        className="font-mono text-xs leading-relaxed"
+        spellCheck={false}
+        autoComplete="off"
+      />
+      {error && <p className="text-xs text-danger">{error}</p>}
+      {warnings.map((w, i) => (
+        <p key={i} className="text-xs text-warning">
+          {w}
+        </p>
+      ))}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="primary" disabled={!dirty || saving} onClick={() => void save()}>
+          {saving ? 'Saving\u{2026}' : status || 'Save'}
+        </Button>
+        <Button variant="ghost" onClick={onClose}>
+          Close
+        </Button>
+        {/* Only offer this when there is something to reveal -- a 4-line theme
+            is already fully visible, and a toggle that does nothing is noise. */}
+        {lineCount > 4 && (
+          <Button size="sm" variant="ghost" onClick={() => setExpanded(!expanded)}>
+            {expanded ? (
+              <>
+                <ChevronsDownUp className="h-3.5 w-3.5" /> Collapse
+              </>
+            ) : (
+              <>
+                <ChevronsUpDown className="h-3.5 w-3.5" /> Expand
+                <span className="text-text-subtle">{lineCount} lines</span>
+              </>
+            )}
+          </Button>
+        )}
+        {/* Hidden on narrow layouts: beside the reference panel this column is
+            ~380px and the hint collapsed to one word per line, which looked
+            broken. It is the least important thing in the row, so it drops out
+            rather than wrapping into a vertical stripe. */}
+        <span className="ml-auto hidden shrink-0 text-[11px] text-text-subtle lg:inline">
+          Saving re-applies the theme if it&#8217;s the active one.
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * What can go in a theme file.
+ *
+ * Two shapes for two situations. `collapsed` is the standalone accordion shown
+ * on the page; `panel` is always-open and sits beside the editor, because while
+ * you are typing JSON the answer to "what does surface-2 paint?" needs to be on
+ * screen, not one click and a scroll away.
+ *
+ * The Copy prompt button is the point of the whole panel. Everything here is
+ * generated from the token registry by `buildThemePrompt()`, so what you paste
+ * into an LLM is the same spec the validator enforces — it cannot drift, and a
+ * model given it emits a file that saves without warnings.
+ */
+function ThemeReference({
+  variant = 'collapsed'
+}: {
+  variant?: 'collapsed' | 'panel'
+}): JSX.Element {
+  const isPanel = variant === 'panel'
+  const [open, setOpen] = useState(isPanel)
+  const [copied, setCopied] = useState(false)
+  const groups = useMemo(
+    () => [
+      { id: 'surfaces', label: 'Surfaces' },
+      { id: 'text', label: 'Text' },
+      { id: 'accents', label: 'Accents' },
+      { id: 'polarity', label: 'Contrast pair' }
+    ],
+    []
+  )
+
+  const copyPrompt = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(buildThemePrompt())
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard denied — leave the label alone rather than claim success.
+    }
+  }
+
+  // Pulled into a variable so it can render at the TOP in the side panel and at
+  // the BOTTOM full-width, without duplicating the markup.
+  const aiBlock = (
+    <div className={cn(!isPanel && 'border-t border-border pt-4')}>
+      <div className="text-sm font-medium text-text">Build one with AI</div>
+      <p className="mt-0.5 text-xs text-text-muted">
+        Copies a full spec of this format &#8212; every token, what it paints, the rules and a
+        worked example. Paste it into any model, describe the theme you want, and drop the JSON it
+        returns into the editor.
+      </p>
+      <Button
+        variant={copied ? 'secondary' : 'primary'}
+        onClick={() => void copyPrompt()}
+        className="mt-3 w-full"
+      >
+        {copied ? (
+          <>
+            <Check className="h-3.5 w-3.5" /> Copied to clipboard
+          </>
+        ) : (
+          <>
+            <Copy className="h-3.5 w-3.5" /> Copy prompt
+          </>
+        )}
+      </Button>
+    </div>
+  )
+
+  const body = (
+    <div className="flex flex-col gap-4 sq sq-xl sq-ring rounded-xl border border-border bg-surface p-4">
+      {/* Order flips with the layout. Beside the editor this leads, because
+          "hand it to an AI" is the fastest route to a theme and the panel is
+          narrow enough that everything below is a scroll away anyway. Read
+          full-width the reference IS the content, so a call-to-action wedged
+          above it would only push the documentation you came for down. */}
+      {isPanel && aiBlock}
+
+      <div className={cn(isPanel && 'border-t border-border pt-4')}>
+        <div className="text-sm font-medium text-text">Colors</div>
+        <p className="mt-0.5 text-xs text-text-muted">
+          Any CSS color &#8212; hex, <code>rgb()</code>, <code>oklch()</code>, or a{' '}
+          <code>color-mix()</code>. Anything you leave out is inherited from the theme you{' '}
+          <code>extends</code>, so a theme can be three lines long.
+        </p>
+      </div>
+      {groups.map((g) => (
+        <div key={g.id}>
+          <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-text-subtle">
+            {g.label}
+          </div>
+          <div className={cn('grid grid-cols-1 gap-1.5', !isPanel && 'sm:grid-cols-2')}>
+            {THEME_COLOR_TOKENS.filter((t) => t.group === g.id).map((t) => (
+              <div key={t.key} className="flex items-baseline gap-2 text-xs">
+                <code className="shrink-0 text-text">{t.key}</code>
+                {/* Wraps in the side panel: the polarity hints are the most
+                    important text here and truncating them loses the warning. */}
+                <span className={cn('text-text-subtle', !isPanel && 'truncate')} title={t.hint}>
+                  {t.hint}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+      <div>
+        <div className="text-sm font-medium text-text">Fonts</div>
+        <p className="mt-0.5 text-xs text-text-muted">
+          <code>sans</code> is the UI font and <code>mono</code> is the code font &#8212; tool
+          calls, terminal output, diffs and code blocks. Give one family, an array to build your own
+          stack, or <code>&quot;system&quot;</code> for the platform&apos;s native font. Fallbacks
+          are appended automatically, so naming a font you don&apos;t have degrades gracefully.
+        </p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {FONT_PRESETS.mono.map((f) => (
+            <code
+              key={f}
+              className="rounded-full border border-border px-2 py-0.5 text-[11px] text-text-subtle"
+            >
+              {f}
+            </code>
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="text-sm font-medium text-text">Example</div>
+        <pre className="mt-1.5 overflow-x-auto sq sq-lg rounded-lg bg-surface-2 p-3 font-mono text-[11px] leading-relaxed text-text-muted">
+          {EXAMPLE}
+        </pre>
+      </div>
+
+      {!isPanel && aiBlock}
+    </div>
+  )
+
+  // Beside the editor: no toggle, and sticky so it stays put while scrolling a
+  // long theme file.
+  if (isPanel) return <div className="xl:sticky xl:top-4">{body}</div>
+
+  return (
+    <section>
+      <button
+        onClick={() => setOpen(!open)}
+        className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-subtle hover:text-text"
+      >
+        {open ? 'Hide' : 'Show'} reference
+      </button>
+      {open && body}
+    </section>
+  )
+}
+
+/**
+ * A minimal theme, produced by the SAME serializer that writes theme files.
+ *
+ * Hand-writing this block would make it the one piece of documentation on the
+ * page that can silently go stale - it would keep claiming a shape the parser
+ * had stopped accepting. Generating it means the example is always literally
+ * valid, and demonstrates the two things worth showing: `extends` letting a
+ * theme be three colors long, and `mono` taking an explicit stack.
+ */
+const EXAMPLE = serializeTheme({
+  id: 'my-theme',
+  name: 'My Theme',
+  appearance: 'dark',
+  extends: DEFAULT_THEME_ID,
+  colors: {
+    bg: '#0d0b14',
+    surface: '#141020',
+    accent: 'oklch(0.72 0.19 305)'
+  },
+  fonts: { sans: 'system', mono: ['Berkeley Mono', 'JetBrains Mono'] }
+}).trim()

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -30,6 +30,7 @@ import type { ForgeStatusView, ForgeHostView, ForgeKind } from './forge'
 import type { RepoLayout } from './repos'
 import type { SessionConfigPatch } from './session-config'
 import type { ClipboardAction } from './context-menu'
+import type { ResolvedTheme, ThemeView } from './theme'
 
 /** A configured MCP server merged with its live connection status (for Settings). */
 export interface McpServerView {
@@ -71,6 +72,30 @@ export interface SkillWriteInput {
   body?: string
   /** Where to write it â€” defaults to 'global' from the Skills page (no workspace context). */
   scope?: 'workspace' | 'global'
+}
+
+/** The themes the app knows about, plus any problems found while scanning. */
+export interface ThemeListResult {
+  themes: ThemeView[]
+  /** The id currently applied. */
+  activeId: string
+  /** Where the app writes themes it creates -- shown in the UI so files are findable. */
+  directory: string
+  /** Files that failed to parse, or tokens that were dropped, during the scan. */
+  warnings: { file: string; message: string }[]
+}
+
+/** Outcome of a theme write (save / create / delete). */
+export interface ThemeSaveResult {
+  ok: boolean
+  /** The id written -- create() may pick a different one to avoid a collision. */
+  id?: string
+  /** Why the write failed; a validation message fit to show the author. */
+  error?: string
+  /** Non-fatal problems (unknown token, unsafe value) -- the theme still saved. */
+  warnings?: string[]
+  /** The refreshed list, so the caller can update its view in one round trip. */
+  themes?: ThemeView[]
 }
 
 /** Outcome of installing skill(s) from a remote source (`skills.install`). */
@@ -775,6 +800,37 @@ export interface RoxyApi {
      * skills by default (or workspace when a cwd is given).
      */
     install(source: string, cwd?: string): Promise<SkillInstallResult>
+  }
+  themes: {
+    /** Built-in themes followed by user themes found on disk. */
+    list(): Promise<ThemeListResult>
+    /** Re-scan the theme directories (drops the cache) and return the fresh list. */
+    refresh(): Promise<ThemeListResult>
+    /** A theme's raw JSON source, for the editor. Null if it doesn't exist. */
+    read(id: string): Promise<string | null>
+    /**
+     * The CSS custom properties for a theme, ready to apply. Passing null
+     * resolves whichever theme is currently active.
+     */
+    resolve(id?: string | null): Promise<ResolvedTheme>
+    /** Validate and write a theme's JSON. Returns errors rather than throwing. */
+    save(id: string, source: string): Promise<ThemeSaveResult>
+    /** Create a new theme, or duplicate rom, under a fresh id. */
+    create(input: { name: string; from?: string }): Promise<ThemeSaveResult>
+    /** Delete a user theme; built-ins are protected. */
+    remove(id: string): Promise<ThemeSaveResult>
+    /**
+     * Show a theme's folder in the OS file manager. Pass an empty id to open
+     * the themes directory itself (a built-in has no file to reveal).
+     */
+    reveal(id: string): Promise<void>
+    /** Persist the active theme and broadcast it to every window. */
+    setActive(id: string): Promise<ResolvedTheme>
+    /**
+     * Subscribe to theme changes made elsewhere -- another window switching
+     * theme, or a save that re-resolves the active one. Returns an unsubscribe fn.
+     */
+    onChanged(callback: (theme: ResolvedTheme) => void): () => void
   }
   system: {
     getVersions(): Promise<AppVersions>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -63,6 +63,24 @@ export const CHANNELS = {
   skillsRemove: 'skills:remove',
   skillsInstall: 'skills:install',
 
+  /**
+   * Themes -- user-authored `theme.json` files that re-point the app's CSS
+   * custom properties. `themesResolve` returns the properties to set on the
+   * root element, which is what actually restyles the UI.
+   */
+  themesList: 'themes:list',
+  themesRefresh: 'themes:refresh',
+  themesRead: 'themes:read',
+  themesResolve: 'themes:resolve',
+  themesSave: 'themes:save',
+  themesCreate: 'themes:create',
+  themesRemove: 'themes:remove',
+  themesReveal: 'themes:reveal',
+  /** Persist the active theme; also broadcasts so every window follows. */
+  themesSetActive: 'themes:setActive',
+  /** main -> renderer: the active theme changed (or its file was edited). */
+  themesChanged: 'themes:changed',
+
   systemGetVersions: 'system:getVersions',
   systemOpenExternal: 'system:openExternal',
 

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -1,0 +1,935 @@
+/**
+ * Themes — user-authored `theme.json` files that restyle the whole app.
+ *
+ * The design rests on one fact about Tailwind v4, verified against the compiler
+ * rather than assumed: a `@theme` token compiles to a *runtime* `var()`
+ * reference, not to a baked literal. `bg-surface` emits
+ * `background-color: var(--color-surface)`, and `bg-white/5` emits
+ * `color-mix(in oklab, var(--color-white) 5%, transparent)`. So re-pointing the
+ * custom properties on `<html>` restyles every one of the ~1000 utility usages
+ * in this app live, with no rebuild, no stylesheet swap and no reload.
+ *
+ * That is why a theme here is *data*, not CSS. A theme file names tokens and
+ * values; nothing in it is code, nothing is injected into a stylesheet, and the
+ * set of keys it may write is closed (see THEME_COLOR_TOKENS). The `vars`
+ * escape hatch below is the single exception, and it is deliberately narrow.
+ *
+ * This module is pure — no node, no electron, no DOM — so the main process, the
+ * renderer and `npm run smoke:shared` all share one implementation and one set
+ * of rules. Everything that touches disk lives in main/services/themes.ts;
+ * everything that touches the document lives in renderer/src/lib/theme.ts.
+ */
+
+/** Marker + version stamped into every theme file we write. */
+export const THEME_KIND = 'roxy.theme'
+export const THEME_VERSION = 1
+/** The filename a theme is stored under inside its own folder. */
+export const THEME_FILENAME = 'theme.json'
+
+/** Longest accepted value for any single token — a guard against absurd input. */
+const MAX_VALUE_LENGTH = 512
+/** Cap on `vars` entries, so a hand-edited file can't bloat the style attribute. */
+export const MAX_CUSTOM_VARS = 64
+
+// ---------------------------------------------------------------------------
+// Token registry
+// ---------------------------------------------------------------------------
+
+export type ThemeTokenGroup = 'surfaces' | 'text' | 'accents' | 'polarity'
+
+export interface ThemeTokenSpec {
+  /** Key as written in theme.json (`colors.bg`). */
+  key: string
+  /** CSS custom property it drives (`--color-bg`). */
+  cssVar: string
+  label: string
+  group: ThemeTokenGroup
+  /** What it actually paints, for the editor UI. */
+  hint: string
+}
+
+/**
+ * Every color a theme may set, in the order the editor shows them.
+ *
+ * Closed by design: an unknown `colors` key is a validation error rather than a
+ * silently-ignored typo, because a theme that half-applies looks like a bug in
+ * the app rather than a mistake in the file.
+ */
+export const THEME_COLOR_TOKENS: ThemeTokenSpec[] = [
+  {
+    key: 'bg',
+    cssVar: '--color-bg',
+    label: 'Background',
+    group: 'surfaces',
+    hint: 'The window behind everything.'
+  },
+  {
+    key: 'surface',
+    cssVar: '--color-surface',
+    label: 'Surface',
+    group: 'surfaces',
+    hint: 'Sidebar, cards, page panels.'
+  },
+  {
+    key: 'surface-2',
+    cssVar: '--color-surface-2',
+    label: 'Surface 2',
+    group: 'surfaces',
+    hint: 'Inputs and inset wells.'
+  },
+  {
+    key: 'elevated',
+    cssVar: '--color-elevated',
+    label: 'Elevated',
+    group: 'surfaces',
+    hint: 'Menus and popovers that float above.'
+  },
+  {
+    key: 'border',
+    cssVar: '--color-border',
+    label: 'Border',
+    group: 'surfaces',
+    hint: 'Hairlines between regions.'
+  },
+  {
+    key: 'border-strong',
+    cssVar: '--color-border-strong',
+    label: 'Border strong',
+    group: 'surfaces',
+    hint: 'Hover borders and scrollbars.'
+  },
+  {
+    key: 'text',
+    cssVar: '--color-text',
+    label: 'Text',
+    group: 'text',
+    hint: 'Primary copy.'
+  },
+  {
+    key: 'text-muted',
+    cssVar: '--color-text-muted',
+    label: 'Text muted',
+    group: 'text',
+    hint: 'Secondary copy and labels.'
+  },
+  {
+    key: 'text-subtle',
+    cssVar: '--color-text-subtle',
+    label: 'Text subtle',
+    group: 'text',
+    hint: 'Timestamps, paths, counts.'
+  },
+  {
+    key: 'accent',
+    cssVar: '--color-accent',
+    label: 'Accent',
+    group: 'accents',
+    hint: 'Links, focus rings, the active state.'
+  },
+  {
+    key: 'accent-hover',
+    cssVar: '--color-accent-hover',
+    label: 'Accent hover',
+    group: 'accents',
+    hint: 'Accent, one step brighter.'
+  },
+  {
+    key: 'success',
+    cssVar: '--color-success',
+    label: 'Success',
+    group: 'accents',
+    hint: 'Live indicators, additions.'
+  },
+  {
+    key: 'warning',
+    cssVar: '--color-warning',
+    label: 'Warning',
+    group: 'accents',
+    hint: 'Pending and degraded states.'
+  },
+  {
+    key: 'danger',
+    cssVar: '--color-danger',
+    label: 'Danger',
+    group: 'accents',
+    hint: 'Errors, deletions, the danger zone.'
+  },
+  /**
+   * The polarity pair. Tailwind's `white`/`black` are ordinary theme tokens, so
+   * they resolve through `var()` like everything else — which makes them the
+   * lever that turns a dark UI light. This app leans on `bg-white/5` for ~75
+   * hover states and on `bg-white text-black` for its primary button; re-point
+   * these two and all of it inverts at once, without touching a component.
+   *
+   * So: these are NOT "the color white". They are "the color that contrasts
+   * with the background", and a light theme sets `white` to near-black.
+   */
+  {
+    key: 'white',
+    cssVar: '--color-white',
+    label: 'Contrast',
+    group: 'polarity',
+    hint: 'Hover washes and the primary button fill. Near-black in a light theme.'
+  },
+  {
+    key: 'black',
+    cssVar: '--color-black',
+    label: 'Contrast text',
+    group: 'polarity',
+    hint: 'Text ON the primary button, and modal scrims. Near-white in a light theme.'
+  }
+]
+
+const TOKEN_BY_KEY = new Map(THEME_COLOR_TOKENS.map((t) => [t.key, t]))
+
+/** Custom properties a theme may set through `vars`, beyond the color tokens. */
+const EXTRA_VAR_ALLOWLIST = new Set([
+  // Motion
+  '--ease-out-quart',
+  '--ease-in-out-quart',
+  '--ease-drawer',
+  // Corner geometry (see the squircle system in main.css)
+  '--sq-scale',
+  // Typography detail
+  '--font-sans',
+  '--font-mono',
+  '--theme-code-line-height',
+  '--theme-code-font-size',
+  // Chrome
+  '--theme-scrollbar-thumb',
+  '--theme-scrollbar-thumb-hover',
+  '--theme-selection'
+])
+
+// ---------------------------------------------------------------------------
+// Fonts
+// ---------------------------------------------------------------------------
+
+export type PlatformId = 'darwin' | 'win32' | 'linux'
+
+/** The bundled faces, and the `system` keyword, offered as one-click picks. */
+export const FONT_PRESETS = {
+  sans: ['system', 'Geist Variable', 'Inter', 'Söhne', 'Helvetica Neue'],
+  mono: [
+    'system',
+    'Geist Mono Variable',
+    'JetBrains Mono',
+    'SF Mono',
+    'Cascadia Code',
+    'Fira Code',
+    'IBM Plex Mono'
+  ]
+} as const
+
+const SANS_FALLBACK = "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif"
+const MONO_FALLBACK = "ui-monospace, 'SF Mono', 'JetBrains Mono', monospace"
+
+/** Native UI font per platform, used when a theme asks for `system`. */
+const SYSTEM_SANS: Record<PlatformId, string> = {
+  darwin:
+    "-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', system-ui, sans-serif",
+  win32: "'Segoe UI Variable Text', 'Segoe UI', system-ui, sans-serif",
+  linux: "system-ui, 'Cantarell', 'Ubuntu', 'DejaVu Sans', sans-serif"
+}
+
+/** Native monospace per platform. */
+const SYSTEM_MONO: Record<PlatformId, string> = {
+  darwin: "ui-monospace, 'SF Mono', Menlo, Monaco, monospace",
+  win32: "'Cascadia Mono', Consolas, ui-monospace, monospace",
+  linux: "ui-monospace, 'DejaVu Sans Mono', 'Liberation Mono', monospace"
+}
+
+/** CSS-wide keywords and generic families that must never be quoted. */
+const UNQUOTED_FAMILIES = new Set([
+  'inherit',
+  'initial',
+  'unset',
+  'revert',
+  'serif',
+  'sans-serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'ui-sans-serif',
+  'ui-serif',
+  'ui-monospace',
+  'ui-rounded',
+  'math',
+  'emoji',
+  'fangsong'
+])
+
+/** A bare family name needs quoting when it isn't a generic and isn't an identifier. */
+function quoteFamily(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) return ''
+  if (UNQUOTED_FAMILIES.has(trimmed.toLowerCase())) return trimmed
+  if (/^['"].*['"]$/.test(trimmed)) return trimmed
+  // A CSS <custom-ident> sequence (Geist, Menlo, -apple-system) is legal bare;
+  // anything with a space, a digit-leading word or punctuation gets quoted.
+  if (/^-?[A-Za-z_][A-Za-z0-9_-]*$/.test(trimmed)) return trimmed
+  return `'${trimmed.replace(/'/g, '')}'`
+}
+
+/**
+ * Turn a theme's font choice into a full CSS font stack.
+ *
+ * Accepts a single family, an explicit stack (array), or the `system` keyword.
+ * A user naming one font still gets the fallbacks appended, because a theme
+ * that names a font the machine doesn't have should degrade to a sane stack
+ * rather than to Times New Roman.
+ */
+export function resolveFontStack(
+  value: string | string[] | undefined,
+  kind: 'sans' | 'mono',
+  platform: PlatformId
+): string | null {
+  if (value === undefined || value === null) return null
+  const list = Array.isArray(value) ? value : [value]
+  const names = list.map((n) => String(n).trim()).filter(Boolean)
+  if (names.length === 0) return null
+
+  const fallback = kind === 'sans' ? SANS_FALLBACK : MONO_FALLBACK
+  const system = kind === 'sans' ? SYSTEM_SANS[platform] : SYSTEM_MONO[platform]
+
+  // `system` is a keyword, not a family: it expands to the platform stack and
+  // needs nothing appended.
+  if (names.length === 1 && names[0].toLowerCase() === 'system') return system
+
+  const head = names
+    .map((n) => (n.toLowerCase() === 'system' ? system : quoteFamily(n)))
+    .filter(Boolean)
+
+  // Drop fallback entries the author already named. Asking for JetBrains Mono
+  // would otherwise emit it twice - harmless to CSS, which takes the first
+  // match, but it looks like a bug in devtools and in the copied theme file.
+  const bare = (n: string): string => n.replace(/['"]/g, '').trim().toLowerCase()
+  const seen = new Set(head.flatMap((n) => n.split(',').map(bare)))
+  const tail = fallback
+    .split(',')
+    .map((n) => n.trim())
+    .filter((n) => !seen.has(bare(n)))
+
+  return [...head, ...tail].join(', ')
+}
+
+// ---------------------------------------------------------------------------
+// The theme file
+// ---------------------------------------------------------------------------
+
+export interface ThemeFonts {
+  /** UI font. A family, a stack, or `system`. */
+  sans?: string | string[]
+  /** Code font — tool calls, terminal output, diffs, markdown code blocks. */
+  mono?: string | string[]
+}
+
+export interface ThemeFile {
+  kind?: typeof THEME_KIND
+  version?: number
+  /** Stable slug; also the folder name on disk. */
+  id: string
+  name: string
+  description?: string
+  author?: string
+  /** Drives `color-scheme`, so native scrollbars and form controls match. */
+  appearance?: 'dark' | 'light'
+  /** Start from a built-in and override only what differs. */
+  extends?: string
+  colors?: Record<string, string>
+  fonts?: ThemeFonts
+  /**
+   * Escape hatch: raw custom properties, for anything the typed fields above
+   * don't cover. Restricted to a known allowlist of property names — a theme
+   * cannot invent properties, because a value here is applied verbatim and the
+   * set of things it can reach has to stay auditable.
+   */
+  vars?: Record<string, string>
+}
+
+/** A theme as the app knows it — the file plus where it came from. */
+export interface ThemeView {
+  id: string
+  name: string
+  description?: string
+  author?: string
+  appearance: 'dark' | 'light'
+  /** Built-ins ship with the app and can't be edited or deleted. */
+  source: 'builtin' | 'user'
+  /** Absolute path to the theme's folder (user themes only). */
+  location?: string
+  /** Resolved swatches for the picker, keyed by token key. */
+  swatches: Record<string, string>
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Reject anything that could escape a CSS declaration or reach the network.
+ *
+ * Applying a theme goes through `style.setProperty()`, which parses one value
+ * and cannot be made to emit a second declaration — so this is defence in
+ * depth rather than the only guard. It still matters:
+ *
+ *  - `url()` is the real risk. A custom property holding `url(https://…)` is
+ *    inert until something references it, at which point the browser fetches
+ *    it — a shared theme file could quietly phone home, or read a local file.
+ *  - Rejecting early lets the editor tell the author their value is bad,
+ *    instead of silently dropping it and looking broken.
+ */
+export function isSafeCssValue(value: string): boolean {
+  if (typeof value !== 'string') return false
+  const v = value.trim()
+  if (!v || v.length > MAX_VALUE_LENGTH) return false
+  // Structural characters that only make sense if you're trying to break out.
+  if (/[;{}<>\\]/.test(v)) return false
+  // Comments can be used to smuggle the above past a naive reader.
+  if (v.includes('/*') || v.includes('*/')) return false
+  // Anything that loads or executes.
+  if (/\b(url|image-set|image|element|expression|-moz-binding|attr)\s*\(/i.test(v)) return false
+  if (/(javascript|data|vbscript|file|blob)\s*:/i.test(v)) return false
+  // At-rules have no business inside a value.
+  if (v.includes('@')) return false
+  return true
+}
+
+/** A theme id doubles as a folder name, so keep it to a strict slug. */
+export function isValidThemeId(id: unknown): id is string {
+  return typeof id === 'string' && /^[a-z0-9][a-z0-9-]{0,63}$/.test(id)
+}
+
+/** Coerce arbitrary text into a usable theme id. */
+export function sanitizeThemeId(input: string): string {
+  const slug = String(input)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+  return slug || 'theme'
+}
+
+export type ParseThemeResult =
+  | { ok: true; theme: ThemeFile; warnings: string[] }
+  | { ok: false; error: string }
+
+/**
+ * Parse and validate a theme file.
+ *
+ * Split into hard errors (the file is unusable — bad JSON, no id) and warnings
+ * (a single token was dropped). A typo'd color must not cost the author their
+ * whole theme, but it must also not pass unmentioned, so the bad key is
+ * dropped and named in `warnings` for the UI to show.
+ */
+export function parseTheme(raw: string): ParseThemeResult {
+  let data: unknown
+  try {
+    data = JSON.parse(raw)
+  } catch (err) {
+    return { ok: false, error: `Not valid JSON: ${(err as Error).message}` }
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { ok: false, error: 'A theme must be a JSON object.' }
+  }
+  const obj = data as Record<string, unknown>
+  const warnings: string[] = []
+
+  const id = obj.id
+  if (!isValidThemeId(id)) {
+    return {
+      ok: false,
+      error: 'Missing or invalid "id" — use lowercase letters, digits and dashes.'
+    }
+  }
+  const name = typeof obj.name === 'string' && obj.name.trim() ? obj.name.trim() : id
+
+  const theme: ThemeFile = {
+    kind: THEME_KIND,
+    version: typeof obj.version === 'number' ? obj.version : THEME_VERSION,
+    id,
+    name
+  }
+  if (typeof obj.description === 'string') theme.description = obj.description
+  if (typeof obj.author === 'string') theme.author = obj.author
+  if (obj.appearance === 'light' || obj.appearance === 'dark') theme.appearance = obj.appearance
+  if (typeof obj.extends === 'string' && isValidThemeId(obj.extends)) theme.extends = obj.extends
+
+  // ---- colors
+  if (obj.colors !== undefined) {
+    if (typeof obj.colors !== 'object' || obj.colors === null || Array.isArray(obj.colors)) {
+      return { ok: false, error: '"colors" must be an object.' }
+    }
+    const colors: Record<string, string> = {}
+    for (const [key, value] of Object.entries(obj.colors as Record<string, unknown>)) {
+      if (!TOKEN_BY_KEY.has(key)) {
+        warnings.push(`Unknown color "${key}" — ignored.`)
+        continue
+      }
+      if (typeof value !== 'string' || !isSafeCssValue(value)) {
+        warnings.push(`Color "${key}" has an unsafe or empty value — ignored.`)
+        continue
+      }
+      colors[key] = value.trim()
+    }
+    theme.colors = colors
+  }
+
+  // ---- fonts
+  if (obj.fonts !== undefined) {
+    if (typeof obj.fonts !== 'object' || obj.fonts === null || Array.isArray(obj.fonts)) {
+      return { ok: false, error: '"fonts" must be an object.' }
+    }
+    const fontsIn = obj.fonts as Record<string, unknown>
+    const fonts: ThemeFonts = {}
+    for (const key of ['sans', 'mono'] as const) {
+      const value = fontsIn[key]
+      if (value === undefined) continue
+      if (typeof value === 'string') {
+        if (!isSafeCssValue(value)) {
+          warnings.push(`Font "${key}" has an unsafe value — ignored.`)
+          continue
+        }
+        fonts[key] = value
+      } else if (Array.isArray(value)) {
+        const names = value.filter((n): n is string => typeof n === 'string' && isSafeCssValue(n))
+        if (names.length !== value.length) {
+          warnings.push(`Font "${key}" has an unsafe entry — ignored.`)
+          continue
+        }
+        fonts[key] = names
+      } else {
+        warnings.push(`Font "${key}" must be a string or an array of strings — ignored.`)
+      }
+    }
+    if (Object.keys(fonts).length > 0) theme.fonts = fonts
+  }
+
+  // ---- vars
+  if (obj.vars !== undefined) {
+    if (typeof obj.vars !== 'object' || obj.vars === null || Array.isArray(obj.vars)) {
+      return { ok: false, error: '"vars" must be an object.' }
+    }
+    const vars: Record<string, string> = {}
+    let count = 0
+    for (const [key, value] of Object.entries(obj.vars as Record<string, unknown>)) {
+      if (count >= MAX_CUSTOM_VARS) {
+        warnings.push(`More than ${MAX_CUSTOM_VARS} custom vars — the rest were ignored.`)
+        break
+      }
+      if (!EXTRA_VAR_ALLOWLIST.has(key)) {
+        warnings.push(`"${key}" is not a themeable property — ignored.`)
+        continue
+      }
+      if (typeof value !== 'string' || !isSafeCssValue(value)) {
+        warnings.push(`Var "${key}" has an unsafe or empty value — ignored.`)
+        continue
+      }
+      vars[key] = value.trim()
+      count++
+    }
+    if (Object.keys(vars).length > 0) theme.vars = vars
+  }
+
+  return { ok: true, theme, warnings }
+}
+
+/** Pretty-print a theme for writing to disk. */
+export function serializeTheme(theme: ThemeFile): string {
+  const ordered: ThemeFile = {
+    kind: THEME_KIND,
+    version: THEME_VERSION,
+    id: theme.id,
+    name: theme.name,
+    ...(theme.description ? { description: theme.description } : {}),
+    ...(theme.author ? { author: theme.author } : {}),
+    ...(theme.appearance ? { appearance: theme.appearance } : {}),
+    ...(theme.extends ? { extends: theme.extends } : {}),
+    ...(theme.colors && Object.keys(theme.colors).length ? { colors: theme.colors } : {}),
+    ...(theme.fonts && Object.keys(theme.fonts).length ? { fonts: theme.fonts } : {}),
+    ...(theme.vars && Object.keys(theme.vars).length ? { vars: theme.vars } : {})
+  }
+  return `${JSON.stringify(ordered, null, 2)}\n`
+}
+
+// ---------------------------------------------------------------------------
+// Built-in themes
+// ---------------------------------------------------------------------------
+
+/** The palette compiled into main.css — the app's out-of-the-box look. */
+export const DEFAULT_THEME_ID = 'roxy-dark'
+
+const ROXY_DARK: ThemeFile = {
+  kind: THEME_KIND,
+  version: THEME_VERSION,
+  id: DEFAULT_THEME_ID,
+  name: 'Roxy Dark',
+  description: 'The default — near-black surfaces, hairline borders, a blue accent.',
+  appearance: 'dark',
+  colors: {
+    bg: '#0a0a0a',
+    surface: '#0f0f10',
+    'surface-2': '#161618',
+    elevated: '#1d1d20',
+    border: '#232326',
+    'border-strong': '#303035',
+    text: '#ededed',
+    'text-muted': '#9a9aa3',
+    'text-subtle': '#6a6a73',
+    accent: '#4d8dff',
+    'accent-hover': '#6aa0ff',
+    success: '#3fb950',
+    warning: '#d9a441',
+    danger: '#f0556a',
+    white: '#ffffff',
+    black: '#000000'
+  }
+}
+
+/**
+ * The proof the abstraction is complete: a light theme built only from tokens,
+ * with no component changes. `white`/`black` invert (see the polarity note in
+ * THEME_COLOR_TOKENS), which flips every hover wash and the primary button.
+ */
+const ROXY_LIGHT: ThemeFile = {
+  kind: THEME_KIND,
+  version: THEME_VERSION,
+  id: 'roxy-light',
+  name: 'Roxy Light',
+  description: 'Paper-white surfaces with the same blue accent.',
+  appearance: 'light',
+  colors: {
+    bg: '#ffffff',
+    surface: '#f7f7f8',
+    'surface-2': '#efeff1',
+    elevated: '#ffffff',
+    border: '#e2e2e5',
+    'border-strong': '#c9c9cf',
+    text: '#1a1a1c',
+    'text-muted': '#5c5c66',
+    'text-subtle': '#8a8a94',
+    accent: '#2563eb',
+    'accent-hover': '#1d4ed8',
+    success: '#177d3c',
+    warning: '#9a6700',
+    danger: '#c81e3d',
+    white: '#18181b',
+    black: '#ffffff'
+  }
+}
+
+export const BUILT_IN_THEMES: ThemeFile[] = [ROXY_DARK, ROXY_LIGHT]
+
+export function getBuiltInTheme(id: string): ThemeFile | undefined {
+  return BUILT_IN_THEMES.find((t) => t.id === id)
+}
+
+export function isBuiltInThemeId(id: string): boolean {
+  return BUILT_IN_THEMES.some((t) => t.id === id)
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Fold a theme onto its base.
+ *
+ * Always starts from the default palette, so a theme that sets three colors
+ * gets a coherent UI rather than eleven unset tokens — the same reason
+ * `extends` exists at all. An explicit `extends` layers a chosen built-in in
+ * between.
+ */
+export function flattenTheme(
+  theme: ThemeFile,
+  lookup?: (id: string) => ThemeFile | undefined
+): ThemeFile {
+  const chain: ThemeFile[] = []
+  const seen = new Set<string>([theme.id])
+  let base = theme.extends
+  // Walk the extends chain, guarding against cycles and runaway depth.
+  for (let i = 0; base && i < 8; i++) {
+    if (seen.has(base)) break
+    seen.add(base)
+    const parent = lookup?.(base) ?? getBuiltInTheme(base)
+    if (!parent) break
+    chain.unshift(parent)
+    base = parent.extends
+  }
+  const layers = [ROXY_DARK, ...chain, theme]
+  const out: ThemeFile = {
+    kind: THEME_KIND,
+    version: THEME_VERSION,
+    id: theme.id,
+    name: theme.name,
+    description: theme.description,
+    author: theme.author,
+    appearance: theme.appearance ?? chain[chain.length - 1]?.appearance ?? 'dark',
+    colors: {},
+    fonts: {},
+    vars: {}
+  }
+  for (const layer of layers) {
+    Object.assign(out.colors as object, layer.colors ?? {})
+    Object.assign(out.fonts as object, layer.fonts ?? {})
+    Object.assign(out.vars as object, layer.vars ?? {})
+  }
+  return out
+}
+
+export interface ResolvedTheme {
+  id: string
+  name: string
+  appearance: 'dark' | 'light'
+  /** CSS custom property -> value, ready to set on the root element. */
+  vars: Record<string, string>
+}
+
+/**
+ * Turn a theme into the exact set of custom properties to put on `<html>`.
+ *
+ * Only tokens the theme actually specifies are emitted. That matters for fonts:
+ * main.css overrides `--font-sans`/`--font-mono` under
+ * `[data-platform='darwin']` to use San Francisco, and a theme that stays quiet
+ * about fonts must not clobber it. Inline styles beat that selector, so
+ * emitting a default here would silently break the macOS system font.
+ */
+export function resolveTheme(
+  theme: ThemeFile,
+  platform: PlatformId = 'win32',
+  lookup?: (id: string) => ThemeFile | undefined
+): ResolvedTheme {
+  const flat = flattenTheme(theme, lookup)
+  const vars: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(flat.colors ?? {})) {
+    const spec = TOKEN_BY_KEY.get(key)
+    if (!spec || typeof value !== 'string' || !isSafeCssValue(value)) continue
+    vars[spec.cssVar] = value
+  }
+
+  const sans = resolveFontStack(flat.fonts?.sans, 'sans', platform)
+  if (sans) vars['--font-sans'] = sans
+  const mono = resolveFontStack(flat.fonts?.mono, 'mono', platform)
+  if (mono) vars['--font-mono'] = mono
+
+  // `vars` is applied last so an author can override anything above it.
+  for (const [key, value] of Object.entries(flat.vars ?? {})) {
+    if (!EXTRA_VAR_ALLOWLIST.has(key) || !isSafeCssValue(value)) continue
+    vars[key] = value
+  }
+
+  return {
+    id: flat.id,
+    name: flat.name,
+    appearance: flat.appearance ?? 'dark',
+    vars
+  }
+}
+
+/** The handful of colors the picker previews, in swatch order. */
+export const SWATCH_KEYS = ['bg', 'surface', 'border', 'text', 'accent'] as const
+
+export function themeSwatches(theme: ThemeFile): Record<string, string> {
+  const flat = flattenTheme(theme)
+  const out: Record<string, string> = {}
+  for (const key of SWATCH_KEYS) {
+    const value = flat.colors?.[key]
+    if (value) out[key] = value
+  }
+  return out
+}
+
+/** Build the list entry the renderer shows for a theme. */
+export function toThemeView(
+  theme: ThemeFile,
+  source: 'builtin' | 'user',
+  location?: string
+): ThemeView {
+  return {
+    id: theme.id,
+    name: theme.name,
+    description: theme.description,
+    author: theme.author,
+    appearance: flattenTheme(theme).appearance ?? 'dark',
+    source,
+    location,
+    swatches: themeSwatches(theme)
+  }
+}
+
+/** A starter file for "New theme" — the default palette, ready to edit. */
+export function starterTheme(id: string, name: string): ThemeFile {
+  return {
+    kind: THEME_KIND,
+    version: THEME_VERSION,
+    id,
+    name,
+    description: 'My theme',
+    appearance: 'dark',
+    extends: DEFAULT_THEME_ID,
+    colors: {
+      bg: '#0a0a0a',
+      surface: '#0f0f10',
+      accent: '#4d8dff'
+    },
+    fonts: { sans: 'system', mono: 'system' }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Authoring prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the "copy prompt" text — a self-contained spec an LLM can turn into a
+ * valid theme file, and a human can read as documentation.
+ *
+ * GENERATED, never hand-written. Every token, hint, allowlisted var and font
+ * preset below is read out of the same constants the validator enforces, so the
+ * prompt cannot drift from the rules. A hand-maintained copy would be wrong the
+ * first time someone adds a token — and wrong documentation that *looks*
+ * authoritative is worse than none, because the model confidently emits fields
+ * that then get dropped as unknown.
+ *
+ * Written as instructions to a model rather than prose about the format: it
+ * states the output contract first, explains what each token PAINTS (a model
+ * can pick a good `surface-2` only if it knows it sits behind inputs), and ends
+ * with the failure modes that actually produce ugly or broken themes.
+ */
+export function buildThemePrompt(options: { goal?: string } = {}): string {
+  const goal =
+    options.goal?.trim() ||
+    'a theme of your own design — pick a distinctive palette and commit to it'
+
+  const group = (id: ThemeTokenGroup): string =>
+    THEME_COLOR_TOKENS.filter((t) => t.group === id)
+      .map((t) => `  "${t.key}" — ${t.hint}`)
+      .join('\n')
+
+  // Only the vars worth an author's attention; the font ones duplicate `fonts`.
+  const vars = [...EXTRA_VAR_ALLOWLIST]
+    .filter((v) => v !== '--font-sans' && v !== '--font-mono')
+    .map((v) => `  ${v}`)
+    .join('\n')
+
+  return `You are writing a theme file for Roxy, a desktop AI coding app.
+
+GOAL
+${goal}
+
+OUTPUT
+Return ONE JSON object and nothing else — no markdown fence, no commentary.
+It must parse as JSON. Unknown keys are dropped, so do not invent any.
+
+SHAPE
+{
+  "id":          required. lowercase letters, digits and dashes only. Used as the folder name.
+  "name":        required. Human-readable, e.g. "Deep Ocean".
+  "description": optional. One short sentence shown under the name in the picker.
+  "author":      optional.
+  "appearance":  "dark" | "light". Drives native scrollbars and form controls, so it MUST
+                 match your palette. A light palette with "dark" here looks broken.
+  "extends":     optional. "${DEFAULT_THEME_ID}" or "roxy-light". Anything you omit is
+                 inherited from it, so you may set as few as three colors.
+  "colors":      object of the tokens below. Any CSS color: hex, rgb(), hsl(), oklch(),
+                 or color-mix(). No url(), no gradients, no var().
+  "fonts":       { "sans": …, "mono": … }
+  "vars":        optional. Advanced escape hatch, see below.
+}
+
+COLOR TOKENS
+These are the ONLY accepted color keys. Each one names what it paints — read the
+description, because picking a value without knowing where it lands is how themes
+end up unreadable.
+
+Surfaces (darkest → lightest in a dark theme; the reverse in a light one):
+${group('surfaces')}
+
+Text (in descending prominence — these sit ON the surfaces above):
+${group('text')}
+
+Accents (meaning-carrying; keep them distinguishable from each other):
+${group('accents')}
+
+Contrast pair — READ THIS, it is the one non-obvious part:
+${group('polarity')}
+  These are NOT literally white and black. "white" is the color that CONTRASTS
+  with your background: it fills the primary button and every hover wash in the
+  app. "black" is what sits ON the primary button.
+    - Dark theme:  "white": "#ffffff", "black": "#000000"
+    - Light theme: "white": "#18181b", "black": "#ffffff"   ← inverted
+  Get this backwards on a light theme and every hover state turns into a white
+  smear on white, and the primary button becomes unreadable.
+
+FONTS
+  "sans" is the UI font. "mono" is the code font — tool calls, terminal output,
+  diffs and code blocks. Each accepts:
+    "system"                      the platform's native font (SF / Segoe / system-ui)
+    "Berkeley Mono"               one family; fallbacks are appended automatically
+    ["Berkeley Mono", "Menlo"]    an explicit stack, tried in order
+  Naming a font the machine lacks degrades to the fallback stack, so it is safe.
+  Omit "fonts" entirely to leave the app's fonts alone.
+  Common mono choices: ${FONT_PRESETS.mono.filter((f) => f !== 'system').join(', ')}.
+
+VARS (optional, advanced)
+  Raw CSS custom properties for things the fields above don't cover. Only these
+  names are accepted; anything else is dropped:
+${vars}
+
+CONSTRAINTS — a value breaking any of these is silently discarded
+  - No url(), image-set(), attr() or expression() — blocked as an exfiltration risk.
+  - No javascript:, data:, file: or blob: URIs.
+  - No semicolons, braces, angle brackets, backslashes, comments or @-rules.
+  - Each value under ${MAX_VALUE_LENGTH} characters.
+  - At most ${MAX_CUSTOM_VARS} entries in "vars".
+
+MAKING IT ACTUALLY GOOD
+  - Contrast is the whole job. "text" on "bg" should clear WCAG AA (4.5:1);
+    "text-muted" ≥ 3:1. A palette that looks great as swatches and fails here is
+    a bad theme.
+  - Keep the surface ramp SUBTLE — bg → surface → surface-2 → elevated should be
+    small steps in the same hue family. Big jumps make the UI look striped.
+  - "border" is a hairline, not a divider: keep it close to the surfaces, only a
+    little lighter (dark theme) or darker (light theme).
+  - Pick ONE accent hue and let success/warning/danger stay conventionally
+    green/amber/red — they carry meaning and should not be restyled for looks.
+  - "accent-hover" is the accent one step BRIGHTER in a dark theme, one step
+    DARKER in a light theme.
+  - Tint your greys toward the accent hue instead of using pure neutrals; it is
+    what makes a palette feel designed rather than default.
+
+EXAMPLE (a complete, valid theme)
+${serializeTheme({
+  kind: THEME_KIND,
+  version: THEME_VERSION,
+  id: 'deep-ocean',
+  name: 'Deep Ocean',
+  description: 'Cold blue-black with a cyan accent.',
+  appearance: 'dark',
+  extends: DEFAULT_THEME_ID,
+  colors: {
+    bg: '#04121a',
+    surface: '#081a24',
+    'surface-2': '#0d2430',
+    elevated: '#123040',
+    border: '#16323f',
+    'border-strong': '#1f4553',
+    text: '#e2f1f7',
+    'text-muted': '#8fadb9',
+    'text-subtle': '#5f7d89',
+    accent: '#22d3ee',
+    'accent-hover': '#4ae0f7',
+    success: '#3fb98a',
+    warning: '#d9a441',
+    danger: '#f0556a',
+    white: '#ffffff',
+    black: '#000000'
+  },
+  fonts: { mono: 'JetBrains Mono' }
+}).trim()}
+
+Now output the JSON for: ${goal}`
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -418,6 +418,15 @@ export interface AppSettings {
    * people prefer; it is a real choice, not a reason to reimpose the default.
    */
   branchPrefix: string
+  /**
+   * Which theme paints the UI. Null means the built-in default.
+   *
+   * Only the ID lives here -- the theme itself is a file on disk, so settings
+   * stay small and a theme can be edited, shared or version-controlled without
+   * the database knowing anything about it. An id naming a theme that has since
+   * been deleted resolves back to the default rather than failing.
+   */
+  activeThemeId: string | null
 }
 
 export interface AppVersions {

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -43,6 +43,23 @@ import {
 } from '../src/shared/cliproxy'
 import { modelLabel, pickDefaultModel } from '../src/shared/models'
 import {
+  BUILT_IN_THEMES,
+  DEFAULT_THEME_ID,
+  MAX_CUSTOM_VARS,
+  THEME_COLOR_TOKENS,
+  buildThemePrompt,
+  getBuiltInTheme,
+  isSafeCssValue,
+  isValidThemeId,
+  parseTheme,
+  resolveFontStack,
+  resolveTheme,
+  sanitizeThemeId,
+  serializeTheme,
+  starterTheme,
+  type ThemeFile
+} from '../src/shared/theme'
+import {
   ACTIVATION_MILESTONES,
   FEATURE_IDS,
   bucketCount,
@@ -5809,6 +5826,341 @@ async function main(): Promise<void> {
   check(
     'responses: unknown events are ignored',
     !applyResponsesEvent({ type: 'response.in_progress' }, { onText: () => {} })
+  )
+
+  // ---- themes (config-driven theming) ----
+  //
+  // The whole feature rests on one fact about Tailwind v4, so it is asserted
+  // here rather than assumed: a `@theme` token compiles to a runtime `var()`
+  // reference, which is what lets a theme repaint the app without a rebuild.
+  // These tests cover the three things that would actually hurt in the wild:
+  // a malicious value reaching CSS, a theme half-applying, and the macOS
+  // system font being clobbered by a theme that never mentioned fonts.
+  console.log('\nthemes\n')
+
+  // -- validation: what a theme file may contain
+  check(
+    'theme: a well-formed file parses',
+    parseTheme('{"id":"x","name":"X","colors":{"bg":"#000"}}').ok
+  )
+  check('theme: malformed JSON is rejected, not thrown', !parseTheme('{nope').ok)
+  check('theme: a non-object is rejected', !parseTheme('[]').ok && !parseTheme('"x"').ok)
+  check('theme: a missing id is rejected', !parseTheme('{"name":"X"}').ok)
+  check(
+    'theme: an id that is not a slug is rejected',
+    !parseTheme('{"id":"../../etc","name":"X"}').ok &&
+      !parseTheme('{"id":"Has Spaces","name":"X"}').ok
+  )
+  {
+    // A typo must cost the author one token, not the whole theme.
+    const res = parseTheme('{"id":"x","name":"X","colors":{"bakground":"#000","bg":"#111"}}')
+    check(
+      'theme: an unknown color is dropped and reported, not fatal',
+      res.ok && res.theme.colors?.bg === '#111' && !('bakground' in (res.theme.colors ?? {})),
+      JSON.stringify(res)
+    )
+    check(
+      'theme: the dropped token is named in a warning',
+      res.ok && res.warnings.some((w) => w.includes('bakground')),
+      res.ok ? res.warnings.join('|') : ''
+    )
+  }
+
+  // -- the security boundary. A theme is a file people SHARE, so a hostile one
+  //    is a realistic threat, and `url()` in a custom property is a real
+  //    exfiltration vector the moment anything references it.
+  check(
+    'theme: url() is refused (exfiltration / local file read)',
+    !isSafeCssValue('url(https://evil.example/pixel)') &&
+      !isSafeCssValue('URL("file:///etc/passwd")') &&
+      !isSafeCssValue('image-set(url(x.png))')
+  )
+  check(
+    'theme: declaration break-out is refused',
+    !isSafeCssValue('red; background: url(x)') && !isSafeCssValue('red} body{display:none')
+  )
+  check(
+    'theme: javascript:/data: payloads are refused',
+    !isSafeCssValue('javascript:alert(1)') && !isSafeCssValue('data:text/html,<script>')
+  )
+  check(
+    'theme: comment smuggling and at-rules are refused',
+    !isSafeCssValue('red/*x*/') && !isSafeCssValue('@import "evil.css"')
+  )
+  check('theme: an unreasonably long value is refused', !isSafeCssValue('#' + 'a'.repeat(600)))
+  check(
+    'theme: ordinary CSS colors are allowed',
+    isSafeCssValue('#0a0a0a') &&
+      isSafeCssValue('rgb(10 10 10 / 50%)') &&
+      isSafeCssValue('oklch(0.72 0.19 305)') &&
+      isSafeCssValue('color-mix(in srgb, #fff 5%, transparent)')
+  )
+  {
+    const res = parseTheme('{"id":"x","name":"X","colors":{"bg":"url(https://evil.example)"}}')
+    check(
+      'theme: an unsafe value never survives parsing',
+      res.ok && Object.keys(res.theme.colors ?? {}).length === 0,
+      JSON.stringify(res)
+    )
+  }
+  check(
+    'theme: vars are limited to an allowlist',
+    (() => {
+      const res = parseTheme('{"id":"x","name":"X","vars":{"--evil":"1","--sq-scale":"2"}}')
+      return res.ok && res.theme.vars?.['--sq-scale'] === '2' && !res.theme.vars?.['--evil']
+    })()
+  )
+
+  // -- resolution: a theme id becomes the exact set of properties to apply
+  {
+    const dark = resolveTheme(getBuiltInTheme(DEFAULT_THEME_ID)!, 'win32')
+    check(
+      'theme: the default resolves to the palette compiled into main.css',
+      dark.vars['--color-bg'] === '#0a0a0a' && dark.vars['--color-text'] === '#ededed',
+      JSON.stringify(dark.vars['--color-bg'])
+    )
+    check(
+      'theme: token keys map to the CSS properties Tailwind emits',
+      THEME_COLOR_TOKENS.every((t) => t.cssVar === `--color-${t.key}`),
+      THEME_COLOR_TOKENS.filter((t) => t.cssVar !== `--color-${t.key}`)
+        .map((t) => t.key)
+        .join(',')
+    )
+  }
+  {
+    // The reason a light theme works at all without touching components: the
+    // ~75 `bg-white/5` hovers resolve through --color-white.
+    const light = resolveTheme(getBuiltInTheme('roxy-light')!, 'win32')
+    check(
+      'theme: a light theme inverts the contrast pair',
+      light.vars['--color-white'] === '#18181b' && light.vars['--color-black'] === '#ffffff',
+      `${light.vars['--color-white']} / ${light.vars['--color-black']}`
+    )
+    check('theme: appearance drives color-scheme', light.appearance === 'light')
+  }
+  {
+    // A three-line theme must still produce a coherent UI.
+    const partial = parseTheme('{"id":"tiny","name":"Tiny","colors":{"accent":"#f0f"}}')
+    const resolved = partial.ok ? resolveTheme(partial.theme, 'win32') : null
+    check(
+      'theme: unspecified tokens inherit from the default (no half-applied UI)',
+      !!resolved &&
+        resolved.vars['--color-accent'] === '#f0f' &&
+        resolved.vars['--color-bg'] === '#0a0a0a',
+      JSON.stringify(resolved?.vars['--color-bg'])
+    )
+  }
+  {
+    const child = parseTheme(
+      '{"id":"c","name":"C","extends":"roxy-light","colors":{"accent":"#0f0"}}'
+    )
+    const resolved = child.ok ? resolveTheme(child.theme, 'win32') : null
+    check(
+      'theme: extends layers onto the named base',
+      !!resolved &&
+        resolved.vars['--color-accent'] === '#0f0' &&
+        resolved.vars['--color-bg'] === '#ffffff',
+      JSON.stringify(resolved?.vars)
+    )
+    check(
+      'theme: extends inherits the base appearance, not the default',
+      resolved?.appearance === 'light',
+      String(resolved?.appearance)
+    )
+  }
+  check(
+    'theme: an extends cycle terminates instead of hanging',
+    (() => {
+      const a: ThemeFile = { id: 'a', name: 'A', extends: 'b', colors: { accent: '#111' } }
+      const b: ThemeFile = { id: 'b', name: 'B', extends: 'a', colors: { accent: '#222' } }
+      const lookup = (id: string): ThemeFile | undefined =>
+        id === 'a' ? a : id === 'b' ? b : undefined
+      return resolveTheme(a, 'win32', lookup).vars['--color-accent'] === '#111'
+    })()
+  )
+
+  // -- fonts. The subtle one: main.css overrides --font-sans under
+  //    [data-platform='darwin'] to get San Francisco, and lib/theme.ts applies
+  //    theme vars as INLINE styles, which beat any selector. So a theme that
+  //    says nothing about fonts must emit NO font property at all, or every
+  //    macOS user silently loses the system font.
+  {
+    const quiet = resolveTheme(getBuiltInTheme(DEFAULT_THEME_ID)!, 'darwin')
+    check(
+      'theme: a theme with no fonts emits no font vars (keeps the macOS system font)',
+      !('--font-sans' in quiet.vars) && !('--font-mono' in quiet.vars),
+      JSON.stringify(Object.keys(quiet.vars).filter((k) => k.startsWith('--font')))
+    )
+  }
+  check(
+    'theme: "system" expands to the platform stack, per platform',
+    resolveFontStack('system', 'sans', 'darwin')!.includes('-apple-system') &&
+      resolveFontStack('system', 'sans', 'win32')!.includes('Segoe UI') &&
+      resolveFontStack('system', 'mono', 'win32')!.includes('Cascadia')
+  )
+  check(
+    'theme: a named family keeps fallbacks, so a missing font degrades sanely',
+    resolveFontStack('Berkeley Mono', 'mono', 'win32') ===
+      "'Berkeley Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', monospace",
+    String(resolveFontStack('Berkeley Mono', 'mono', 'win32'))
+  )
+  check(
+    'theme: a family needing quotes gets them; a bare ident does not',
+    resolveFontStack('Berkeley Mono', 'mono', 'win32')!.startsWith("'Berkeley Mono'") &&
+      resolveFontStack('Menlo', 'mono', 'win32')!.startsWith('Menlo,')
+  )
+  check(
+    'theme: generic families are never quoted (quoting breaks them)',
+    resolveFontStack('monospace', 'mono', 'win32')!.startsWith('monospace,'),
+    String(resolveFontStack('monospace', 'mono', 'win32'))
+  )
+  check(
+    'theme: an array builds a stack in order',
+    resolveFontStack(['Berkeley Mono', 'Menlo'], 'mono', 'win32')!.startsWith(
+      "'Berkeley Mono', Menlo,"
+    ),
+    String(resolveFontStack(['Berkeley Mono', 'Menlo'], 'mono', 'win32'))
+  )
+  check(
+    'theme: the code font is separately configurable from the UI font',
+    (() => {
+      const res = parseTheme('{"id":"x","name":"X","fonts":{"mono":"Fira Code"}}')
+      if (!res.ok) return false
+      const vars = resolveTheme(res.theme, 'win32').vars
+      return vars['--font-mono']?.includes('Fira Code') === true && !('--font-sans' in vars)
+    })()
+  )
+
+  // -- ids and round-tripping
+  check(
+    'theme: sanitizeThemeId produces a usable folder name',
+    sanitizeThemeId('My Cool Theme!') === 'my-cool-theme' &&
+      sanitizeThemeId('  ') === 'theme' &&
+      isValidThemeId(sanitizeThemeId('../../etc/passwd'))
+  )
+  check(
+    'theme: serialize -> parse round-trips',
+    (() => {
+      const original = getBuiltInTheme('roxy-light')!
+      const again = parseTheme(serializeTheme(original))
+      return again.ok && again.theme.colors?.bg === original.colors?.bg
+    })()
+  )
+  check(
+    'theme: every built-in is internally valid',
+    BUILT_IN_THEMES.every((t) => parseTheme(serializeTheme(t)).ok),
+    BUILT_IN_THEMES.filter((t) => !parseTheme(serializeTheme(t)).ok)
+      .map((t) => t.id)
+      .join(',')
+  )
+  check(
+    'theme: every built-in defines the full palette (no inherited gaps)',
+    BUILT_IN_THEMES.every((t) =>
+      THEME_COLOR_TOKENS.every((tok) => typeof t.colors?.[tok.key] === 'string')
+    ),
+    BUILT_IN_THEMES.map(
+      (t) =>
+        `${t.id}:${THEME_COLOR_TOKENS.filter((tok) => !t.colors?.[tok.key])
+          .map((tok) => tok.key)
+          .join('/')}`
+    )
+      .filter((s) => !s.endsWith(':'))
+      .join(' ')
+  )
+  check(
+    'theme: the starter theme a user gets is valid',
+    parseTheme(serializeTheme(starterTheme('mine', 'Mine'))).ok
+  )
+
+  // -- the authoring prompt. Its whole value is being GENERATED from the token
+  //    registry: a hand-written spec would drift the first time a token was
+  //    added, and confidently-wrong docs make a model emit fields that then get
+  //    dropped. These tests are what stop that drift.
+  {
+    const prompt = buildThemePrompt()
+
+    // Every token must be documented, and nothing may be documented that isn't
+    // real. Both directions matter -- the second is how docs invent fields.
+    const documented = [...prompt.matchAll(/^ {2}"([a-z0-9-]+)" \u2014 /gm)].map((m) => m[1])
+    const real = THEME_COLOR_TOKENS.map((t) => t.key)
+    check(
+      'prompt: documents every color token',
+      real.every((k) => documented.includes(k)),
+      real.filter((k) => !documented.includes(k)).join(',')
+    )
+    check(
+      'prompt: documents no token that does not exist',
+      documented.every((k) => real.includes(k)),
+      documented.filter((k) => !real.includes(k)).join(',')
+    )
+    check(
+      'prompt: carries each token\u2019s real hint, not a paraphrase',
+      THEME_COLOR_TOKENS.every((t) => prompt.includes(t.hint)),
+      THEME_COLOR_TOKENS.filter((t) => !prompt.includes(t.hint))
+        .map((t) => t.key)
+        .join(',')
+    )
+
+    // The example is the part a model is most likely to copy verbatim, so it
+    // has to survive the real validator with no warnings at all.
+    const start = prompt.indexOf('EXAMPLE (a complete, valid theme)')
+    const example = prompt.slice(
+      prompt.indexOf('{', start),
+      prompt.lastIndexOf('}\n\nNow output') + 1
+    )
+    const parsed = parseTheme(example)
+    check('prompt: its worked example parses', parsed.ok, parsed.ok ? '' : parsed.error)
+    check(
+      'prompt: its worked example produces zero warnings',
+      parsed.ok && parsed.warnings.length === 0,
+      parsed.ok ? parsed.warnings.join('|') : ''
+    )
+    check(
+      'prompt: its example sets every token (a model copying it gets a full theme)',
+      parsed.ok && real.every((k) => typeof parsed.theme.colors?.[k] === 'string'),
+      parsed.ok ? real.filter((k) => !parsed.theme.colors?.[k]).join(',') : ''
+    )
+
+    // The limits it quotes must be the limits actually enforced.
+    check(
+      'prompt: quotes the real value-length and vars limits',
+      prompt.includes(String(MAX_CUSTOM_VARS)) && prompt.includes('512'),
+      prompt.includes(String(MAX_CUSTOM_VARS)) + '/' + prompt.includes('512')
+    )
+    check(
+      'prompt: names the real built-ins for extends',
+      prompt.includes(DEFAULT_THEME_ID) && prompt.includes('roxy-light')
+    )
+    // The polarity trap is the single most common way to get a light theme
+    // wrong, so the prompt must spell out the inversion explicitly.
+    check(
+      'prompt: explains the inverted contrast pair',
+      prompt.includes('"white": "#18181b"') && prompt.includes('NOT literally white')
+    )
+    check(
+      'prompt: states the output contract (one JSON object, no prose)',
+      /ONE JSON object/.test(prompt) && /no markdown fence/i.test(prompt)
+    )
+    check(
+      'prompt: a custom goal is threaded through',
+      buildThemePrompt({ goal: 'a nord-inspired theme' }).includes('a nord-inspired theme')
+    )
+  }
+
+  // -- font stack dedupe: naming a font that is already in the fallback list
+  //    used to emit it twice, which reads as a bug in devtools.
+  check(
+    'theme: a named font is not repeated by the fallback stack',
+    (() => {
+      const stack = resolveFontStack('JetBrains Mono', 'mono', 'win32')!
+      return stack.split(',').filter((n) => /jetbrains/i.test(n)).length === 1
+    })(),
+    String(resolveFontStack('JetBrains Mono', 'mono', 'win32'))
+  )
+  check(
+    'theme: dedupe ignores quoting differences',
+    !resolveFontStack('SF Mono', 'mono', 'win32')!.match(/'SF Mono'.*'SF Mono'/),
+    String(resolveFontStack('SF Mono', 'mono', 'win32'))
   )
 
   if (fails.length) {

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -10,7 +10,7 @@ import { existsSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { app } from 'electron'
+import { app, BrowserWindow } from 'electron'
 
 import * as repo from '../src/main/db/repo'
 import { getActivityStats } from '../src/main/services/activity'
@@ -25,6 +25,22 @@ import {
   restartService
 } from '../src/main/harness'
 import { sessionCwd } from '../src/main/services/workspace'
+import {
+  createTheme,
+  deleteTheme,
+  listThemes,
+  refreshThemes,
+  resolveThemeById,
+  themeWarnings,
+  writeTheme
+} from '../src/main/services/themes'
+import {
+  OVERLAY_HEIGHT,
+  applyWindowChrome,
+  backgroundColorFor,
+  initialOverlay,
+  symbolColorFor
+} from '../src/main/services/window-chrome'
 import Database from 'better-sqlite3'
 import { MIGRATIONS, repairSchema } from '../src/main/db/migrations'
 import * as git from '../src/main/services/git'
@@ -4523,6 +4539,242 @@ async function main(): Promise<void> {
     delete process.env.ROXY_TRACK_ENDPOINT
   } catch (e) {
     check('usage tracking', false, e instanceof Error ? e.message : String(e))
+  }
+
+  // ---- themes on disk (config-driven theming) ----
+  //
+  // shared.ts covers the pure logic (parsing, validation, resolution). What can
+  // only be verified against a real filesystem is the part that decides whether
+  // a hand-authored file actually reaches the UI: discovery, precedence between
+  // roots, and the write/delete paths.
+  try {
+    const themesRoot = path.join(tmp, 'themes')
+
+    // A theme authored by hand, in the folder layout the docs describe.
+    await fs.mkdir(path.join(themesRoot, 'ocean'), { recursive: true })
+    await fs.writeFile(
+      path.join(themesRoot, 'ocean', 'theme.json'),
+      JSON.stringify({
+        id: 'ocean',
+        name: 'Ocean',
+        appearance: 'dark',
+        colors: { bg: '#001018', accent: '#22d3ee' },
+        fonts: { mono: 'Fira Code' }
+      }),
+      'utf8'
+    )
+    // The other accepted shape: a bare <id>.json dropped straight into a root.
+    await fs.writeFile(
+      path.join(themesRoot, 'plain.json'),
+      JSON.stringify({ id: 'plain', name: 'Plain', colors: { bg: '#111' } }),
+      'utf8'
+    )
+    // Junk must not take the scan down with it.
+    await fs.writeFile(path.join(themesRoot, 'broken.json'), '{not json', 'utf8')
+
+    refreshThemes()
+    const listed = await listThemes()
+    check(
+      'themes: a hand-authored theme.json is discovered',
+      listed.some((t) => t.id === 'ocean' && t.source === 'user'),
+      listed.map((t) => t.id).join(',')
+    )
+    check(
+      'themes: a bare <id>.json is discovered too',
+      listed.some((t) => t.id === 'plain')
+    )
+    check(
+      'themes: built-ins are always present and marked as such',
+      listed.some((t) => t.id === 'roxy-dark' && t.source === 'builtin') &&
+        listed.some((t) => t.id === 'roxy-light')
+    )
+    check(
+      'themes: a malformed file is reported, not fatal',
+      themeWarnings().some((w) => w.file.includes('broken.json')),
+      JSON.stringify(themeWarnings())
+    )
+    check(
+      'themes: the picker gets swatches to render',
+      (listed.find((t) => t.id === 'ocean')?.swatches.bg ?? '') === '#001018'
+    )
+
+    // Resolution is what the renderer actually applies.
+    const resolved = await resolveThemeById('ocean', 'win32')
+    check(
+      'themes: a user theme resolves to CSS custom properties',
+      resolved.vars['--color-bg'] === '#001018' && resolved.vars['--color-accent'] === '#22d3ee',
+      JSON.stringify(resolved.vars['--color-bg'])
+    )
+    check(
+      'themes: tokens it never mentioned still come from the default',
+      resolved.vars['--color-text'] === '#ededed'
+    )
+    check(
+      'themes: a code font survives the round trip to disk',
+      resolved.vars['--font-mono']?.includes('Fira Code') === true,
+      String(resolved.vars['--font-mono'])
+    )
+    check(
+      'themes: an unknown id falls back to the default rather than failing',
+      (await resolveThemeById('does-not-exist', 'win32')).vars['--color-bg'] === '#0a0a0a'
+    )
+
+    // Writes.
+    const created = await createTheme({ name: 'My Theme' })
+    check('themes: create writes a new theme', created.ok && created.id === 'my-theme')
+    check(
+      'themes: the created file is on disk where the UI says it is',
+      existsSync(path.join(themesRoot, 'my-theme', 'theme.json'))
+    )
+    const dup = await createTheme({ name: 'My Theme' })
+    check(
+      'themes: creating the same name twice does not overwrite the first',
+      dup.ok && dup.id === 'my-theme-2',
+      JSON.stringify(dup)
+    )
+    const fromBuiltin = await createTheme({ name: 'Light Copy', from: 'roxy-light' })
+    const copied = fromBuiltin.ok ? await resolveThemeById(fromBuiltin.id, 'win32') : null
+    check(
+      'themes: duplicating a built-in copies its palette',
+      copied?.vars['--color-bg'] === '#ffffff',
+      JSON.stringify(copied?.vars['--color-bg'])
+    )
+    check(
+      'themes: a duplicate keeps the polarity of what it copied',
+      copied?.vars['--color-white'] === '#18181b',
+      JSON.stringify(copied?.vars['--color-white'])
+    )
+
+    // A theme found OUTSIDE the app's own folder must be rewritten in place,
+    // not forked into userData where the copy would shadow the original.
+    const savedPlain = await writeTheme(
+      JSON.stringify({ id: 'plain', name: 'Plain', colors: { bg: '#222' } }),
+      { id: 'plain' }
+    )
+    check('themes: saving an existing theme succeeds', savedPlain.ok)
+    check(
+      'themes: a theme is rewritten where it was found, not duplicated',
+      !existsSync(path.join(themesRoot, 'plain', 'theme.json')) &&
+        JSON.parse(await fs.readFile(path.join(themesRoot, 'plain.json'), 'utf8')).colors.bg ===
+          '#222'
+    )
+
+    check(
+      'themes: a built-in id cannot be overwritten',
+      !(await writeTheme(JSON.stringify({ id: 'roxy-dark', name: 'Hijack' }), { id: 'roxy-dark' }))
+        .ok
+    )
+    check('themes: a built-in cannot be deleted', !(await deleteTheme('roxy-dark')).ok)
+
+    const removed = await deleteTheme('my-theme')
+    check('themes: delete removes a user theme', removed.ok)
+    check('themes: its folder is gone from disk', !existsSync(path.join(themesRoot, 'my-theme')))
+    refreshThemes()
+    check(
+      'themes: a deleted theme leaves the list',
+      !(await listThemes()).some((t) => t.id === 'my-theme')
+    )
+
+    // A user file claiming a built-in id would make the default unreachable
+    // from the picker, so it is refused at discovery.
+    await fs.mkdir(path.join(themesRoot, 'roxy-dark'), { recursive: true })
+    await fs.writeFile(
+      path.join(themesRoot, 'roxy-dark', 'theme.json'),
+      JSON.stringify({ id: 'roxy-dark', name: 'Impostor', colors: { bg: '#f00' } }),
+      'utf8'
+    )
+    refreshThemes()
+    const shadowed = await listThemes()
+    check(
+      'themes: a user theme cannot shadow a built-in id',
+      shadowed.filter((t) => t.id === 'roxy-dark').length === 1 &&
+        shadowed.find((t) => t.id === 'roxy-dark')?.source === 'builtin',
+      JSON.stringify(shadowed.filter((t) => t.id === 'roxy-dark'))
+    )
+    check(
+      'themes: the default still resolves to its real palette',
+      (await resolveThemeById('roxy-dark', 'win32')).vars['--color-bg'] === '#0a0a0a'
+    )
+
+    // The active theme is persisted as an id only.
+    repo.setActiveThemeId('ocean')
+    check(
+      'themes: the active id persists in settings',
+      repo.getSettings().activeThemeId === 'ocean'
+    )
+    repo.setActiveThemeId(null)
+    check('themes: clearing it returns to the default', repo.getSettings().activeThemeId === null)
+  } catch (e) {
+    check('themes', false, e instanceof Error ? e.message : String(e))
+  }
+
+  // ---- native window chrome (the OS-drawn window controls) ----
+  //
+  // The minimise / maximise / close buttons are painted by the OS ABOVE the
+  // page, so no stylesheet reaches them. Getting this wrong is very visible --
+  // a dark block in the corner of a light theme -- and it cannot be caught by
+  // the CSS-level tests, so the colour derivation is pinned here.
+  try {
+    const dark = await resolveThemeById('roxy-dark', 'win32')
+    const light = await resolveThemeById('roxy-light', 'win32')
+
+    check(
+      'chrome: the overlay is transparent, never a flat colour',
+      initialOverlay(48).color === 'rgba(1, 0, 0, 0)',
+      String(initialOverlay(48).color)
+    )
+    // electron#51014: a FULLY transparent black silently falls back to the
+    // default opaque frame colour, which is the exact bug being fixed.
+    check(
+      'chrome: the overlay avoids the rgba(0,0,0,0) fallback bug',
+      initialOverlay(48).color !== 'rgba(0, 0, 0, 0)'
+    )
+    check(
+      'chrome: the overlay height matches the app header',
+      initialOverlay(OVERLAY_HEIGHT.main).height === 48 &&
+        initialOverlay(OVERLAY_HEIGHT.browser).height === 40
+    )
+    // The glyphs are the one part still painted by the OS, so they must track
+    // the theme or they go invisible on one polarity.
+    check(
+      'chrome: control glyphs follow the theme text colour',
+      symbolColorFor(dark) === '#9a9aa3' && symbolColorFor(light) === '#5c5c66',
+      symbolColorFor(dark) + ' / ' + symbolColorFor(light)
+    )
+    check(
+      'chrome: the pre-paint background follows the theme',
+      backgroundColorFor(dark) === '#0a0a0a' && backgroundColorFor(light) === '#ffffff',
+      backgroundColorFor(dark) + ' / ' + backgroundColorFor(light)
+    )
+    // The OS parses these itself and understands only literal colours.
+    check(
+      'chrome: never hands the OS a var() or color-mix() it cannot parse',
+      [symbolColorFor(dark), symbolColorFor(light), backgroundColorFor(dark)].every(
+        (c) => !c.includes('var(') && !c.includes('color-mix')
+      )
+    )
+    check(
+      'chrome: applying to a destroyed window is a no-op, not a crash',
+      (() => {
+        const w = new BrowserWindow({ show: false })
+        w.destroy()
+        applyWindowChrome(w, dark)
+        return true
+      })()
+    )
+    check(
+      'chrome: a window with no overlay is tolerated',
+      (() => {
+        // Constructed WITHOUT titleBarOverlay: setTitleBarOverlay throws here,
+        // and that must not take a theme change down with it.
+        const w = new BrowserWindow({ show: false })
+        applyWindowChrome(w, light)
+        w.destroy()
+        return true
+      })()
+    )
+  } catch (e) {
+    check('chrome', false, e instanceof Error ? e.message : String(e))
   }
 
   closeDb()


### PR DESCRIPTION
## What

Themes you can write yourself: a `theme.json` that re-points the app's design tokens - surfaces, text, accents, and the fonts for the UI and for code. A **Themes** page (below MCP Servers) picks, duplicates, edits and deletes them.

```
<userData>/themes/<id>/theme.json      written by the app
~/.roxy/themes/<id>/theme.json         hand-authored, shareable, dotfile-able
```

## Why it is small

Tailwind v4 compiles a `@theme` token to a **runtime** `var()` reference, not a baked literal:

```css
.bg-surface  { background-color: var(--color-surface); }
.bg-white\/5 { background-color: color-mix(in oklab, var(--color-white) 5%, transparent); }
```

So re-pointing the custom properties on `<html>` restyles all ~1000 utility usages **live** - no rebuild, no stylesheet swap, no reload, no React involvement.

I checked this against the compiler before designing anything, then against the real runtime (Electron 33 / Chromium 130). One `setProperty` call:

| | before | after |
|---|---|---|
| `bg-surface` | `rgb(15,15,16)` | `rgb(247,247,248)` |
| `bg-white/5` | `oklab(0.999...)` | `oklab(0.210...)` |

A theme is therefore **data, not CSS**. Nothing in the file is code, nothing is injected into a stylesheet, and the set of keys it may write is closed.

## Decisions worth reviewing

**`white`/`black` are a polarity pair, not literal colours.** They are ordinary Tailwind tokens, so this app's ~75 `bg-white/5` hovers and its `bg-white text-black` primary button resolve through them. Inverting the pair turns the whole UI light **without touching a single component** - `roxy-light` is the proof, and it is why there are no component changes in this diff.

**A theme that omits fonts emits _no_ font property.** `main.css` overrides `--font-sans` under `[data-platform='darwin']` for San Francisco, and theme vars are applied as inline styles, which win. Emitting a default would have silently broken the macOS system font. There is a test pinning this.

**The authoring prompt is generated from the token registry.** Hand-maintained docs drift the first time a token is added, and confidently-wrong docs make a model emit fields that get dropped as unknown. Tests assert both directions of the registry/prompt mapping.

**Native window controls.** They are drawn by the OS *above* the page, so CSS cannot reach them - a fixed colour left a dark block in the corner of a light theme. Now transparent, with only the glyphs themed. It is `rgba(1, 0, 0, 0)` rather than `rgba(0, 0, 0, 0)` because a fully transparent black hits [electron#51014](https://github.com/electron/electron/issues/51014) and falls back to the opaque default.

**One thing I deliberately did _not_ tokenise:** `sq-fill-white`, whose only user is the Remote Workspace QR panel. A QR code has to stay dark-on-light to scan; inverting it under a light theme would have quietly broken pairing.

## Security

Theme files get shared, so a hostile one is realistic. `url()` is the real vector - inert in a custom property until something references it, at which point the browser fetches it. Values are validated against declaration break-out, `url()`/`image-set()`, `javascript:`/`data:` URIs, comment smuggling and at-rules; `vars` is limited to an allowlist. Applying goes through `setProperty()`, which cannot emit a second declaration, so this is defence in depth rather than the only guard.

## Tests

**79 new checks** - 54 pure (`smoke:shared`) and 25 against a real filesystem (`smoke:app`). Beyond the happy path they cover the security boundary, the polarity inversion, the macOS font interaction, precedence between theme roots, a user theme trying to shadow a built-in, and that the prompt's worked example parses with **zero** warnings.

Two of the window-chrome tests exist because I probed the failure first: `setTitleBarOverlay` genuinely throws on a window built without an overlay, so the `try/catch` is load-bearing - without it a theme switch would crash whenever such a window existed.

## Bugs found and fixed along the way

- `startTheme()` threw synchronously when the preload bridge lacked `themes` (stale dev preload, or renderer outside Electron). It runs before React mounts, so it white-screened the entire app. A `.catch()` does not help - the property access is what throws.
- Duplicate font entries: asking for `JetBrains Mono` emitted it twice, since it is also in the fallback stack.
- The editor's "Saving re-applies..." hint collapsed to one word per line beside the reference panel.
- Button labels could wrap mid-word; fixed on the shared `Button` so it cannot recur.

## Verification

`format:check`, `typecheck`, `build`, `smoke:shared` (1056 checks), `smoke:store` and `smoke:app` all pass.

One pre-existing `smoke:app` failure - `a session without a port does not set PORT` - is unrelated. I stashed this work and confirmed it fails identically on a clean baseline.

## Not included

Gradients. The `vars` escape hatch is the seam for them, but no token accepts one yet.