### PR TITLE
ci(mac): pin release runner to macOS 15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,10 @@ jobs:
       matrix:
         # windows-2022 ships Visual Studio 2022, which node-gyp detects reliably
         # (the newest windows-latest image has a VS that older node-gyp can't
-        # parse). macOS/Linux have working toolchains out of the box.
-        os: [windows-2022, macos-latest, ubuntu-latest]
+        # parse). Pin macOS too: the macos-latest update to 26.6.2 broke
+        # electron-builder 25's temporary signing keychain (SecKeychainUnlock).
+        # macos-15 keeps the same arm64 artifacts; CI still tests macos-latest.
+        os: [windows-2022, macos-15, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -161,6 +161,15 @@ Windows job).
 
 ### Troubleshooting
 
+**`security set-key-partition-list` fails with `SecKeychainUnlock`** during
+packaging: this is access to the temporary signing keychain, before Apple
+notarization. The macOS 26.6.2 runner image failed here with electron-builder
+25.1.8, while 26.5.2 signed and notarized successfully using the same signing
+secrets. The release workflow pins `macos-15` (still ARM64) to avoid that image;
+regular CI continues to test `macos-latest`. Do not rotate the Apple
+app-specific password for this error. To use the updated workflow for a stuck
+draft, start a fresh run as described below rather than rerunning the old job.
+
 **`⨯ APPLE_APP_SPECIFIC_PASSWORD env var needs to be set`** (mac job signs the
 app, then fails) — one of the notarization secrets is **empty**. The workflow's
 _“Verify macOS signing secrets”_ preflight now catches this in ~1s and names the
@@ -185,6 +194,17 @@ gh run watch  <run-id>
 
 Get `<run-id>` from `gh run list`. Once mac passes, the `publish` job flips the
 draft to Latest automatically.
+
+If the fix changes the **workflow**, merge it to `main` and start a fresh run
+instead. Rerunning a failed job uses the original commit and workflow, not the
+updated code:
+
+```sh
+gh workflow run release.yml --ref main
+```
+
+No version bump is needed while that version's release is still a draft. The
+new run rebuilds all three platforms and publishes only after they all succeed.
 
 ## Windows
 


### PR DESCRIPTION
Avoid the temporary signing-keychain failure observed after macos-latest moved to 26.6.2. Keep ARM64 packaging, signing, notarization, and latest-runner CI coverage unchanged.

Document starting a fresh workflow run to finish a draft release after workflow changes.