### PR TITLE
chore(release): bump version to 0.0.93

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roxy",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roxy",
-      "version": "0.0.92",
+      "version": "0.0.93",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roxy",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "description": "Roxy — an open-source AI coding agent for engineers.",
   "main": "./out/main/index.js",
   "author": "Roxy (https://github.com/roxy-gg/roxy)",


### PR DESCRIPTION
## Summary

- bump the desktop app version from 0.0.92 to 0.0.93
- update the npm lockfile version metadata
- trigger the release workflow after merge

## Verification

- `npm run typecheck`
- `prettier --check package.json package-lock.json`
- `git diff --check`